### PR TITLE
fix(sidebar): hide unused Transcription page from Upload content menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.15.0"
+version = "0.15.1"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/shared/ui/layout/app-sidebar.tsx
+++ b/src/shared/ui/layout/app-sidebar.tsx
@@ -81,11 +81,9 @@ const data = {
         {
           title: 'Trello',
           url: '/upload/trello'
-        },
-        {
-          title: 'Transcription',
-          url: '/upload/otter'
         }
+        // 'Transcription' (/upload/otter) hidden from sidebar — feature currently unused.
+        // Route remains registered in AppRouter so it can be re-enabled by restoring this item.
       ]
     },
     {


### PR DESCRIPTION
## Summary
Hides the **Transcription** entry (`/upload/otter`) from the **Upload content** section of the sidebar. The page is a placeholder for an Otter.ai integration that is not yet functional, so exposing it in navigation is misleading.

## Changes
- Remove the `Transcription` nav item from `data.navMain` in [app-sidebar.tsx](src/shared/ui/layout/app-sidebar.tsx).
- Leave a comment documenting why it's hidden and how to restore it.
- The `/upload/otter` route stays registered in `AppRouter.tsx`, so re-enabling is a one-line revert once the feature ships.

## Verification
- `bun run eslint:fix` — 0 errors (only pre-existing warnings, none in touched file)
- `bun run prettier:fix` — file unchanged (already formatted)
- `bun run test` — 139 files / 2257 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Version
- Bumped to **0.15.1** (patch, rebased onto current master which is at 0.15.0) across `package.json`, `Cargo.toml`, `tauri.conf.json`, `Cargo.lock`.

