### PR TITLE
fix(baker): increase max linked Trello cards per project to 50 (v0.16.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.16.0"
+version = "0.16.1"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/src/baker/video_links.rs
+++ b/src-tauri/src/baker/video_links.rs
@@ -192,8 +192,8 @@ pub async fn baker_associate_trello_card(
 
     let cards = breadcrumbs.trello_cards.as_mut().unwrap();
 
-    if cards.len() >= 10 {
-        return Err("Maximum of 10 Trello cards per project reached".to_string());
+    if cards.len() >= 50 {
+        return Err("Maximum of 50 Trello cards per project reached".to_string());
     }
 
     if cards.iter().any(|c| c.card_id == trello_card.card_id) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/Trello/hooks/useTrelloCardsManager.ts
+++ b/src/features/Trello/hooks/useTrelloCardsManager.ts
@@ -29,8 +29,8 @@ function validateCardCanBeAdded(
   trelloCards: TrelloCard[],
   cardId: string
 ): string | null {
-  if (trelloCards.length >= 10) {
-    return 'Maximum of 10 Trello cards per project reached'
+  if (trelloCards.length >= 50) {
+    return 'Maximum of 50 Trello cards per project reached'
   }
   if (trelloCards.some((card) => card.cardId === cardId)) {
     return 'This Trello card is already associated with the project'
@@ -374,7 +374,7 @@ export function useTrelloCardsManager({
 
     // Computed
     hasApiCredentials: !!(trelloApiKey && trelloApiToken),
-    canAddCard: trelloCards.length < 10 && !isUpdating,
+    canAddCard: trelloCards.length < 50 && !isUpdating,
 
     // Handlers
     handleSelectCard,

--- a/tests/setup/tauri-mocks.ts
+++ b/tests/setup/tauri-mocks.ts
@@ -128,9 +128,9 @@ export function setupTauriMocks() {
         const existing =
           mockBreadcrumbsStore.get(projectPath) || createEmptyBreadcrumbs(projectPath)
 
-        // Validate max 10 cards
-        if ((existing.trelloCards?.length ?? 0) >= 10) {
-          return Promise.reject('Maximum of 10 Trello cards per project reached')
+        // Validate max 50 cards
+        if ((existing.trelloCards?.length ?? 0) >= 50) {
+          return Promise.reject('Maximum of 50 Trello cards per project reached')
         }
 
         // Check for duplicate cardId


### PR DESCRIPTION
## Summary

Users need to link more Trello cards to a project in the **Baker** feature. This raises the maximum linked Trello cards per project from **10 → 50**.

Delivered as a hotfix: version bumped `0.16.0 → 0.16.1`.

## Changes

- `src/features/Trello/hooks/useTrelloCardsManager.ts` — `validateCardCanBeAdded` limit + error message, and the `canAddCard` guard
- `src-tauri/src/baker/video_links.rs` — `baker_associate_trello_card` backend enforcement + error message
- `tests/setup/tauri-mocks.ts` — mock validation for `baker_associate_trello_card` + message
- Version bump to `0.16.1` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`

## Verification

- `bun run test` — **2276 passed** (141 files)
- `bun run eslint:fix` — **0 errors** (15 pre-existing warnings, none in touched files)
- `bun run prettier:fix` — all files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)