### PR TITLE
fix(Posterframe): repair text rendering on cold-cache + missing-font machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.14.6"
+version = "0.14.7"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/Upload/components/Posterframe.tsx
+++ b/src/features/Upload/components/Posterframe.tsx
@@ -32,7 +32,7 @@ import {
   ZoomIn,
   ZoomOut
 } from 'lucide-react'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { logger } from '@shared/utils'
@@ -43,7 +43,21 @@ const PosterframeContent: React.FC = () => {
 
   const { files: backgroundFiles, loadFolder } = useBackgroundFolder()
   const { selectedFilePath, selectedFileBlob, selectFile } = useFileSelection()
-  const { canvasRef, draw } = usePosterframeCanvas()
+  const { canvasRef, draw, fontStatus } = usePosterframeCanvas()
+  // Toast exactly once when we first discover the font isn't installed —
+  // otherwise the user gets a blank thumbnail with no explanation and no
+  // diagnostic, exactly the silent-failure mode this fix is closing.
+  const fontMissingToastedRef = useRef(false)
+  useEffect(() => {
+    if (fontStatus === 'missing' && !fontMissingToastedRef.current) {
+      fontMissingToastedRef.current = true
+      toast.error('Posterframe font (Cabrito.otf) not found on this machine.', {
+        duration: 10000,
+        description:
+          'Text overlay requires Cabrito.otf in ~/Library/Fonts/. The background image will still render, but no title text will appear until the font is installed.'
+      })
+    }
+  }, [fontStatus])
   const { zoomLevel, pan, setZoomLevel, setPan } = useZoomPan('posterframe-canvas')
 
   useBreadcrumb([
@@ -74,10 +88,23 @@ const PosterframeContent: React.FC = () => {
   }
 
   const generateThumbnail = async () => {
-    if (!canvasRef.current || !savePath || !videoTitle.trim()) {
+    if (!canvasRef.current || !savePath || !videoTitle.trim() || !selectedFileBlob) {
       toast.error(
         'Please ensure you have selected a background, entered a title, and chosen a save path'
       )
+      return
+    }
+
+    // Force a synchronous-relative-to-this-handler redraw before snapshotting.
+    // The auto-redraw hook debounces by 300ms, so a quick "type-then-save"
+    // sequence can leave a pending redraw in flight when toBlob fires. Awaiting
+    // a fresh draw here guarantees the canvas reflects the current image+title
+    // when we capture it.
+    try {
+      await draw(selectedFileBlob, videoTitle)
+    } catch (err) {
+      logger.error('Pre-save draw failed:', err)
+      toast.error('Could not render the thumbnail. Please try again.')
       return
     }
 

--- a/src/features/Upload/hooks/usePosterframeCanvas.ts
+++ b/src/features/Upload/hooks/usePosterframeCanvas.ts
@@ -1,12 +1,38 @@
 import { loadFont } from '../internal/loadFont'
 import type { Font } from 'opentype.js'
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
+
+/**
+ * Outcome of attempting to load the Cabrito font.
+ *
+ * - `unknown` — `draw()` hasn't been called yet, so we don't know if the font
+ *   is available on this machine.
+ * - `loaded` — the font file was found and parsed successfully; text overlay
+ *   will render normally.
+ * - `missing` — the expected font file isn't present on the user's machine
+ *   (Cabrito.otf in macOS user fonts dir). The background image will still
+ *   draw, but the title-text branch silently bails. Consumers should surface
+ *   this so the user knows why the thumbnail looks blank.
+ */
+export type PosterframeFontStatus = 'unknown' | 'loaded' | 'missing'
 
 export function usePosterframeCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const fontRef = useRef<Font | null>(null)
+  const [fontStatus, setFontStatus] = useState<PosterframeFontStatus>('unknown')
 
-  const draw = useCallback(async (imageUrl: string, title: string) => {
+  /**
+   * Paint the background image and (optionally) the title text onto the
+   * canvas, awaiting all asynchronous loading first.
+   *
+   * The previous implementation registered `img.onload` as a callback and let
+   * the outer `async` function resolve immediately. Callers that awaited
+   * `draw(...)` (the auto-redraw hook, and most importantly the save handler)
+   * would proceed before any pixels had been written, capturing an empty or
+   * partial canvas. This version awaits the image load before continuing so
+   * `await draw(...)` actually waits for the paint to complete.
+   */
+  const draw = useCallback(async (imageUrl: string, title: string): Promise<void> => {
     if (!canvasRef.current || !imageUrl) return
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
@@ -14,83 +40,93 @@ export function usePosterframeCanvas() {
 
     ctx.imageSmoothingEnabled = false
 
-    const img = new Image()
-    img.src = imageUrl
-    img.onload = async () => {
-      // 1) match canvas to image
-      canvas.width = img.width
-      canvas.height = img.height
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      ctx.drawImage(img, 0, 0)
+    // Promisify Image loading so we can `await` it and avoid the
+    // fire-and-forget race that hid this code's effect from any caller.
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const i = new Image()
+      i.onload = () => resolve(i)
+      i.onerror = () => reject(new Error(`Posterframe image failed to load: ${imageUrl}`))
+      i.src = imageUrl
+    })
 
-      // 2) load & cache font
-      if (!fontRef.current) {
-        fontRef.current = await loadFont()
-      }
-      const font = fontRef.current
-      if (!font || !title.trim()) return
+    // 1) match canvas to image
+    canvas.width = img.width
+    canvas.height = img.height
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.drawImage(img, 0, 0)
 
-      // 3) layout params
-      const fontSize = 37 // px
-      const xStart = 292 // left edge of box
-      const yStart = 467 // first-line baseline
-      const maxWidth = 380 // box width
-      const lineHeight = 45 // px between baselines
-      const letterSpacing = 1.5 // extra px between glyphs
-
-      // 4) word-wrap into lines[]
-      const lines: string[] = []
-      {
-        let line = ''
-        for (const word of title.split(' ')) {
-          const testLine = line + word + ' '
-          // measure width of testLine manually (including letterSpacing)
-          const glyphs = font.stringToGlyphs(testLine)
-          let widthPx = 0
-          for (const g of glyphs) {
-            widthPx += g.advanceWidth * (fontSize / font.unitsPerEm) + letterSpacing
-          }
-          if (widthPx > maxWidth && line) {
-            lines.push(line.trim())
-            line = word + ' '
-          } else {
-            line = testLine
-          }
-        }
-        if (line) lines.push(line.trim())
-      }
-
-      // 5) set up clipping region to restore your bounding box
-      const boxX = xStart
-      const boxY = yStart - fontSize // top of first line
-      const boxW = maxWidth
-      const boxH = lines.length * lineHeight // height for all lines
-      ctx.save()
-      ctx.beginPath()
-      ctx.rect(boxX, boxY, boxW, boxH)
-      ctx.clip()
-
-      // 6) draw each line glyph-by-glyph with letterSpacing
-      let y = yStart
-      for (const line of lines) {
-        let x = xStart
-        const glyphs = font.stringToGlyphs(line)
-        for (const glyph of glyphs) {
-          const path = glyph.getPath(x, y, fontSize)
-          path.fill = 'white'
-          path.stroke = null
-          path.draw(ctx)
-          // advance x
-          const adv = glyph.advanceWidth * (fontSize / font.unitsPerEm)
-          x += adv + letterSpacing
-        }
-        y += lineHeight
-      }
-
-      // 7) restore so any further drawing isn't clipped
-      ctx.restore()
+    // 2) load & cache font. loadFont() returns null when the expected
+    // Cabrito.otf isn't present in the macOS user fonts directory — we
+    // record that as `fontStatus = 'missing'` so the component can warn
+    // the user instead of silently producing a thumbnail with no text.
+    if (!fontRef.current) {
+      const loaded = await loadFont()
+      fontRef.current = loaded
+      setFontStatus(loaded ? 'loaded' : 'missing')
     }
+    const font = fontRef.current
+    if (!font || !title.trim()) return
+
+    // 3) layout params
+    const fontSize = 37 // px
+    const xStart = 292 // left edge of box
+    const yStart = 467 // first-line baseline
+    const maxWidth = 380 // box width
+    const lineHeight = 45 // px between baselines
+    const letterSpacing = 1.5 // extra px between glyphs
+
+    // 4) word-wrap into lines[]
+    const lines: string[] = []
+    {
+      let line = ''
+      for (const word of title.split(' ')) {
+        const testLine = line + word + ' '
+        // measure width of testLine manually (including letterSpacing)
+        const glyphs = font.stringToGlyphs(testLine)
+        let widthPx = 0
+        for (const g of glyphs) {
+          widthPx += g.advanceWidth * (fontSize / font.unitsPerEm) + letterSpacing
+        }
+        if (widthPx > maxWidth && line) {
+          lines.push(line.trim())
+          line = word + ' '
+        } else {
+          line = testLine
+        }
+      }
+      if (line) lines.push(line.trim())
+    }
+
+    // 5) set up clipping region to restore your bounding box
+    const boxX = xStart
+    const boxY = yStart - fontSize // top of first line
+    const boxW = maxWidth
+    const boxH = lines.length * lineHeight // height for all lines
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(boxX, boxY, boxW, boxH)
+    ctx.clip()
+
+    // 6) draw each line glyph-by-glyph with letterSpacing
+    let y = yStart
+    for (const line of lines) {
+      let x = xStart
+      const glyphs = font.stringToGlyphs(line)
+      for (const glyph of glyphs) {
+        const path = glyph.getPath(x, y, fontSize)
+        path.fill = 'white'
+        path.stroke = null
+        path.draw(ctx)
+        // advance x
+        const adv = glyph.advanceWidth * (fontSize / font.unitsPerEm)
+        x += adv + letterSpacing
+      }
+      y += lineHeight
+    }
+
+    // 7) restore so any further drawing isn't clipped
+    ctx.restore()
   }, [])
 
-  return { canvasRef, draw }
+  return { canvasRef, draw, fontStatus }
 }

--- a/tests/unit/hooks/usePosterframeCanvas.test.ts
+++ b/tests/unit/hooks/usePosterframeCanvas.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for usePosterframeCanvas.
+ *
+ * The two behaviours under test are the ones that produced the
+ * "saved thumbnail has no text" report from a user on a fresh-cache machine:
+ *
+ * 1. `draw()` must `await` the Image's onload before resolving its returned
+ *    promise. Previously `draw()` was `async` but registered `img.onload` as
+ *    a callback, so `await draw(...)` resolved immediately. `Posterframe.tsx`
+ *    then called `canvas.toBlob()` against a canvas that hadn't been painted
+ *    yet.
+ *
+ * 2. `fontStatus` must transition to `'missing'` when `loadFont()` returns
+ *    null, so the page component can surface the silent-failure path
+ *    (Cabrito.otf not present on the user's machine) to the user.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { usePosterframeCanvas } from '@features/Upload/hooks/usePosterframeCanvas'
+
+vi.mock('@features/Upload/internal/loadFont', () => ({
+  loadFont: vi.fn()
+}))
+import { loadFont } from '@features/Upload/internal/loadFont'
+
+// ============================================================================
+// Image + Canvas2D mocks
+// ============================================================================
+
+interface PendingImage {
+  src: string
+  fireOnload: () => void
+  fireOnerror: (err?: Error) => void
+}
+
+let pendingImages: PendingImage[] = []
+
+function installImageMock() {
+  // Replace the global Image constructor with a version that captures each
+  // instance so the test can decide when (or whether) onload fires.
+  class MockImage {
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    width = 1024
+    height = 768
+    private _src = ''
+    get src(): string {
+      return this._src
+    }
+    set src(v: string) {
+      this._src = v
+      pendingImages.push({
+        src: v,
+        fireOnload: () => this.onload?.(),
+        fireOnerror: () => this.onerror?.()
+      })
+    }
+  }
+  // @ts-expect-error - replacing the global Image in tests
+  globalThis.Image = MockImage
+}
+
+function installCanvas2dStub(canvas: HTMLCanvasElement) {
+  // jsdom returns null from getContext('2d'); the hook bails out without a
+  // context. Provide just enough of the API the draw function uses so the
+  // code path executes and we can observe its async behaviour.
+  const ctx: Partial<CanvasRenderingContext2D> = {
+    imageSmoothingEnabled: true,
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn()
+  }
+  // @ts-expect-error - returning a partial stub for the test
+  canvas.getContext = vi.fn(() => ctx)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('usePosterframeCanvas', () => {
+  beforeEach(() => {
+    pendingImages = []
+    installImageMock()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('draw() promise does NOT resolve until the Image fires onload', async () => {
+    // Font is irrelevant to the race; null skips the text branch and keeps
+    // the test focused on image-load awaiting.
+    vi.mocked(loadFont).mockResolvedValue(null)
+
+    const { result } = renderHook(() => usePosterframeCanvas())
+    const canvas = document.createElement('canvas')
+    installCanvas2dStub(canvas)
+    // @ts-expect-error - assigning to RefObject.current in a test
+    result.current.canvasRef.current = canvas
+
+    let resolved = false
+    const drawPromise = result.current.draw('/some-image.jpg', 'Title')
+    drawPromise.then(() => {
+      resolved = true
+    })
+
+    // Microtask flush — promise must still be pending because onload hasn't
+    // fired. This is the regression check: previous implementation would
+    // already be resolved at this point.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    expect(pendingImages).toHaveLength(1)
+    expect(pendingImages[0].src).toBe('/some-image.jpg')
+
+    // Fire onload — now draw should be able to finish.
+    await act(async () => {
+      pendingImages[0].fireOnload()
+      await drawPromise
+    })
+    expect(resolved).toBe(true)
+  })
+
+  test('draw() rejects when image fails to load', async () => {
+    vi.mocked(loadFont).mockResolvedValue(null)
+
+    const { result } = renderHook(() => usePosterframeCanvas())
+    const canvas = document.createElement('canvas')
+    installCanvas2dStub(canvas)
+    // @ts-expect-error - assigning to RefObject.current in a test
+    result.current.canvasRef.current = canvas
+
+    const drawPromise = result.current.draw('/bad-image.jpg', 'Title')
+    // Catch upfront so an unhandled rejection doesn't bubble in the test.
+    const caught = drawPromise.catch((e: Error) => e)
+
+    pendingImages[0].fireOnerror()
+    const err = await caught
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toContain('failed to load')
+  })
+
+  test("fontStatus transitions to 'missing' when loadFont returns null", async () => {
+    vi.mocked(loadFont).mockResolvedValue(null)
+
+    const { result } = renderHook(() => usePosterframeCanvas())
+    expect(result.current.fontStatus).toBe('unknown')
+
+    const canvas = document.createElement('canvas')
+    installCanvas2dStub(canvas)
+    // @ts-expect-error - assigning to RefObject.current in a test
+    result.current.canvasRef.current = canvas
+
+    await act(async () => {
+      const p = result.current.draw('/image.jpg', 'Title')
+      pendingImages[0].fireOnload()
+      await p
+    })
+
+    expect(result.current.fontStatus).toBe('missing')
+  })
+
+  test("fontStatus transitions to 'loaded' when loadFont returns a font", async () => {
+    // Minimal opentype.Font stub — we only need stringToGlyphs to not throw
+    // and unitsPerEm to be defined for the layout pass.
+    const fakeFont = {
+      unitsPerEm: 1000,
+      stringToGlyphs: vi.fn(() => [])
+    }
+    // @ts-expect-error - partial Font stub is enough for the loaded branch
+    vi.mocked(loadFont).mockResolvedValue(fakeFont)
+
+    const { result } = renderHook(() => usePosterframeCanvas())
+    expect(result.current.fontStatus).toBe('unknown')
+
+    const canvas = document.createElement('canvas')
+    installCanvas2dStub(canvas)
+    // @ts-expect-error - assigning to RefObject.current in a test
+    result.current.canvasRef.current = canvas
+
+    await act(async () => {
+      const p = result.current.draw('/image.jpg', 'Title')
+      pendingImages[0].fireOnload()
+      await p
+    })
+
+    expect(result.current.fontStatus).toBe('loaded')
+  })
+})


### PR DESCRIPTION
## Summary

User-reported bug: thumbnail saved by the Posterframe tool had no title text. Worked fine on the developer's machine, failed on a freshly-set-up user's machine.

Two latent bugs found, both fixed in this PR. **One layer (font bundling) is deferred pending a licensing answer** — see "Out of scope" below.

## Bug 1 — async fire-and-forget in `usePosterframeCanvas.draw()`

\`\`\`ts
// Before
const draw = useCallback(async (imageUrl, title) => {
  const img = new Image()
  img.src = imageUrl
  img.onload = async () => { /* all the painting */ }
}, [])
// ↑ outer Promise resolves immediately; `await draw(...)` never waits
\`\`\`

Effect: `Posterframe.tsx::generateThumbnail` calls `canvas.toBlob()` after `await draw(...)` — but with the bug, that captures a canvas that hasn't been painted yet. Developer machine had image + font cached so `onload` fired synchronously and masked the race.

Fix: promisify the Image load and `await` it. Also `await draw(...)` once more before `toBlob` to drain any pending 300ms debounced redraw from the auto-redraw hook.

## Bug 2 — silent failure when Cabrito.otf isn't installed

\`loadFont()\` returns null when \`~/Library/Fonts/Cabrito.otf\` is absent, and the draw function silently bailed out of its text-rendering branch. Users without the font installed saw a blank thumbnail and no diagnostic.

Fix: expose \`fontStatus: 'unknown' | 'loaded' | 'missing'\` from the canvas hook. \`Posterframe.tsx\` toasts once when the missing state is first detected, with instructions for where to install the font.

## Out of scope: font bundling (Layer 1)

The cleanest user-facing fix is to bundle \`Cabrito.otf\` with the app so users don't need to install it manually. Cabrito is a commercial typeface from Insigne Design and bundling has licensing implications — deferred until that's resolved. Once we know the licence permits app-embedding (or we swap to an OFL-licensed substitute), it's a small follow-up:

1. Add the font file under \`src-tauri/resources/fonts/\`.
2. Update \`tauri.conf.json\` \`bundle.resources\` to include it.
3. Switch \`loadFont()\` to read from \`resourceDir()\` instead of \`fontDir()\`.

## Test plan

- [x] 2245 frontend tests passing (no regressions)
- [x] 4 new unit tests in \`tests/unit/hooks/usePosterframeCanvas.test.ts\`:
  - **Race-condition regression**: asserts \`draw()\`'s Promise does NOT resolve until \`image.onload\` fires — this is the test that would have caught the original bug.
  - Error handling: \`draw()\` rejects when image fails to load.
  - \`fontStatus\` → \`'missing'\` when \`loadFont()\` returns null.
  - \`fontStatus\` → \`'loaded'\` when \`loadFont()\` returns a font.
- [x] Prettier clean on all three touched files
- [x] ESLint: 0 errors on touched files (17 pre-existing repo warnings unchanged)
- [ ] Reviewer: pull branch, launch app on a machine **without** \`Cabrito.otf\` installed → confirm toast appears explaining the missing font.
- [ ] Reviewer: pull branch, launch app on a machine **with** \`Cabrito.otf\` installed → confirm both live preview and saved thumbnail render text correctly.
- [ ] Reviewer (the original failure mode): with \`Cabrito.otf\` installed but a cold image cache (e.g. fresh \`bun run dev:tauri\` after \`rm -rf dist\`), enter a title and quickly click Generate → saved file should now contain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)