### PR TITLE
docs: full documentation refresh for v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,312 @@ All notable changes to the Bucket project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-30
+
+### Added
+
+- Self-assign to Trello cards directly from Baker via a new toggle control
+
+---
+
+## [0.15.1] - 2026-06-19
+
+### Fixed
+
+- Hide unused Transcription page from the Upload content sidebar menu
+
+---
+
+## [0.15.0] - 2026-06-11
+
+### Changed
+
+- Baker UI refresh: full-height layout, diff-row previews, and rebuilt batch dialog
+
+### Fixed
+
+- Posterframe text rendering on cold-cache and missing-font machines
+- BuildProject hang resolved by wiring to throttled native file transfer path
+
+---
+
+## [0.14.8] - 2026-06-10
+
+### Fixed
+
+- Reliably sync breadcrumbs to all linked Trello cards
+- Pin @tauri-apps npm packages to crate-compatible minors to prevent build failures
+
+---
+
+## [0.14.7] - 2026-06-10
+
+### Security
+
+- Resolve dependency security vulnerabilities (Vite upgraded to 7.3.2 for high/moderate CVE fixes)
+
+---
+
+## [0.14.5] - 2026-04-02
+
+### Security
+
+- Remove unused dependencies carrying lodash vulnerabilities
+- Resolve 42 dependency vulnerabilities (security hotfix)
+
+---
+
+## [0.14.4] - 2026-04-01
+
+### Added
+
+- E2E integration tests covering core user stories (US-02 through US-11)
+
+### Fixed
+
+- Sync Tauri NPM packages with Rust crate versions (@tauri-apps/plugin-dialog bumped to ^2.6.0)
+- Patch Rust dependency vulnerabilities (tar, rustls-webpki)
+
+### Changed
+
+- Upgrade GitHub Actions to Node.js 22+ compatible versions
+
+---
+
+## [0.14.3] - 2026-03-03
+
+### Added
+
+- Modular BuildProject architecture with XState v5 state machine and native macOS file transfers
+- Video lesson hooks for transcript and playback
+
+### Changed
+
+- Feature modules rewritten as grey-box modules (milestone 1 refactor)
+
+### Fixed
+
+- Remove unused glib dependency to fix cross-compilation
+
+---
+
+## [0.14.2] - 2026-01-29
+
+### Fixed
+
+- Build native binaries for both Apple Silicon and Intel Macs
+- Split build and notarization into separate CI workflow jobs to prevent timeouts
+- Increase publish workflow timeout to 120 minutes for notarization
+
+---
+
+## [0.14.1] - 2026-01-29
+
+### Fixed
+
+- Skip notarization in CI builds to unblock release pipeline
+- Build for aarch64-apple-darwin only in CI
+
+---
+
+## [0.14.0] - 2025-12-15
+
+### Changed
+
+- Consolidated release combining 0.10.0 through 0.13.0 improvements into a stable baseline for CI/CD publishing
+
+---
+
+## [0.13.0] - 2025-12-15
+
+### Added
+
+- Four new light themes for better variety
+- Settings page restyled with improved navigation and ErrorBoundary wrapper pattern
+
+### Fixed
+
+- System theme now uses dark styling correctly; isDark flag corrected
+- Theme preview hover behaviour stabilised
+
+### Changed
+
+- UploadSprout and UploadTrello pages updated to use standard page templates
+
+---
+
+## [0.12.0] - 2025-12-12
+
+### Added
+
+- Theme customisation: multiple themes (including Tokyo Night) with dynamic loading and colour swatch selector
+- Scrollable UpdateDialog for long release notes
+- Sidebar menu icons link to pages when the sidebar is collapsed
+- PreviewProgress component integrated with breadcrumbs preview
+
+### Changed
+
+- ScriptFormatter UI updated with Baker template pattern and theme support
+- Example Embeddings page refreshed with new UI
+- Settings menu updated with accordion-based themes card
+- Light-mode toggle removed from menu (themes replace it)
+- Virtual scrolling for ProjectFileList and ProjectListPanel for large-list performance
+- Framer Motion animations replaced with CSS transforms for better performance
+- Component memoisation (React.memo) applied across list panels
+
+### Fixed
+
+- Content header gap when sidebar is expanded
+
+---
+
+## [0.10.0] - 2025-12-11
+
+### Added
+
+- Custom macOS title bar with native traffic-light buttons and window state persistence
+- Premiere Pro Plugin Management: install, manage, and update Premiere plugins from the app
+- Trello board integration UI components
+- Version bump scripts and branching strategy documentation
+
+### Changed
+
+- Complete migration from npm to Bun across CI/CD workflows, documentation, and tooling
+- Prettier configuration added and codebase formatted
+- Animation system enhanced with constants, hooks, and Apple-style animation principles
+- BuildProject page refactored to use XState state machine for project creation workflow
+
+---
+
+## [0.9.7] - 2025-11-26
+
+### Fixed
+
+- Script editor DiffEditor loads Monaco conditionally and handles late content updates
+- Trello card update logic streamlined with improved error handling
+
+---
+
+## [0.9.6] - 2025-11-26
+
+### Fixed
+
+- Script processing state management and DiffEditor initialisation improved
+
+---
+
+## [0.9.5] - 2025-11-20
+
+### Changed
+
+- ESLint issues resolved; codebase-wide formatting pass
+- Replace several useEffect patterns with useMemo for Trello card grouping, sidebar skeleton, image refresh, and preferences loading
+- CI build step updated with Tauri signing environment variables
+
+---
+
+## [0.9.4] - 2025-11-20
+
+### Added
+
+- E2E testing infrastructure with Playwright and Tauri API mocks
+- Cache invalidation service with configurable max age
+- Centralised timing constants across the application
+
+### Changed
+
+- Migrated all console.log statements to logger utility
+- CI workflows updated to use Node.js instead of Bun for compatibility
+
+---
+
+## [0.9.2] - 2025-11-14
+
+### Fixed
+
+- Script processor output validation and examples count display
+- DiffEditor CDN loading and loading state improvements
+- Custom fetch with timeout for AI generation requests
+
+---
+
+## [0.9.1] - 2025-11-13
+
+### Changed
+
+- DiffEditor enhanced with loading state and validation logging
+- Tauri API updated to 2.9.0; Tauri crate updated to 2.9
+
+---
+
+## [0.9.0] - 2025-11-13
+
+### Added
+
+- RAG (Retrieval-Augmented Generation) for script processing with example retrieval
+- Upload and View Example Dialogs for script management
+- ScriptFormatter enhanced with RAG support and example saving
+- Database migration for example embeddings storage
+- ExampleToggleList component for managing script example selection
+- Ollama URL configuration and AI provider integration in Settings
+
+### Fixed
+
+- Monaco editor reverted to 0.53.0 for stability
+- Ollama AI provider updated to version 2 with improved error handling
+
+---
+
+## [0.8.6] - 2025-10-16
+
+### Changed
+
+- Enhanced upload handling in UploadSprout component
+- Dependencies updated with improved type imports
+
+---
+
+## [0.8.5] - 2025-10-03
+
+### Fixed
+
+- Premiere Pro template corruption prevented by adding file sync during project creation
+
+---
+
+## [0.8.4] - 2025-10-02
+
+### Added
+
+- Video upload functionality in VideoLinksManager with Sprout Video URL parsing
+- TrelloCardsManager with tabbed interface integrated into Baker UI
+- Support for multiple Trello cards per project (migrated from single-card to array-based structure)
+- Trello card updates integrated with video upload dialog
+
+---
+
+## [0.8.3] - 2025-09-29
+
+### Added
+
+- Modular Baker components with detailed project change view
+- Invalid breadcrumbs detection and handling
+- Breadcrumbs change preview and categorised field change display
+- Centralised date formatting for breadcrumbs
+
+---
+
+## [0.8.2] - 2025-09-26
+
+### Added
+
+- Baker feature: drive scanning with BreadcrumbsViewer component and breadcrumbs reader hook
+- Enhanced breadcrumbs management with folder size tracking and meaningful diffs
+- Overall progress tracking for file copying operations
+- Title sanitisation in BuildProject with warning display
+
+---
+
 ## [0.8.1] - 2024-12-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ npx npm-check-updates -u             # Update all dependencies to latest
 
 ### Tech Stack
 
-- **Frontend**: React 18.3 + TypeScript 5.7 + Vite 6.1
+- **Frontend**: React 19.2 + TypeScript 5.9 + Vite 7.3
 - **Backend**: Tauri 2.0 (Rust) with extensive plugin ecosystem
 - **UI**: TailwindCSS + Radix UI components + Lucide icons
 - **State**: Zustand stores + TanStack React Query (preferred over useEffect)
@@ -63,24 +63,24 @@ npx npm-check-updates -u             # Update all dependencies to latest
 ```
 src/
 +-- features/
-|   +-- AITools/       # ScriptFormatter + ExampleEmbeddings (api.ts, 6 barrel exports)
+|   +-- AITools/       # ScriptFormatter + ExampleEmbeddings (api.ts, 2 barrel exports)
 |   +-- Auth/          # Login, registration, token management (api.ts, 6 barrel exports)
-|   +-- Baker/         # Drive scanning, breadcrumbs management (api.ts, 21 barrel exports)
-|   +-- BuildProject/  # File ingest, camera assignment, XState (api.ts, 3 barrel exports)
-|   +-- Premiere/      # Adobe Premiere plugin management (api.ts, 3 barrel exports)
+|   +-- Baker/         # Drive scanning, breadcrumbs management (api.ts, 24 barrel exports)
+|   +-- BuildProject/  # File ingest, camera assignment, XState (api.ts, 4 barrel exports)
+|   +-- Premiere/      # Adobe Premiere plugin management (api.ts, 1 barrel export)
 |   +-- Settings/      # App configuration with per-domain tabs (api.ts, 3 barrel exports)
-|   +-- Trello/        # Trello card management, video links (api.ts, 32 barrel exports)
-|   +-- Upload/        # Sprout Video, Posterframe, Otter (api.ts, 19 barrel exports)
+|   +-- Trello/        # Trello card management, video links (api.ts, 29 barrel exports)
+|   +-- Upload/        # Sprout Video, Posterframe, Otter (api.ts, 17 barrel exports)
 |
 +-- shared/
-|   +-- constants/     # Timing, animation, project constants (27 exports)
-|   +-- hooks/         # Cross-feature hooks: breadcrumb, search, API keys, mobile (7 exports)
-|   +-- lib/           # Query infrastructure: keys, client, utils, prefetch, perf (50 exports)
-|   +-- services/      # ProgressTracker, feedback, cache services (16 exports)
-|   +-- store/         # Zustand stores: appStore, breadcrumbStore (2 exports)
-|   +-- types/         # Shared domain types: media, script, breadcrumbs (34 exports)
+|   +-- constants/     # Timing, animation, project constants (26 exports)
+|   +-- hooks/         # Cross-feature hooks: breadcrumb, search, API keys, mobile (8 exports)
+|   +-- lib/           # Query infrastructure: keys, client, utils, prefetch, perf (49 exports)
+|   +-- services/      # ProgressTracker, feedback, cache services (5 exports)
+|   +-- store/         # Zustand stores: appStore, breadcrumbStore (3 exports)
+|   +-- types/         # Shared domain types: media, script, breadcrumbs (41 exports)
 |   +-- ui/            # Radix primitives, sidebar, theme, layout (direct imports, NO barrel)
-|   +-- utils/         # Logger, storage, validation, cn(), breadcrumbs utils (30 exports)
+|   +-- utils/         # Logger, storage, validation, cn(), breadcrumbs utils (29 exports)
 
 src-tauri/
 +-- src/               # Rust backend with file operations, API integrations
@@ -222,9 +222,9 @@ Each feature has `__contracts__/` with three test types:
 
 ## Development Notes
 
-- **Main Branch**: `main` (use for PRs)
+- **Main Branch**: `master` (use for PRs)
 - **Package Manager**: Bun (used for all development and CI, replaces npm entirely)
 - **Platform**: Cross-platform desktop app, primary development on macOS
 - **Security**: Uses argon2 for password hashing, JWT for auth, Tauri stronghold for secure storage
-- **Themes**: 8 themes available (System, Light, Dark, Dracula, Catppuccin variants) via `@shared/ui/theme/`
+- **Themes**: 13 themes available (System, Light, Dark, Dracula, Tokyo Night, Catppuccin variants, Solarized Light, GitHub Light, Nord Light, One Light) via `@shared/ui/theme/`
 - **Window**: Native macOS title bar with traffic lights, vibrancy effects, window state persistence

--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,9 @@
 # Project Requirements Document
 
+*This is the original PRD written at the start of the Bucket project and is kept for
+historical context. For current project documentation, see [README.md](README.md) and
+the [docs/](docs/) directory.*
+
 ## 1. Project Overview
 
 - **Project Name:** Bucket

--- a/README.md
+++ b/README.md
@@ -1,284 +1,155 @@
-<!-- ⚠️ This README has been generated from the file(s) "blueprint.md" ⚠️--><h1 align="center">bucket</h1>
+# Bucket
 
-<p align="center">
-  <b>A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.</b></br>
-  <sub><sub>
-</p>
+A desktop video-production workflow app built with Tauri 2 (Rust + React/TypeScript). Bucket streamlines footage ingest, project creation, and integration with Adobe Premiere, Trello, and Sprout Video.
 
-<br />
+**Version:** 0.16.0  
+**Platform:** macOS (primary)  
+**License:** UNLICENSED (proprietary)
 
+## What Bucket Does
 
+Bucket is a single desktop app that ties together the repetitive steps of a video-production pipeline:
 
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#table-of-contents)
+- **BuildProject** -- Select footage files, assign camera numbers, and generate an organised folder structure with an Adobe Premiere project in one step. File operations run in the Rust backend with real-time progress tracking.
+- **Baker** -- Scan a drive for project folders, validate their structure (Footage, Graphics, Renders, Projects, Scripts), and create or update `breadcrumbs.json` metadata files in batch. Recent updates added a full-height layout, diff-row previews, and a rebuilt batch dialog.
+- **Upload** -- Publish videos to Sprout Video, generate custom posterframes, and manage hosting metadata.
+- **Trello** -- Link projects to Trello cards, sync breadcrumbs metadata, and self-assign to cards via a toggle (added in v0.16.0).
+- **Premiere** -- Install and update Premiere Pro CEP extension plugins (BreadcrumbsPremiere, Boring) with one click.
+- **AI Tools** -- AI-powered script formatting for autocue/teleprompter use, powered by local Ollama models via the Vercel AI SDK.
+- **Auth** -- Login, registration, and token management with argon2 hashing and Tauri Stronghold secure storage.
+- **Settings** -- Per-domain configuration tabs covering Trello boards, Ollama connection, and app preferences. Eight themes available (System, Light, Dark, Dracula, Catppuccin variants).
 
-## ➤ Table of Contents
+## Getting Bucket
 
-* [➤ Overview](#-overview)
-* [➤ Key Features](#-key-features)
-* [➤ Installation](#-installation)
-	* [Prerequisites](#prerequisites)
-	* [Quick Start](#quick-start)
-	* [Development Setup](#development-setup)
-* [➤ Ollama Setup](#-ollama-setup)
-	* [Installing Ollama](#installing-ollama)
-	* [Running Ollama](#running-ollama)
-	* [Installing AI Models](#installing-ai-models)
-	* [Configuring in Bucket](#configuring-in-bucket)
-	* [Troubleshooting Ollama](#troubleshooting-ollama)
-* [➤ How It Works](#-how-it-works)
-	* [AI Script Formatter Workflow](#ai-script-formatter-workflow)
-	* [Video Project Workflow](#video-project-workflow)
-* [➤ Tech Stack](#-tech-stack)
-* [➤ Premiere Pro Plugin Management](#-premiere-pro-plugin-management)
-	* [Bundled Plugins](#bundled-plugins)
-		* [BreadcrumbsPremiere](#breadcrumbspremiere)
-		* [Boring](#boring)
-	* [One-Click Installation](#one-click-installation)
-	* [Platform Support](#platform-support)
-* [➤ License](#-license)
+Releases are published to GitHub via the `publish` workflow. The latest macOS build is available on the [Releases page](https://github.com/twentynineteen/bucket/releases). The app includes a built-in auto-updater.
 
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#overview)
-
-## ➤ Overview
-
-Bucket is a powerful desktop application built with Tauri (Rust + React/TypeScript) designed to streamline video editing workflows for professionals. It simplifies video file ingest, automates project creation, and seamlessly integrates with industry-standard tools like Adobe Premiere, Trello, and Sprout Video.
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#key-features)
-
-## ➤ Key Features
-
-- **AI Script Formatter**: AI-powered autocue script formatting using locally hosted LLM models
-  - Upload Word documents (.docx) and format them for teleprompter use
-  - Text editor to review and update AI changes
-  - Edit and refine AI suggestions before exporting
-  - Powered by local Ollama models (no cloud required)
-- **Multi-Camera Project Setup**: Organize footage by camera assignment for multi-camera shoots
-- **Adobe Premiere Integration**: Automatically generate project templates and folder structures
-- **Progress Tracking**: Real-time progress bars for file operations and project creation
-- **External Tool Integration**:
-  - **Trello**: Project management and card updates
-  - **Sprout Video**: Video hosting with custom posterframe generation
-- **Secure User Management**: Login/registration with encrypted data storage
-- **Cross-Platform**: Available for Windows, macOS, and Linux
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#installation)
-
-## ➤ Installation
+## Development
 
 ### Prerequisites
 
-- Bun (package manager)
-- Rust (for development)
-- **Ollama** (for AI Script Formatter feature) - see [Ollama Setup](#ollama-setup) below
+- [Bun](https://bun.sh) -- package manager and script runner (replaces npm entirely)
+- [Rust toolchain](https://rustup.rs) -- required by the Tauri 2 backend
+- Xcode Command Line Tools (macOS) -- needed for native compilation
 
-### Quick Start
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/twentynineteen/bucket.git
-   cd bucket
-   ```
-
-2. Install dependencies:
-
-   ```bash
-   bun install
-   ```
-
-3. Build the application:
-
-   ```bash
-   bun run build:tauri
-   ```
-
-4. On macOS, open the DMG file in `/target/build/dmg` and copy the app to your Applications folder.
-
-### Development Setup
-
-To run in development mode:
+### Setup
 
 ```bash
-bun run dev:tauri
+git clone https://github.com/twentynineteen/bucket.git
+cd bucket
+bun install
 ```
 
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#ollama-setup)
-
-## ➤ Ollama Setup
-
-The AI Script Formatter feature requires Ollama to be installed and running locally.
-
-### Installing Ollama
-
-1. Download and install Ollama from [ollama.com](https://ollama.com)
-   - **macOS**: Download the `.dmg` installer
-   - **Linux**: Run `curl -fsSL https://ollama.com/install.sh | sh`
-   - **Windows**: Download from the Ollama website
-
-2. Verify installation:
-   ```bash
-   ollama --version
-   ```
-
-### Running Ollama
-
-Ollama runs as a background service. To start it:
+### Running
 
 ```bash
-ollama serve
+bun run dev:tauri       # Start the full Tauri app in dev mode (primary dev command)
+bun run dev             # Start the Vite frontend dev server only
+bun run preview         # Preview the production frontend build
 ```
 
-The service runs on `http://localhost:11434` by default.
-
-### Installing AI Models
-
-Before using the Script Formatter, download the following language models:
+### Building
 
 ```bash
-
-ollama pull llama3.1:latest
-ollama pull nomic-embed-text:latest
-ollama list
+bun run build:tauri     # Build the complete desktop app (produces a DMG in target/build/dmg)
+bun run build           # Build the frontend only
 ```
 
-**Model Selection Tips:**
-
-- **llama3.2**: Best for quick formatting on limited hardware
-
-### Configuring in Bucket
-
-1. Launch Bucket and navigate to **Settings**
-2. Find the **Ollama URL** field (default: `http://localhost:11434`)
-3. Update the URL if needed and click **Save**
-4. Click **Test Connection** to verify Ollama is running and see how many models are available
-5. Navigate to **AI Tools > Script Formatter** to start formatting scripts
-
-### Troubleshooting Ollama
-
-**Connection Failed:**
-Check if Ollama is running:
+### Tests
 
 ```bash
-curl http://localhost:11434/api/tags
+bun run test            # Run Vitest in watch mode
+bun run test:run        # Run Vitest once (CI mode)
+bun run test:coverage   # Run with coverage report
+bun run test:ui         # Open the Vitest browser UI
 ```
 
-If not running, start it:
+End-to-end tests use Playwright:
 
 ```bash
-ollama serve
+bun run test:e2e                    # Run all e2e tests
+bun run test:e2e:headed             # Run with a visible browser
+bun run test:e2e:buildproject       # Run only BuildProject e2e tests
+bun run test:e2e:report             # View the HTML test report
 ```
 
-**No Models Available:**
-List installed models:
+### Code Quality
+
+Run these before committing:
 
 ```bash
-ollama list
+bun run eslint:fix      # Fix lint issues (includes module-boundary rules)
+bun run prettier:fix    # Auto-format (90 char width, single quotes, no semicolons)
+bun run knip            # Detect unused exports and dependencies
 ```
 
-Install a model:
+## CI
+
+GitHub Actions workflows run on every push and PR to `master` and `release`:
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| **CI** (`ci.yml`) | Push/PR to `master`, `release` | Lint, unit tests, frontend build |
+| **E2E Tests** (`e2e-tests.yml`) | PRs touching BuildProject or e2e paths | Playwright end-to-end tests |
+| **Publish** (`publish.yml`) | Push to `release` | Build app, create GitHub release, upload artifacts |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 19 + TypeScript 5.9 + Vite 7 |
+| Backend | Tauri 2.0 (Rust 2021 edition) |
+| UI | TailwindCSS 4 + Radix UI + Lucide icons |
+| State | Zustand + TanStack React Query |
+| State machines | XState (BuildProject workflow) |
+| Testing | Vitest + Testing Library + Playwright |
+| AI | Vercel AI SDK + Ollama (local LLM) |
+| Formatting | Prettier + ESLint (auto-configured) |
+
+## Project Structure
+
+```
+src/
+  features/
+    AITools/        Script formatting + embeddings
+    Auth/           Login, registration, token management
+    Baker/          Drive scanning, breadcrumbs management
+    BuildProject/   File ingest, camera assignment, project creation
+    Premiere/       Premiere Pro plugin management
+    Settings/       App configuration
+    Trello/         Trello card management, video links
+    Upload/         Sprout Video, posterframe generation
+  shared/
+    constants/      Timing, animation, project constants
+    hooks/          Cross-feature hooks
+    lib/            React Query infrastructure
+    services/       Progress tracking, feedback, caching
+    store/          Zustand stores (appStore, breadcrumbStore)
+    types/          Shared domain types
+    ui/             Radix primitives, sidebar, theme, layout
+    utils/          Logger, storage, validation utilities
+
+src-tauri/
+  src/              Rust backend (file operations, API integrations)
+  Cargo.toml        Rust dependencies
+  tauri.conf.json   Tauri app configuration
+```
+
+Each feature module follows a strict convention: an `api.ts` I/O boundary wrapping all Tauri calls, a barrel `index.ts` with JSDoc exports, and `__contracts__/` tests enforcing shape, behaviour, and no-bypass rules. Shared modules never import from features.
+
+## Further Reading
+
+- **[CLAUDE.md](./CLAUDE.md)** -- Architecture conventions, import rules, and how to add a new feature module
+- **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)** -- System design, data flow, and component interactions
+- **[docs/ONBOARDING.md](./docs/ONBOARDING.md)** -- Developer onboarding guide
+- **[docs/PREMIERE_PLUGINS.md](./docs/PREMIERE_PLUGINS.md)** -- Premiere Pro plugin documentation
+- **[docs/BRANCHING_STRATEGY.md](./docs/BRANCHING_STRATEGY.md)** -- Git branching and release conventions
+
+## Version Bumping
 
 ```bash
-ollama pull llama3:latest
+bun run version:patch   # 0.16.0 -> 0.16.1
+bun run version:minor   # 0.16.0 -> 0.17.0
+bun run version:major   # 0.16.0 -> 1.0.0
 ```
 
-**Port Conflicts:**
-If port 11434 is in use, you can run Ollama on a different port:
-
-```bash
-OLLAMA_HOST=0.0.0.0:11435 ollama serve
-```
-
-Then update the URL in Bucket Settings to `http://localhost:11435`
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#how-it-works)
-
-## ➤ How It Works
-
-### AI Script Formatter Workflow
-
-1. **Upload Script**: Select a `.docx` file from your computer (up to 1GB)
-2. **Select AI Model**: Choose from available Ollama models running on your machine
-3. **AI Processing**: The script is automatically formatted for autocue/teleprompter readability
-4. **Review Changes**: View side-by-side diff showing original vs. AI-formatted text
-5. **Edit & Refine**: Make manual adjustments to the AI's suggestions if needed
-6. **Export**: Download the formatted script as a `.docx` file ready for teleprompter use
-
-### Video Project Workflow
-
-1. **Select Video Files**: Choose footage files from your file system
-2. **Assign Cameras**: Organize files by camera number for multi-camera projects
-3. **Configure Project**: Set project title and output folder location
-4. **Create Project**: Generate organized folder structure with Adobe Premiere integration
-5. **Track Progress**: Monitor file operations with real-time progress updates
-6. **Integrate & Upload**: Connect with Trello for project management or Sprout Video for hosting
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#tech-stack)
-
-## ➤ Tech Stack
-
-- **Frontend**: React 18 + TypeScript + TailwindCSS
-- **Backend**: Tauri 2.0 (Rust)
-- **UI Components**: Radix UI + Lucide icons
-- **State Management**: Zustand + TanStack React Query
-- **Build Tool**: Vite
-- **AI Integration**:
-  - Vercel AI SDK v5 for unified provider interface
-  - Ollama (local LLM runtime)
-  - Monaco Editor for diff visualization and editing
-  - mammoth.js for Word document parsing
-  - docx for document generation
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#premiere-pro-plugin-management)
-
-## ➤ Premiere Pro Plugin Management
-
-Bucket includes an **integrated plugin manager** for Premiere Pro CEP extensions. Install and update plugins with one click - no manual file operations required.
-
-### Bundled Plugins
-
-#### BreadcrumbsPremiere
-
-Metadata management panel that syncs with Bucket's project system. View and edit breadcrumbs directly in your Premiere timeline.
-
-**Features**:
-
-- View and edit project metadata in Premiere Pro
-- Sync with Trello cards and Sprout Video
-- Quick access to project resources
-- Seamless integration with Bucket workflows
-
-#### Boring
-
-Premiere Pro extension for streamlined workflows.
-
-**Features**:
-
-- _(User to specify features)_
-
-### One-Click Installation
-
-1. Navigate to **Upload Content > Premiere Plugin Manager**
-2. Click **Install** on any plugin
-3. Restart Premiere Pro
-4. Access via **Window > Extensions**
-
-### Platform Support
-
-- **macOS**: Automatic debug mode configuration
-- **Windows**: Silent installation
-- **Cross-platform**: Works identically on both platforms
-
-[Read full documentation →](../PREMIERE_PLUGINS.md)
-
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/cloudy.png)](#license)
-
-## ➤ License
-	
-Licensed under [UNLICENSED](https://opensource.org/licenses/UNLICENSED).
+These scripts update `package.json`, `Cargo.toml`, and `tauri.conf.json` in one step.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Bucket is a single desktop app that ties together the repetitive steps of a vide
 - **Premiere** -- Install and update Premiere Pro CEP extension plugins (BreadcrumbsPremiere, Boring) with one click.
 - **AI Tools** -- AI-powered script formatting for autocue/teleprompter use, powered by local Ollama models via the Vercel AI SDK.
 - **Auth** -- Login, registration, and token management with argon2 hashing and Tauri Stronghold secure storage.
-- **Settings** -- Per-domain configuration tabs covering Trello boards, Ollama connection, and app preferences. Eight themes available (System, Light, Dark, Dracula, Catppuccin variants).
+- **Settings** -- Per-domain configuration tabs covering Trello boards, Ollama connection, and app preferences. Thirteen themes available (System, Light, Dark, Dracula, Tokyo Night, Catppuccin variants, Solarized Light, GitHub Light, Nord Light, One Light).
 
 ## Getting Bucket
 
@@ -96,7 +96,7 @@ GitHub Actions workflows run on every push and PR to `master` and `release`:
 
 | Layer | Technology |
 |-------|-----------|
-| Frontend | React 19 + TypeScript 5.9 + Vite 7 |
+| Frontend | React 19.2 + TypeScript 5.9 + Vite 7.3 |
 | Backend | Tauri 2.0 (Rust 2021 edition) |
 | UI | TailwindCSS 4 + Radix UI + Lucide icons |
 | State | Zustand + TanStack React Query |

--- a/docs/API_COMMANDS.md
+++ b/docs/API_COMMANDS.md
@@ -6,110 +6,27 @@ This document provides complete reference documentation for all Tauri commands e
 
 **Target audience:** Frontend developers building features that interact with the Rust backend.
 
-**Last updated:** January 2025 (v0.9.3)
+**Last updated:** July 2026 (v0.16.0)
 
 ---
 
 ## Table of Contents
 
-1. [File Operations](#file-operations)
-2. [Authentication](#authentication)
-3. [RAG (Retrieval-Augmented Generation)](#rag-retrieval-augmented-generation)
-4. [Adobe Premiere Integration](#adobe-premiere-integration)
-5. [DOCX Processing](#docx-processing)
-6. [Sprout Video](#sprout-video)
-7. [AI Provider Management](#ai-provider-management)
-8. [System Utilities](#system-utilities)
-
----
-
-## File Operations
-
-Commands for file system operations with progress tracking.
-
-### `move_files`
-
-**Purpose:** Copy files to camera-specific folders with real-time progress tracking.
-
-**Signature:**
-
-```rust
-pub fn move_files(
-    files: Vec<(String, u32)>,  // [(file_path, camera_number), ...]
-    base_dest: String,          // Base destination folder
-    app_handle: AppHandle,      // For emitting progress events
-) -> Result<(), String>
-```
-
-**Parameters:**
-
-| Parameter    | Type                 | Description                                   |
-| ------------ | -------------------- | --------------------------------------------- |
-| `files`      | `Vec<(String, u32)>` | Array of tuples: `(file_path, camera_number)` |
-| `base_dest`  | `String`             | Destination project folder path               |
-| `app_handle` | `AppHandle`          | Tauri app handle (automatically provided)     |
-
-**Returns:** `Result<(), String>` - Immediate success (runs async in background)
-
-**Events Emitted:**
-
-- `copy_progress` - Emitted during file copy with progress data
-
-  ```typescript
-  interface CopyProgressEvent {
-    current: number // Current file index
-    total: number // Total files
-    filename: string // Current file name
-    progress: number // 0-100 percentage
-  }
-  ```
-
-- `copy_complete` - Emitted when all files are copied
-  ```typescript
-  type CopyCompleteEvent = string[] // Array of destination file paths
-  ```
-
-**Example Usage:**
-
-```typescript
-import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
-
-// Listen to progress events
-const unlisten = await listen('copy_progress', event => {
-  const { current, total, filename, progress } = event.payload
-  console.log(`Copying ${filename}: ${progress}% (${current}/${total})`)
-})
-
-// Start file copy
-await invoke('move_files', {
-  files: [
-    ['/path/to/clip1.mov', 1],
-    ['/path/to/clip2.mov', 1],
-    ['/path/to/clip3.mov', 2]
-  ],
-  baseDest: '/path/to/project'
-})
-
-// Listen for completion
-await listen('copy_complete', event => {
-  console.log('All files copied:', event.payload)
-  unlisten() // Clean up listener
-})
-```
-
-**Implementation Details:**
-
-- Runs in a separate thread to avoid blocking the UI
-- Creates camera folders if they don't exist (`Footage/Camera 1/`, etc.)
-- Uses buffered I/O for performance (~100 MB/s on SSD)
-- Emits progress events every 10% of file size
-- Continues on error (logs error, skips file)
-
-**Error Handling:**
-
-- Returns immediately with `Ok(())` (errors logged to stderr)
-- Failed files are skipped, not included in `copy_complete` event
+1. [Authentication](#authentication)
+2. [System Utilities](#system-utilities)
+3. [File Operations (BuildProject)](#file-operations-buildproject)
+4. [Baker: Scanning](#baker-scanning)
+5. [Baker: Breadcrumbs](#baker-breadcrumbs)
+6. [Baker: Video Links](#baker-video-links)
+7. [Baker: Trello Cards](#baker-trello-cards)
+8. [Trello Boards](#trello-boards)
+9. [Sprout Video](#sprout-video)
+10. [DOCX Processing](#docx-processing)
+11. [AI Provider Validation](#ai-provider-validation)
+12. [RAG: Script Similarity Search](#rag-script-similarity-search)
+13. [RAG: Example Management](#rag-example-management)
+14. [Adobe Premiere Integration](#adobe-premiere-integration)
+15. [Premiere Pro Plugin Management](#premiere-pro-plugin-management)
 
 ---
 
@@ -121,13 +38,10 @@ Simple token-based authentication for user sessions.
 
 **Purpose:** Verify if a token is valid.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn check_auth(
-    token: String,
-    state: State<AuthState>,
-) -> String
+pub fn check_auth(token: String, state: State<AuthState>) -> String
 ```
 
 **Parameters:**
@@ -136,31 +50,22 @@ pub fn check_auth(
 | --------- | -------- | ------------------------------ |
 | `token`   | `String` | Authentication token to verify |
 
-**Returns:** `String` - `"authenticated"` or `"unauthorized"`
+**Returns:** `String` -- `"authenticated"` or `"unauthorized"`
 
-**Example Usage:**
+**Frontend usage** (`Auth/api.ts`):
 
 ```typescript
-const result = await invoke<string>('check_auth', { token: userToken })
-
-if (result === 'authenticated') {
-  // User is logged in
-} else {
-  // Redirect to login
-}
+const result = await invoke<string>('check_auth', { token })
 ```
 
 ### `add_token`
 
 **Purpose:** Add a token to the authenticated tokens list.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn add_token(
-    token: String,
-    state: State<AuthState>,
-)
+pub fn add_token(token: String, state: State<AuthState>)
 ```
 
 **Parameters:**
@@ -171,106 +76,1185 @@ pub fn add_token(
 
 **Returns:** `void`
 
-**Example Usage:**
+**Frontend usage** (`Auth/api.ts`):
 
 ```typescript
-// After successful login, add token
-await invoke('add_token', { token: newToken })
+await invoke('add_token', { token })
 ```
-
-**Note:** Current implementation is simplified. Production apps should use JWT verification with expiration.
 
 ---
 
-## RAG (Retrieval-Augmented Generation)
+## System Utilities
 
-Commands for managing script examples and vector similarity search.
+### `get_username`
 
-### `find_similar_examples`
+**Purpose:** Get the current OS username from environment variables.
 
-**Purpose:** Find script examples most similar to a given embedding vector.
-
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn find_similar_examples(
+pub fn get_username() -> String
+```
+
+**Parameters:** None
+
+**Returns:** `String` -- Username from `$USERNAME` or `$USER`, or `"Unknown User"` on failure.
+
+**Frontend usage** (`shared/ui/layout/nav-user.tsx`, `shared/hooks/useUsername.ts`):
+
+```typescript
+const name = await invoke<string>('get_username')
+```
+
+### `open_folder`
+
+**Purpose:** Open a folder in the system file explorer.
+
+**Rust signature:**
+
+```rust
+pub fn open_folder(path: String)
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description         |
+| --------- | -------- | ------------------- |
+| `path`    | `String` | Folder path to open |
+
+**Returns:** `void` (no Result -- panics on failure)
+
+**Platform behavior:** macOS: Finder, Windows: Explorer, Linux: xdg-open.
+
+**Frontend usage** (`Upload/api.ts`):
+
+```typescript
+await invoke('open_folder', { path })
+```
+
+### `graceful_restart`
+
+**Purpose:** Restart the application by spawning a new process and exiting the current one. No-op in debug/development mode.
+
+**Rust signature:**
+
+```rust
+pub async fn graceful_restart(_app_handle: AppHandle) -> Result<(), String>
+```
+
+**Parameters:** None (AppHandle auto-injected)
+
+**Returns:** `Result<(), String>`
+
+**Frontend usage** (`shared/hooks/useUpdateMutation.ts`):
+
+```typescript
+await invoke('graceful_restart')
+```
+
+### `open_resource_file`
+
+**Purpose:** Read a file from the bundled resource directory and return its raw bytes.
+
+**Rust signature:**
+
+```rust
+pub fn open_resource_file(handle: AppHandle, relative_file_path: &str) -> Result<Vec<u8>, String>
+```
+
+**Parameters:**
+
+| Parameter            | Type     | Description                                    |
+| -------------------- | -------- | ---------------------------------------------- |
+| `relative_file_path` | `String` | Path relative to the resource directory         |
+
+**Returns:** `Result<Vec<u8>, String>` -- Raw file bytes
+
+**Note:** Used internally by `copy_premiere_project`; not directly called from frontend api.ts files.
+
+### `show_confirmation_dialog`
+
+**Purpose:** Display a Yes/No dialog and open the specified folder if the user clicks Yes.
+
+**Rust signature:**
+
+```rust
+pub fn show_confirmation_dialog(
+    app: tauri::AppHandle,
+    message: String,
+    title: String,
+    destination: String,
+) -> Result<(), String>
+```
+
+**Parameters:**
+
+| Parameter     | Type     | Description                                 |
+| ------------- | -------- | ------------------------------------------- |
+| `message`     | `String` | Dialog message text                         |
+| `title`       | `String` | Dialog title                                |
+| `destination` | `String` | Folder path to open if user selects Yes     |
+
+**Returns:** `Result<(), String>`
+
+**Frontend usage** (`BuildProject/api.ts`, `Premiere/api.ts`):
+
+```typescript
+await invoke('show_confirmation_dialog', { message, title, destination })
+```
+
+---
+
+## File Operations (BuildProject)
+
+### `transfer_files_with_progress`
+
+**Purpose:** Transfer files from source to destination paths with real-time progress tracking, cancellation support, and stall detection. On macOS, uses Apple's `copyfile(3)` syscall for O(1) APFS clones and kernel-level copies.
+
+**Rust signature:**
+
+```rust
+pub async fn transfer_files_with_progress(
+    app: AppHandle,
+    registry: State<'_, OperationRegistry>,
+    request: TransferRequest,
+) -> Result<String, FileTransferError>
+```
+
+**Parameters:**
+
+| Parameter | Type              | Description                              |
+| --------- | ----------------- | ---------------------------------------- |
+| `request` | `TransferRequest` | Transfer request with file source/dest pairs |
+
+**TransferRequest structure:**
+
+```typescript
+interface TransferRequest {
+  files: Array<{
+    source: string       // Source file path
+    destination: string  // Destination file path
+  }>
+}
+```
+
+**Returns:** `Result<String, FileTransferError>` -- Operation ID (transfer runs in background)
+
+**Events emitted:**
+
+- `file-transfer-progress` -- Throttled progress updates (every 100ms)
+
+  ```typescript
+  interface TransferProgressEvent {
+    operationId: string
+    currentFile: string
+    filesCompleted: number
+    totalFiles: number
+    bytesTransferred: number
+    totalBytes: number
+    percentage: number  // 0-100
+  }
+  ```
+
+- `file-transfer-complete` -- Transfer finished (success, failure, or cancellation)
+
+  ```typescript
+  interface TransferComplete {
+    operationId: string
+    success: boolean
+    filesTransferred: number
+    error: string | null
+  }
+  ```
+
+**Frontend usage** (`build-project/stages/fileTransfer.ts`):
+
+```typescript
+const operationId = await invoke<string>('transfer_files_with_progress', {
+  request: { files: [{ source: '/path/to/file.mov', destination: '/dest/file.mov' }] }
+})
+```
+
+### `cancel_file_transfer`
+
+**Purpose:** Signal cancellation to an in-progress file transfer operation. The transfer stops at the next safe point and cleans up partial files.
+
+**Rust signature:**
+
+```rust
+pub async fn cancel_file_transfer(
+    registry: State<'_, OperationRegistry>,
+    operation_id: String,
+) -> Result<bool, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description                              |
+| -------------- | -------- | ---------------------------------------- |
+| `operation_id` | `String` | Operation ID returned by `transfer_files_with_progress` |
+
+**Returns:** `Result<bool, String>` -- `true` if cancellation was signalled, `false` if operation not found
+
+**Frontend usage** (`build-project/stages/fileTransfer.ts`):
+
+```typescript
+await invoke('cancel_file_transfer', { operationId })
+```
+
+---
+
+## Baker: Scanning
+
+### `baker_start_scan`
+
+**Purpose:** Start an asynchronous recursive directory scan to find BuildProject-compatible folders. Returns immediately with a scan ID; results arrive via events.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_start_scan(
+    root_path: String,
+    options: ScanOptions,
+    state: State<'_, ScanState>,
+    app_handle: AppHandle,
+) -> Result<String, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type          | Description                                |
+| ----------- | ------------- | ------------------------------------------ |
+| `root_path` | `String`      | Root directory to scan                     |
+| `options`   | `ScanOptions` | Scan configuration                         |
+
+**ScanOptions structure:**
+
+```typescript
+interface ScanOptions {
+  max_depth: number       // Minimum 1
+  include_hidden: boolean
+}
+```
+
+**Returns:** `Result<String, String>` -- Scan ID (UUID)
+
+**Events emitted:** `baker_scan_complete`, `baker_scan_error`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const scanId = await invoke<string>('baker_start_scan', { rootPath, options })
+```
+
+### `baker_get_scan_status`
+
+**Purpose:** Retrieve the result of a completed scan by its ID.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_get_scan_status(
+    scan_id: String,
+    state: State<'_, ScanState>,
+) -> Result<ScanResult, String>
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description |
+| --------- | -------- | ----------- |
+| `scan_id` | `String` | Scan UUID   |
+
+**Returns:** `Result<ScanResult, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const result = await invoke<ScanResult>('baker_get_scan_status', { scanId })
+```
+
+### `baker_cancel_scan`
+
+**Purpose:** Cancel a running scan by setting its end time.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_cancel_scan(scan_id: String, state: State<'_, ScanState>) -> Result<(), String>
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description |
+| --------- | -------- | ----------- |
+| `scan_id` | `String` | Scan UUID   |
+
+**Returns:** `Result<(), String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+await invoke('baker_cancel_scan', { scanId })
+```
+
+### `baker_validate_folder`
+
+**Purpose:** Validate whether a folder has the required BuildProject structure (Footage/, Graphics/, Renders/, Projects/, Scripts/) and check breadcrumbs state.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_validate_folder(folder_path: String) -> Result<ProjectFolder, String>
+```
+
+**Parameters:**
+
+| Parameter     | Type     | Description          |
+| ------------- | -------- | -------------------- |
+| `folder_path` | `String` | Path to folder       |
+
+**Returns:** `Result<ProjectFolder, String>`
+
+**ProjectFolder structure:**
+
+```typescript
+interface ProjectFolder {
+  path: string
+  name: string
+  is_valid: boolean
+  has_breadcrumbs: boolean
+  stale_breadcrumbs: boolean
+  last_scanned: string
+  camera_count: number
+  validation_errors: string[]
+  invalid_breadcrumbs: boolean
+}
+```
+
+**Note:** Not currently called from frontend api.ts files; used internally by the scan pipeline.
+
+---
+
+## Baker: Breadcrumbs
+
+### `baker_read_breadcrumbs`
+
+**Purpose:** Read and parse the breadcrumbs.json file from a project directory.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_read_breadcrumbs(
+    project_path: String,
+) -> Result<Option<BreadcrumbsFile>, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+
+**Returns:** `Result<Option<BreadcrumbsFile>, String>` -- `None` if no breadcrumbs.json exists
+
+**Frontend usage** (`Baker/api.ts`, `Trello/api.ts`):
+
+```typescript
+const breadcrumbs = await invoke<BreadcrumbsFile | null>('baker_read_breadcrumbs', { projectPath })
+```
+
+### `baker_read_raw_breadcrumbs`
+
+**Purpose:** Read the raw JSON string of breadcrumbs.json without parsing into a typed struct. Useful for debugging or when the file has drifted schema.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_read_raw_breadcrumbs(project_path: String) -> Result<Option<String>, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+
+**Returns:** `Result<Option<String>, String>` -- Raw JSON string or `None`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const raw = await invoke<string | null>('baker_read_raw_breadcrumbs', { projectPath })
+```
+
+### `baker_update_breadcrumbs`
+
+**Purpose:** Batch update or create breadcrumbs.json files for multiple project directories. Handles schema-drifted files by salvaging Trello cards and video links.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_update_breadcrumbs(
+    project_paths: Vec<String>,
+    create_missing: bool,
+    backup_originals: bool,
+) -> Result<BatchUpdateResult, String>
+```
+
+**Parameters:**
+
+| Parameter          | Type           | Description                              |
+| ------------------ | -------------- | ---------------------------------------- |
+| `project_paths`    | `Vec<String>`  | List of project directories to update    |
+| `create_missing`   | `bool`         | Create breadcrumbs.json if missing       |
+| `backup_originals` | `bool`         | Backup existing files as .bak before update |
+
+**Returns:** `Result<BatchUpdateResult, String>`
+
+**BatchUpdateResult structure:**
+
+```typescript
+interface BatchUpdateResult {
+  successful: string[]
+  failed: Array<{ path: string; error: string }>
+  created: string[]
+  updated: string[]
+}
+```
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const result = await invoke<BatchUpdateResult>('baker_update_breadcrumbs', {
+  projectPaths,
+  createMissing,
+  backupOriginals
+})
+```
+
+### `baker_scan_current_files`
+
+**Purpose:** Scan camera files (Footage/Camera */) in a project directory and return file information.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_scan_current_files(project_path: String) -> Result<Vec<FileInfo>, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+
+**Returns:** `Result<Vec<FileInfo>, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const files = await invoke<FileInfo[]>('baker_scan_current_files', { projectPath })
+```
+
+### `get_folder_size`
+
+**Purpose:** Calculate the total size of a directory in bytes.
+
+**Rust signature:**
+
+```rust
+pub async fn get_folder_size(folder_path: String) -> Result<u64, String>
+```
+
+**Parameters:**
+
+| Parameter     | Type     | Description    |
+| ------------- | -------- | -------------- |
+| `folder_path` | `String` | Directory path |
+
+**Returns:** `Result<u64, String>` -- Size in bytes
+
+**Frontend usage** (`Baker/api.ts`, `BuildProject/api.ts`):
+
+```typescript
+const size = await invoke<number>('get_folder_size', { folderPath })
+```
+
+---
+
+## Baker: Video Links
+
+### `baker_get_video_links`
+
+**Purpose:** Get all video links from a project's breadcrumbs.json.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_get_video_links(project_path: String) -> Result<Vec<VideoLink>, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+
+**Returns:** `Result<Vec<VideoLink>, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const links = await invoke<VideoLink[]>('baker_get_video_links', { projectPath })
+```
+
+### `baker_associate_video_link`
+
+**Purpose:** Add a video link to a project's breadcrumbs. Maximum 20 videos per project.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_associate_video_link(
+    project_path: String,
+    video_link: VideoLink,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type        | Description           |
+| -------------- | ----------- | --------------------- |
+| `project_path` | `String`    | Project directory path |
+| `video_link`   | `VideoLink` | Video link to add     |
+
+**Returns:** `Result<BreadcrumbsFile, String>` -- Updated breadcrumbs
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const updated = await invoke<BreadcrumbsFile>('baker_associate_video_link', {
+  projectPath,
+  videoLink
+})
+```
+
+### `baker_remove_video_link`
+
+**Purpose:** Remove a video link by its index in the array.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_remove_video_link(
+    project_path: String,
+    video_index: usize,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+| `video_index`  | `usize`  | Zero-based index      |
+
+**Returns:** `Result<BreadcrumbsFile, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const updated = await invoke<BreadcrumbsFile>('baker_remove_video_link', {
+  projectPath,
+  videoIndex
+})
+```
+
+### `baker_update_video_link`
+
+**Purpose:** Replace a video link at a specific index with updated data.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_update_video_link(
+    project_path: String,
+    video_index: usize,
+    updated_link: VideoLink,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type        | Description             |
+| -------------- | ----------- | ----------------------- |
+| `project_path` | `String`    | Project directory path   |
+| `video_index`  | `usize`     | Zero-based index         |
+| `updated_link` | `VideoLink` | Replacement video link   |
+
+**Returns:** `Result<BreadcrumbsFile, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const updated = await invoke<BreadcrumbsFile>('baker_update_video_link', {
+  projectPath,
+  videoIndex,
+  updatedLink
+})
+```
+
+### `baker_reorder_video_links`
+
+**Purpose:** Move a video link from one position to another.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_reorder_video_links(
+    project_path: String,
+    from_index: usize,
+    to_index: usize,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+| `from_index`   | `usize`  | Source position        |
+| `to_index`     | `usize`  | Target position        |
+
+**Returns:** `Result<BreadcrumbsFile, String>`
+
+**Frontend usage** (`Baker/api.ts`):
+
+```typescript
+const updated = await invoke<BreadcrumbsFile>('baker_reorder_video_links', {
+  projectPath,
+  fromIndex,
+  toIndex
+})
+```
+
+---
+
+## Baker: Trello Cards
+
+### `baker_get_trello_cards`
+
+**Purpose:** Get all Trello cards associated with a project. Handles legacy migration from single `trelloCardUrl` to `trelloCards` array.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_get_trello_cards(project_path: String) -> Result<Vec<TrelloCard>, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+
+**Returns:** `Result<Vec<TrelloCard>, String>`
+
+**Frontend usage** (`Trello/api.ts`):
+
+```typescript
+const cards = await invoke('baker_get_trello_cards', { projectPath })
+```
+
+### `baker_associate_trello_card`
+
+**Purpose:** Associate a Trello card with a project. Maximum 10 cards per project. Prevents duplicate card IDs.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_associate_trello_card(
+    project_path: String,
+    trello_card: TrelloCard,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type         | Description           |
+| -------------- | ------------ | --------------------- |
+| `project_path` | `String`     | Project directory path |
+| `trello_card`  | `TrelloCard` | Card to associate     |
+
+**Returns:** `Result<BreadcrumbsFile, String>`
+
+**Frontend usage** (`Trello/api.ts`):
+
+```typescript
+const updated = await invoke('baker_associate_trello_card', { projectPath, trelloCard })
+```
+
+### `baker_remove_trello_card`
+
+**Purpose:** Remove a Trello card association by index.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_remove_trello_card(
+    project_path: String,
+    card_index: usize,
+) -> Result<BreadcrumbsFile, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type     | Description           |
+| -------------- | -------- | --------------------- |
+| `project_path` | `String` | Project directory path |
+| `card_index`   | `usize`  | Zero-based index      |
+
+**Returns:** `Result<BreadcrumbsFile, String>`
+
+**Frontend usage** (`Trello/api.ts`):
+
+```typescript
+const updated = await invoke('baker_remove_trello_card', { projectPath, cardIndex })
+```
+
+### `baker_fetch_trello_card_details`
+
+**Purpose:** Fetch card details (title, board name) from the Trello REST API given a card URL. Also resolves the board name via a second API call.
+
+**Rust signature:**
+
+```rust
+pub async fn baker_fetch_trello_card_details(
+    card_url: String,
+    api_key: String,
+    api_token: String,
+) -> Result<TrelloCard, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type     | Description          |
+| ----------- | -------- | -------------------- |
+| `card_url`  | `String` | Full Trello card URL |
+| `api_key`   | `String` | Trello API key       |
+| `api_token` | `String` | Trello API token     |
+
+**Returns:** `Result<TrelloCard, String>`
+
+**TrelloCard structure:**
+
+```typescript
+interface TrelloCard {
+  url: string
+  cardId: string
+  title: string
+  boardName: string | null
+  lastFetched: string | null
+}
+```
+
+**Frontend usage** (`Trello/api.ts`):
+
+```typescript
+const card = await invoke('baker_fetch_trello_card_details', {
+  cardUrl,
+  apiKey,
+  apiToken
+})
+```
+
+---
+
+## Trello Boards
+
+### `fetch_trello_boards`
+
+**Purpose:** Fetch all Trello boards the authenticated user is a member of.
+
+**Rust signature:**
+
+```rust
+pub async fn fetch_trello_boards(
+    api_key: String,
+    api_token: String,
+) -> Result<Vec<TrelloBoard>, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type     | Description      |
+| ----------- | -------- | ---------------- |
+| `api_key`   | `String` | Trello API key   |
+| `api_token` | `String` | Trello API token |
+
+**Returns:** `Result<Vec<TrelloBoard>, String>`
+
+**Frontend usage** (`Trello/api.ts`):
+
+```typescript
+const boards = await invoke<TrelloBoard[]>('fetch_trello_boards', { apiKey, apiToken })
+```
+
+---
+
+## Sprout Video
+
+### `get_folders`
+
+**Purpose:** List folders from the Sprout Video API.
+
+**Rust signature:**
+
+```rust
+pub async fn get_folders(
+    api_key: String,
+    folder_id: Option<String>,
+) -> Result<serde_json::Value, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type             | Description                          |
+| ----------- | ---------------- | ------------------------------------ |
+| `api_key`   | `String`         | Sprout Video API key                 |
+| `folder_id` | `Option<String>` | Optional parent folder ID to filter  |
+
+**Returns:** `Result<Value, String>` -- Raw JSON response from Sprout Video API
+
+**Frontend usage** (`Upload/api.ts`):
+
+```typescript
+const folders = await invoke<GetFoldersResponse>('get_folders', {
+  apiKey,
+  parent_id: parentId
+})
+```
+
+### `upload_video`
+
+**Purpose:** Upload a video file to Sprout Video with progress tracking. Runs asynchronously in the background; emits progress events.
+
+**Rust signature:**
+
+```rust
+pub fn upload_video(
+    app_handle: AppHandle,
+    file_path: String,
+    api_key: String,
+    folder_id: Option<String>,
+)
+```
+
+**Parameters:**
+
+| Parameter   | Type             | Description                        |
+| ----------- | ---------------- | ---------------------------------- |
+| `file_path` | `String`         | Full path to video file            |
+| `api_key`   | `String`         | Sprout Video API key               |
+| `folder_id` | `Option<String>` | Optional destination folder ID     |
+
+**Returns:** `void` (returns immediately; upload runs in background)
+
+**Events emitted:**
+
+- `upload_progress` -- Percentage complete (0-100)
+- `upload_complete` -- JSON response from Sprout Video API
+- `upload_error` -- Error message string
+
+**Frontend usage** (`Upload/api.ts`):
+
+```typescript
+await invoke('upload_video', { filePath, apiKey, folderId })
+```
+
+### `fetch_sprout_video_details`
+
+**Purpose:** Fetch video metadata from the Sprout Video API given a video ID.
+
+**Rust signature:**
+
+```rust
+pub async fn fetch_sprout_video_details(
+    video_id: String,
+    api_key: String,
+) -> Result<SproutVideoDetails, String>
+```
+
+**Parameters:**
+
+| Parameter  | Type     | Description            |
+| ---------- | -------- | ---------------------- |
+| `video_id` | `String` | Sprout Video video ID  |
+| `api_key`  | `String` | Sprout Video API key   |
+
+**Returns:** `Result<SproutVideoDetails, String>`
+
+**Frontend usage** (`Upload/api.ts`):
+
+```typescript
+const details = await invoke<SproutVideoDetails>('fetch_sprout_video_details', {
+  videoId,
+  apiKey
+})
+```
+
+---
+
+## DOCX Processing
+
+### `parse_docx_file`
+
+**Purpose:** Validate a .docx file (existence, extension, size limit of 1GB) and return an empty `ParseResult` shell. Actual parsing is done in the frontend via mammoth.js.
+
+**Rust signature:**
+
+```rust
+pub fn parse_docx_file(file_path: String) -> Result<ParseResult, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type     | Description           |
+| ----------- | -------- | --------------------- |
+| `file_path` | `String` | Path to .docx file    |
+
+**Returns:** `Result<ParseResult, String>`
+
+**ParseResult structure:**
+
+```typescript
+interface ParseResult {
+  text_content: string
+  html_content: string
+  formatting_metadata: {
+    bold_ranges: Array<{ start: number; end: number; text: string }>
+    italic_ranges: Array<{ start: number; end: number; text: string }>
+    underline_ranges: Array<{ start: number; end: number; text: string }>
+    headings: Array<{ level: number; text: string; position: number }>
+    lists: Array<{ item_type: string; text: string; level: number; position: number }>
+    paragraphs: Array<{ text: string; start: number; end: number }>
+  }
+}
+```
+
+**Note:** Not currently invoked from any frontend api.ts file. Validation-only backend command.
+
+### `generate_docx_file`
+
+**Purpose:** Placeholder for future backend .docx generation. Currently returns the suggested download path. Actual generation is done in the frontend via the `docx` npm package.
+
+**Rust signature:**
+
+```rust
+pub fn generate_docx_file(
+    _content: String,
+    default_filename: String,
+) -> Result<DownloadPath, String>
+```
+
+**Parameters:**
+
+| Parameter          | Type     | Description                  |
+| ------------------ | -------- | ---------------------------- |
+| `content`          | `String` | Content (currently unused)   |
+| `default_filename` | `String` | Suggested output filename    |
+
+**Returns:** `Result<DownloadPath, String>` where `DownloadPath = { path: String }`
+
+**Note:** Not currently invoked from any frontend api.ts file.
+
+### `validate_docx_file`
+
+**Purpose:** Validate a .docx file's existence, extension, readability, and size (1GB limit).
+
+**Rust signature:**
+
+```rust
+pub fn validate_docx_file(file_path: String) -> Result<bool, String>
+```
+
+**Parameters:**
+
+| Parameter   | Type     | Description        |
+| ----------- | -------- | ------------------ |
+| `file_path` | `String` | Path to .docx file |
+
+**Returns:** `Result<bool, String>` -- `true` if valid
+
+**Note:** Not currently invoked from any frontend api.ts file.
+
+---
+
+## AI Provider Validation
+
+### `validate_provider_connection`
+
+**Purpose:** Generic HTTP health check for AI provider endpoints. Tests connectivity and measures latency.
+
+**Rust signature:**
+
+```rust
+pub async fn validate_provider_connection(
+    provider_url: String,
+    timeout_ms: Option<u64>,
+) -> Result<ConnectionStatus, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type             | Description                                |
+| -------------- | ---------------- | ------------------------------------------ |
+| `provider_url` | `String`         | Provider health endpoint URL               |
+| `timeout_ms`   | `Option<u64>`    | Connection timeout in ms (default: 5000)   |
+
+**Returns:** `Result<ConnectionStatus, String>`
+
+**ConnectionStatus structure:**
+
+```typescript
+interface ConnectionStatus {
+  connected: boolean
+  message: string | null
+  latency_ms: number | null
+}
+```
+
+**Note:** Not currently invoked from frontend api.ts files. The frontend uses the `providerRegistry` adapter pattern in `Settings/api.ts` instead.
+
+### `validate_provider_with_auth`
+
+**Purpose:** Test AI provider availability with a custom Authorization header.
+
+**Rust signature:**
+
+```rust
+pub async fn validate_provider_with_auth(
+    provider_url: String,
+    auth_header: String,
+    timeout_ms: Option<u64>,
+) -> Result<ConnectionStatus, String>
+```
+
+**Parameters:**
+
+| Parameter      | Type             | Description                                |
+| -------------- | ---------------- | ------------------------------------------ |
+| `provider_url` | `String`         | Provider endpoint URL                      |
+| `auth_header`  | `String`         | Value for Authorization header             |
+| `timeout_ms`   | `Option<u64>`    | Connection timeout in ms (default: 5000)   |
+
+**Returns:** `Result<ConnectionStatus, String>`
+
+**Note:** Not currently invoked from frontend api.ts files.
+
+---
+
+## RAG: Script Similarity Search
+
+Commands for vector similarity search over script formatting examples.
+
+### `search_similar_scripts`
+
+**Purpose:** Find script examples most similar to a given embedding vector using cosine similarity. Filters by minimum quality score (>= 4).
+
+**Rust signature:**
+
+```rust
+pub async fn search_similar_scripts(
     app: tauri::AppHandle,
     query_embedding: Vec<f32>,
     top_k: usize,
+    min_similarity: Option<f32>,
 ) -> Result<Vec<SimilarExample>, String>
 ```
 
 **Parameters:**
 
-| Parameter         | Type       | Description                                 |
-| ----------------- | ---------- | ------------------------------------------- |
-| `query_embedding` | `Vec<f32>` | Vector embedding (typically 768 dimensions) |
-| `top_k`           | `usize`    | Number of results to return (e.g., 3)       |
+| Parameter         | Type            | Description                                      |
+| ----------------- | --------------- | ------------------------------------------------ |
+| `query_embedding` | `Vec<f32>`      | Vector embedding (384 or 768 dimensions)         |
+| `top_k`           | `usize`         | Maximum results to return                        |
+| `min_similarity`  | `Option<f32>`   | Minimum cosine similarity threshold (0.0-1.0)    |
 
 **Returns:** `Result<Vec<SimilarExample>, String>`
 
-**SimilarExample Structure:**
+**SimilarExample structure:**
 
 ```typescript
 interface SimilarExample {
-  id: string // Unique example ID
-  title: string // Example title (e.g., "Educational Lecture")
-  category: string // Category (e.g., "educational", "business")
-  beforeText: string // Raw script text
-  afterText: string // Formatted script text
-  similarity: number // Cosine similarity score (0-1)
+  id: string
+  title: string
+  category: string
+  before_text: string  // Raw script text (snake_case from Rust)
+  after_text: string   // Formatted script text
+  similarity: number   // Cosine similarity score (0-1)
 }
 ```
 
-**Example Usage:**
+**Frontend usage** (`AITools/api.ts`):
 
 ```typescript
-// 1. First, generate embedding for user's script
-const embedding = await invoke<number[]>('embed_text_ollama', {
-  text: userScript,
-  model: 'nomic-embed-text'
-})
-
-// 2. Find similar examples
-const examples = await invoke<SimilarExample[]>('find_similar_examples', {
+const examples = await invoke<SimilarExample[]>('search_similar_scripts', {
   queryEmbedding: embedding,
-  topK: 3
+  topK: 3,
+  minSimilarity: 0.5
 })
-
-// 3. Use examples to construct LLM prompt
-const prompt = `
-Format this script like these examples:
-
-${examples
-  .map(
-    ex => `
-Example: ${ex.title}
-Before: ${ex.beforeText}
-After: ${ex.afterText}
-`
-  )
-  .join('\n')}
-
-Now format this script:
-${userScript}
-`
 ```
 
-**Implementation Details:**
+### `get_example_by_id`
 
-- Uses cosine similarity for vector comparison
-- SQLite performs linear scan (fast for <1000 examples)
-- Results sorted by similarity (descending)
-- Database located in `app_data_dir()/embeddings/examples.db`
+**Purpose:** Retrieve a single RAG example by its ID.
+
+**Rust signature:**
+
+```rust
+pub async fn get_example_by_id(app: tauri::AppHandle, id: String) -> Result<SimilarExample, String>
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description   |
+| --------- | -------- | ------------- |
+| `id`      | `String` | Example UUID  |
+
+**Returns:** `Result<SimilarExample, String>` -- similarity is always 1.0
+
+**Note:** Not currently invoked from frontend api.ts files.
+
+### `get_all_examples`
+
+**Purpose:** Retrieve all RAG examples without full metadata. Ordered by quality score descending, then title ascending.
+
+**Rust signature:**
+
+```rust
+pub async fn get_all_examples(app: tauri::AppHandle) -> Result<Vec<SimilarExample>, String>
+```
+
+**Parameters:** None
+
+**Returns:** `Result<Vec<SimilarExample>, String>` -- similarity is always 1.0
+
+**Note:** Not currently invoked from frontend api.ts files. Use `get_all_examples_with_metadata` instead.
+
+---
+
+## RAG: Example Management
 
 ### `get_all_examples_with_metadata`
 
-**Purpose:** Retrieve all examples with full metadata for management UI.
+**Purpose:** Retrieve all examples with full metadata for the management UI.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn get_all_examples_with_metadata(
+pub async fn get_all_examples_with_metadata(
     app: tauri::AppHandle,
 ) -> Result<Vec<ExampleWithMetadata>, String>
 ```
@@ -279,41 +1263,37 @@ pub fn get_all_examples_with_metadata(
 
 **Returns:** `Result<Vec<ExampleWithMetadata>, String>`
 
-**ExampleWithMetadata Structure:**
+**ExampleWithMetadata structure:**
 
 ```typescript
 interface ExampleWithMetadata {
   id: string
   title: string
   category: string
-  beforeText: string
+  beforeText: string       // camelCase (serde rename_all)
   afterText: string
   tags: string[]
   wordCount: number | null
   qualityScore: number | null
-  source: 'bundled' | 'user-uploaded'
-  createdAt: string // ISO 8601 timestamp
+  source: string           // "bundled" or "user-uploaded"
+  createdAt: string
 }
 ```
 
-**Example Usage:**
+**Frontend usage** (`AITools/api.ts`):
 
 ```typescript
 const examples = await invoke<ExampleWithMetadata[]>('get_all_examples_with_metadata')
-
-// Filter by source
-const bundled = examples.filter(ex => ex.source === 'bundled')
-const userUploaded = examples.filter(ex => ex.source === 'user-uploaded')
 ```
 
 ### `upload_example`
 
-**Purpose:** Upload a new user script example to the database.
+**Purpose:** Upload a new user script example to the RAG database.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn upload_example(
+pub async fn upload_example(
     app: tauri::AppHandle,
     request: UploadExampleRequest,
 ) -> Result<String, String>
@@ -325,73 +1305,38 @@ pub fn upload_example(
 | --------- | ---------------------- | ---------------------------------------- |
 | `request` | `UploadExampleRequest` | Upload payload with content and metadata |
 
-**UploadExampleRequest Structure:**
+**UploadExampleRequest structure:**
 
 ```typescript
 interface UploadExampleRequest {
-  beforeContent: string // Raw script
-  afterContent: string // Formatted script
+  beforeContent: string  // Raw script (min 50, max 100,000 chars)
+  afterContent: string   // Formatted script (min 50, max 100,000 chars)
   metadata: {
-    title: string
-    category: string
+    title: string              // 1-200 chars, no newlines
+    category: string           // educational | business | narrative | interview | documentary | user-custom
     tags?: string[]
-    qualityScore?: number // 1-10
+    qualityScore?: number
   }
-  embedding: number[] // 768-dimensional vector
+  embedding: number[]    // 384 or 768 dimensions
 }
 ```
 
-**Returns:** `Result<String, String>` - New example ID (UUID)
+**Returns:** `Result<String, String>` -- New example ID (UUID)
 
-**Example Usage:**
+**Frontend usage** (`AITools/api.ts`):
 
 ```typescript
-// 1. Generate embedding
-const embedding = await invoke<number[]>('embed_text_ollama', {
-  text: beforeContent,
-  model: 'nomic-embed-text'
-})
-
-// 2. Upload example
-const exampleId = await invoke<string>('upload_example', {
-  request: {
-    beforeContent: rawScript,
-    afterContent: formattedScript,
-    metadata: {
-      title: 'My Conference Script',
-      category: 'business',
-      tags: ['conference', 'keynote'],
-      qualityScore: 8
-    },
-    embedding
-  }
-})
-
-console.log('Uploaded example:', exampleId)
+const exampleId = await invoke<string>('upload_example', { request })
 ```
-
-**Validation Rules:**
-
-- `beforeContent` and `afterContent`: 10-100,000 characters
-- `title`: 1-200 characters
-- `category`: Must be valid category (educational, business, narrative, etc.)
-- `embedding`: Must be 768 dimensions
-
-**Error Responses:**
-
-- `"Invalid text content length"` - Text too short/long
-- `"Invalid category"` - Category not recognized
-- `"Invalid embedding dimensions"` - Embedding not 768-dimensional
-- `"Database error: ..."` - SQLite error
 
 ### `replace_example`
 
-**Purpose:** Replace an existing user-uploaded example.
+**Purpose:** Replace the content and embedding of an existing user-uploaded example. Cannot replace bundled examples.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn replace_example(
+pub async fn replace_example(
     app: tauri::AppHandle,
     id: String,
     request: ReplaceExampleRequest,
@@ -405,7 +1350,7 @@ pub fn replace_example(
 | `id`      | `String`                | Example ID to replace     |
 | `request` | `ReplaceExampleRequest` | New content and embedding |
 
-**ReplaceExampleRequest Structure:**
+**ReplaceExampleRequest structure:**
 
 ```typescript
 interface ReplaceExampleRequest {
@@ -417,35 +1362,20 @@ interface ReplaceExampleRequest {
 
 **Returns:** `Result<(), String>`
 
-**Example Usage:**
+**Frontend usage** (`AITools/api.ts`):
 
 ```typescript
-await invoke('replace_example', {
-  id: exampleId,
-  request: {
-    beforeContent: updatedRawScript,
-    afterContent: updatedFormattedScript,
-    embedding: newEmbedding
-  }
-})
+await invoke('replace_example', { id, request })
 ```
-
-**Security:**
-
-- Can only replace user-uploaded examples (not bundled)
-- Returns error if trying to replace bundled example
 
 ### `delete_example`
 
-**Purpose:** Delete a user-uploaded example.
+**Purpose:** Delete a user-uploaded example. Cannot delete bundled examples.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn delete_example(
-    app: tauri::AppHandle,
-    id: String,
-) -> Result<(), String>
+pub async fn delete_example(app: tauri::AppHandle, id: String) -> Result<(), String>
 ```
 
 **Parameters:**
@@ -456,324 +1386,216 @@ pub fn delete_example(
 
 **Returns:** `Result<(), String>`
 
-**Example Usage:**
+**Frontend usage** (`AITools/api.ts`):
 
 ```typescript
-await invoke('delete_example', { id: exampleId })
+await invoke('delete_example', { id })
 ```
-
-**Security:**
-
-- Can only delete user-uploaded examples (not bundled)
-- Returns error if trying to delete bundled example
 
 ---
 
 ## Adobe Premiere Integration
 
-### `copy_premiere_template`
+### `copy_premiere_project`
 
-**Purpose:** Copy Premiere Pro template to project folder with proper file sync.
+**Purpose:** Copy the bundled Premiere Pro 4K template to a project's destination folder with a custom filename. Includes sync-all with filesystem tolerance for network shares (ENOTSUP is non-fatal).
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn copy_premiere_template(
-    destination_path: String,
+pub fn copy_premiere_project(
+    handle: AppHandle,
+    destination_folder: String,
+    new_title: String,
 ) -> Result<(), String>
 ```
 
 **Parameters:**
 
-| Parameter          | Type     | Description                              |
-| ------------------ | -------- | ---------------------------------------- |
-| `destination_path` | `String` | Full path including filename (`.prproj`) |
+| Parameter            | Type     | Description                                   |
+| -------------------- | -------- | --------------------------------------------- |
+| `destination_folder` | `String` | Destination folder path                       |
+| `new_title`          | `String` | Project name (without .prproj extension)      |
 
 **Returns:** `Result<(), String>`
 
-**Example Usage:**
+**Frontend usage** (`BuildProject/api.ts`, `Premiere/api.ts`):
 
 ```typescript
-await invoke('copy_premiere_template', {
-  destinationPath: '/path/to/project/Projects/My Project.prproj'
-})
+await invoke('copy_premiere_project', { destinationFolder, newTitle })
 ```
 
-**Implementation Details:**
+**Implementation details:**
 
-- Copies `Premiere 4K Template 2025.prproj` from bundled assets
-- Uses `file.sync_all()` to flush OS buffers (prevents corruption)
-- Template supports multi-camera projects
-- Fixed corruption bug in v0.9.1
-
-**Error Handling:**
-
-- Returns error if template file not found in assets
-- Returns error if destination folder doesn't exist
-- Returns error if file write fails
+- Reads template via `open_resource_file` from `resources/Premiere 4K Template 2025.prproj`
+- Creates destination folder if it doesn't exist
+- Returns error if file with the same name already exists
+- Uses `file.sync_all()` to flush OS buffers, with ENOTSUP tolerance for network shares
 
 ---
 
-## DOCX Processing
+## Premiere Pro Plugin Management
 
-Commands for parsing and generating Word documents.
+Commands for installing and managing CEP (Common Extensibility Platform) extensions.
 
-### `parse_docx`
+### `get_available_plugins`
 
-**Purpose:** Extract plain text from a Word document (.docx).
+**Purpose:** Return the hardcoded list of bundled CEP plugins with install status.
 
-**Signature:**
-
-```rust
-pub fn parse_docx(
-    file_data: Vec<u8>,
-) -> Result<String, String>
-```
-
-**Parameters:**
-
-| Parameter   | Type      | Description             |
-| ----------- | --------- | ----------------------- |
-| `file_data` | `Vec<u8>` | Raw bytes of .docx file |
-
-**Returns:** `Result<String, String>` - Plain text content
-
-**Example Usage:**
-
-```typescript
-// 1. Read file as ArrayBuffer
-const file = await open({ accept: ['.docx'] })
-const contents = await file.read()
-
-// 2. Convert to array
-const fileData = Array.from(new Uint8Array(contents))
-
-// 3. Parse
-const text = await invoke<string>('parse_docx', { fileData })
-```
-
-**Implementation Details:**
-
-- Uses `mammoth` crate for parsing
-- Strips all formatting, images, tables (plain text only)
-- Preserves paragraph breaks
-- Maximum file size: ~100 MB (practical limit)
-
-**Error Handling:**
-
-- Returns error if file is corrupted
-- Returns error if file is not valid .docx format
-
----
-
-## Sprout Video
-
-Commands for Sprout Video API integration.
-
-### `upload_to_sprout`
-
-**Purpose:** Upload video file to Sprout Video.
-
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn upload_to_sprout(
-    file_path: String,
-    api_key: String,
-    title: String,
-) -> Result<SproutVideoResponse, String>
+pub async fn get_available_plugins() -> Result<Vec<PluginInfo>, String>
 ```
 
-**Parameters:**
+**Parameters:** None
 
-| Parameter   | Type     | Description             |
-| ----------- | -------- | ----------------------- |
-| `file_path` | `String` | Full path to video file |
-| `api_key`   | `String` | Sprout Video API key    |
-| `title`     | `String` | Video title             |
+**Returns:** `Result<Vec<PluginInfo>, String>`
 
-**Returns:** `Result<SproutVideoResponse, String>`
-
-**SproutVideoResponse Structure:**
+**PluginInfo structure:**
 
 ```typescript
-interface SproutVideoResponse {
-  videoId: string
-  embedCode: string
-  thumbnailUrl: string
+interface PluginInfo {
+  name: string
+  displayName: string
+  version: string
+  filename: string
+  size: number
+  installed: boolean
+  description: string
+  features: string[]
+  icon: string
 }
 ```
 
-**Example Usage:**
+**Frontend usage** (`Premiere/api.ts`):
 
 ```typescript
-const response = await invoke<SproutVideoResponse>('upload_to_sprout', {
-  filePath: '/path/to/video.mp4',
-  apiKey: settings.sproutApiKey,
-  title: 'My Video'
-})
-
-// Save to breadcrumbs
-breadcrumbs.videoLinks.push({
-  video_id: response.videoId,
-  embed_code: response.embedCode,
-  thumbnailUrl: response.thumbnailUrl
-})
+const plugins = await invoke<PluginInfo[]>('get_available_plugins')
 ```
 
-**Note:** Command implementation varies - check source code for exact API.
+### `install_plugin`
 
----
+**Purpose:** Install a CEP plugin by extracting its bundled ZXP file to the user-level CEP extensions directory. Backs up existing installations and removes macOS quarantine attributes.
 
-## AI Provider Management
-
-### `list_ollama_models`
-
-**Purpose:** List available Ollama models.
-
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn list_ollama_models(
-    base_url: String,
-) -> Result<Vec<OllamaModel>, String>
+pub async fn install_plugin(
+    app_handle: AppHandle,
+    plugin_filename: String,
+    plugin_name: String,
+) -> Result<InstallResult, String>
 ```
 
 **Parameters:**
 
-| Parameter  | Type     | Description                                        |
-| ---------- | -------- | -------------------------------------------------- |
-| `base_url` | `String` | Ollama server URL (e.g., `http://localhost:11434`) |
+| Parameter         | Type     | Description                                    |
+| ----------------- | -------- | ---------------------------------------------- |
+| `plugin_filename` | `String` | ZXP filename in assets/plugins/ directory      |
+| `plugin_name`     | `String` | Plugin directory name (e.g., "BreadcrumbsPremiere") |
 
-**Returns:** `Result<Vec<OllamaModel>, String>`
+**Returns:** `Result<InstallResult, String>`
 
-**OllamaModel Structure:**
+**InstallResult structure:**
 
 ```typescript
-interface OllamaModel {
-  name: string // e.g., "llama3.1:latest"
-  modifiedAt: string // ISO timestamp
-  size: number // Bytes
+interface InstallResult {
+  success: boolean
+  message: string
+  pluginName: string
+  installedPath: string
 }
 ```
 
-**Example Usage:**
+**Frontend usage** (`Premiere/api.ts`):
 
 ```typescript
-const models = await invoke<OllamaModel[]>('list_ollama_models', {
-  baseUrl: 'http://localhost:11434'
+const result = await invoke<InstallResult>('install_plugin', {
+  pluginFilename,
+  pluginName
 })
-
-console.log(
-  'Available models:',
-  models.map(m => m.name)
-)
 ```
 
-### `embed_text_ollama`
+### `check_plugin_installed`
 
-**Purpose:** Generate embedding vector for text using Ollama.
+**Purpose:** Check if a specific CEP plugin is installed by verifying its directory and CSXS/manifest.xml exist.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn embed_text_ollama(
-    text: String,
-    model: String,
-    base_url: String,
-) -> Result<Vec<f32>, String>
+pub async fn check_plugin_installed(plugin_name: String) -> Result<bool, String>
 ```
 
 **Parameters:**
 
-| Parameter  | Type     | Description                                     |
-| ---------- | -------- | ----------------------------------------------- |
-| `text`     | `String` | Text to embed                                   |
-| `model`    | `String` | Embedding model name (e.g., `nomic-embed-text`) |
-| `base_url` | `String` | Ollama server URL                               |
+| Parameter     | Type     | Description        |
+| ------------- | -------- | ------------------ |
+| `plugin_name` | `String` | Plugin folder name |
 
-**Returns:** `Result<Vec<f32>, String>` - 768-dimensional vector
+**Returns:** `Result<bool, String>`
 
-**Example Usage:**
+**Note:** Not currently invoked from frontend api.ts files; used internally by `get_available_plugins`.
 
-```typescript
-const embedding = await invoke<number[]>('embed_text_ollama', {
-  text: 'This is my script to format...',
-  model: 'nomic-embed-text',
-  baseUrl: 'http://localhost:11434'
-})
+### `get_cep_directory`
 
-console.log('Embedding dimensions:', embedding.length) // 768
-```
+**Purpose:** Get the CEP extensions directory path for the current platform.
 
-**Recommended Models:**
-
-- `nomic-embed-text` - Fast, good quality (768 dimensions)
-- `all-minilm` - Smaller, faster (384 dimensions - requires code changes)
-
----
-
-## System Utilities
-
-### `get_app_version`
-
-**Purpose:** Get current app version.
-
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn get_app_version() -> String
+pub async fn get_cep_directory() -> Result<String, String>
 ```
 
-**Returns:** `String` - Version from `Cargo.toml` (e.g., `"0.9.3"`)
+**Parameters:** None
 
-**Example Usage:**
+**Returns:** `Result<String, String>` -- Directory path
 
-```typescript
-const version = await invoke<string>('get_app_version')
-console.log('Bucket version:', version)
-```
+**Note:** Not currently invoked from frontend api.ts files.
 
-### `open_folder`
+### `enable_cep_debug_mode`
 
-**Purpose:** Open a folder in the system file explorer.
+**Purpose:** Enable CEP debug mode on macOS (sets `PlayerDebugMode` to `1` for CSXS.11). Allows self-signed extensions to load without certificate warnings. No-op on non-macOS platforms.
 
-**Signature:**
+**Rust signature:**
 
 ```rust
-pub fn open_folder(path: String) -> Result<(), String>
+pub async fn enable_cep_debug_mode() -> Result<(), String>
 ```
 
-**Parameters:**
-
-| Parameter | Type     | Description         |
-| --------- | -------- | ------------------- |
-| `path`    | `String` | Folder path to open |
+**Parameters:** None
 
 **Returns:** `Result<(), String>`
 
-**Example Usage:**
+**Note:** Not currently invoked from frontend api.ts files.
 
-```typescript
-// Open project folder after creation
-await invoke('open_folder', {
-  path: '/path/to/project'
-})
+### `open_cep_folder`
+
+**Purpose:** Open the CEP extensions directory in the system file manager. Creates the directory if it doesn't exist.
+
+**Rust signature:**
+
+```rust
+pub async fn open_cep_folder() -> Result<(), String>
 ```
 
-**Platform Behavior:**
+**Parameters:** None
 
-- **macOS:** Opens in Finder
-- **Windows:** Opens in File Explorer
-- **Linux:** Opens in default file manager
+**Returns:** `Result<(), String>`
+
+**Frontend usage** (`Premiere/api.ts`):
+
+```typescript
+await invoke('open_cep_folder')
+```
 
 ---
 
 ## Error Handling
 
-All Tauri commands return `Result<T, String>` where the error variant is a `String` message.
+All Tauri commands return `Result<T, String>` (or `Result<T, FileTransferError>` for transfer commands) where the error variant is a string message. Commands that return `void` (no Result) do not propagate errors to the frontend.
 
-**Frontend Error Handling Pattern:**
+**Frontend error handling pattern:**
 
 ```typescript
 import { invoke } from '@tauri-apps/api/core'
@@ -789,143 +1611,8 @@ try {
 }
 ```
 
-**Common Error Messages:**
-
-| Error                            | Cause                                 | Solution                            |
-| -------------------------------- | ------------------------------------- | ----------------------------------- |
-| `"Failed to get app data dir"`   | Tauri can't access app data directory | Check file permissions              |
-| `"Database not found"`           | embeddings database missing           | Run `npm run embed:examples:ollama` |
-| `"Invalid embedding dimensions"` | Wrong embedding size                  | Use 768-dimensional embeddings      |
-| `"Failed to copy file"`          | I/O error during file copy            | Check disk space, permissions       |
-| `"Template not found"`           | Premiere template missing             | Verify `src-tauri/assets/` folder   |
-| `"Connection refused"`           | Ollama not running                    | Start Ollama: `ollama serve`        |
-
 ---
 
-## TypeScript Type Definitions
-
-For type safety, define interfaces matching Rust structures:
-
-```typescript
-// Type-safe invoke wrapper
-import { invoke as tauriInvoke } from '@tauri-apps/api/core'
-
-// src/types/tauri-commands.ts
-
-export interface SimilarExample {
-  id: string
-  title: string
-  category: string
-  beforeText: string
-  afterText: string
-  similarity: number
-}
-
-export interface ExampleWithMetadata extends SimilarExample {
-  tags: string[]
-  wordCount: number | null
-  qualityScore: number | null
-  source: 'bundled' | 'user-uploaded'
-  createdAt: string
-}
-
-export interface UploadExampleRequest {
-  beforeContent: string
-  afterContent: string
-  metadata: {
-    title: string
-    category: string
-    tags?: string[]
-    qualityScore?: number
-  }
-  embedding: number[]
-}
-
-export async function invoke<T>(
-  command: string,
-  args?: Record<string, unknown>
-): Promise<T> {
-  return tauriInvoke<T>(command, args)
-}
-```
-
----
-
-## Performance Tips
-
-1. **Use React Query for caching:**
-
-   ```typescript
-   const { data } = useQuery({
-     queryKey: ['examples'],
-     queryFn: () => invoke<ExampleWithMetadata[]>('get_all_examples_with_metadata'),
-     staleTime: 5 * 60 * 1000 // 5 minutes
-   })
-   ```
-
-2. **Batch file operations:**
-   - Use `move_files` with all files at once (not one-by-one)
-   - Backend handles parallelization internally
-
-3. **Debounce search queries:**
-
-   ```typescript
-   const debouncedSearch = useDebouncedCallback(
-     (query: string) => invoke('search_examples', { query }),
-     300
-   )
-   ```
-
-4. **Stream large results:**
-   - For large file operations, use event-based progress tracking
-   - Don't await completion, listen to `copy_complete` event instead
-
----
-
-## Testing Commands
-
-Use Vitest to test Tauri command integration:
-
-```typescript
-// tests/tauri-commands.test.ts
-import { invoke } from '@tauri-apps/api/core'
-import { describe, expect, it } from 'vitest'
-
-describe('RAG Commands', () => {
-  it('should fetch all examples', async () => {
-    const examples = await invoke<ExampleWithMetadata[]>('get_all_examples_with_metadata')
-
-    expect(examples).toBeInstanceOf(Array)
-    expect(examples.length).toBeGreaterThan(0)
-    expect(examples[0]).toHaveProperty('id')
-    expect(examples[0]).toHaveProperty('title')
-  })
-
-  it('should find similar examples', async () => {
-    // Mock embedding
-    const mockEmbedding = new Array(768).fill(0.1)
-
-    const results = await invoke<SimilarExample[]>('find_similar_examples', {
-      queryEmbedding: mockEmbedding,
-      topK: 3
-    })
-
-    expect(results).toHaveLength(3)
-    expect(results[0].similarity).toBeGreaterThan(0)
-  })
-})
-```
-
----
-
-## Additional Resources
-
-- **[Tauri Command Documentation](https://tauri.app/v2/guides/features/commands/)** - Official Tauri guide
-- **[Rust Source Code](../src-tauri/src/commands/)** - Command implementations
-- **[Frontend Hooks](../src/hooks/)** - React hooks wrapping these commands
-
----
-
-**Document Version:** 1.0.0
-**Last Updated:** January 2025
-**Applies to:** Bucket v0.9.3
+**Document Version:** 2.0.0
+**Last Updated:** July 2026
+**Applies to:** Bucket v0.16.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document explains the high-level architecture of Bucket, including how diff
 
 **Target audience:** Developers who need to understand the system design before making significant changes or adding new features.
 
-**Last updated:** January 2025 (v0.9.3)
+**Last updated:** July 2026 (v0.16.0)
 
 ## System Design
 
@@ -49,7 +49,7 @@ This document explains the high-level architecture of Bucket, including how diff
 
 **Components:**
 
-1. **React Frontend** - User interface built with React 19, TypeScript 5.9, and TailwindCSS. Handles all UI rendering, user interactions, and client-side state management.
+1. **React Frontend** - User interface built with React 19, TypeScript 5.9, and TailwindCSS 4. Handles all UI rendering, user interactions, and client-side state management. Organized into feature modules (`src/features/`) with shared code in `src/shared/`.
 
 2. **Rust Backend (Tauri)** - Native application layer that provides secure file system access, API integrations, and performance-critical operations. Exposes commands to the frontend via Tauri's IPC bridge.
 
@@ -62,7 +62,7 @@ This document explains the high-level architecture of Bucket, including how diff
 | Layer                  | Technology                     | Why We Chose It                                                                          |
 | ---------------------- | ------------------------------ | ---------------------------------------------------------------------------------------- |
 | **Frontend Framework** | React 19 + TypeScript 5.9      | Type safety, large ecosystem, excellent tooling, team expertise                          |
-| **Build Tool**         | Vite 7.1                       | Fast HMR, modern ESM support, optimized production builds                                |
+| **Build Tool**         | Vite 7.3                       | Fast HMR, modern ESM support, optimized production builds                                |
 | **Desktop Runtime**    | Tauri 2.0                      | Smaller app size than Electron, better security, Rust performance, native OS integration |
 | **UI Components**      | Radix UI + TailwindCSS         | Accessible primitives, utility-first styling, consistent design system                   |
 | **State Management**   | Zustand + TanStack React Query | Simple API, minimal boilerplate, excellent async state handling                          |
@@ -73,119 +73,124 @@ This document explains the high-level architecture of Bucket, including how diff
 
 ## Directory Structure
 
+> **Note:** The frontend was reorganized in March 2026 from a flat layout
+> (`src/pages/`, `src/hooks/`, `src/components/`, etc.) into a feature-module
+> architecture. See CLAUDE.md for the canonical module map and conventions.
+
 ```
 bucket/
 ├── src/                            # React frontend source
-│   ├── pages/                      # Page-level components (routes)
-│   │   ├── BuildProject/           # Multi-camera project creation
-│   │   │   ├── BuildProject.tsx    # Main orchestrator component
-│   │   │   ├── ProjectInputs.tsx   # Title, date, camera count inputs
-│   │   │   ├── ProjectFileList.tsx # File selection and camera assignment
-│   │   │   ├── ProjectActions.tsx  # Create project button + logic
-│   │   │   └── ProgressBar.tsx     # File copy progress tracking
+│   ├── features/                   # Feature modules (domain-driven)
+│   │   ├── AITools/                # ScriptFormatter + ExampleEmbeddings
+│   │   │   ├── api.ts              # I/O boundary (Tauri invoke wrappers)
+│   │   │   ├── types.ts            # Shared type definitions
+│   │   │   ├── index.ts            # Barrel file (named re-exports + JSDoc)
+│   │   │   ├── __contracts__/      # Contract tests (shape, behavioral, no-bypass)
+│   │   │   ├── internal/           # Internal utilities (not exported)
+│   │   │   ├── ScriptFormatter/    # RAG-based script formatting UI
+│   │   │   └── ExampleEmbeddings/  # Manage RAG examples UI
 │   │   │
-│   │   ├── Baker/                  # Batch breadcrumbs management
-│   │   │   └── Baker.tsx           # Main Baker workflow component
+│   │   ├── Auth/                   # Login, registration, token management
+│   │   │   ├── api.ts
+│   │   │   ├── AuthContext.ts
+│   │   │   ├── AuthProvider.tsx
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   ├── components/         # Login.tsx, Register.tsx
+│   │   │   └── hooks/
 │   │   │
-│   │   ├── AI/                     # AI-powered features
-│   │   │   ├── ScriptFormatter/    # RAG-based script formatting
-│   │   │   │   ├── ScriptFormatter.tsx # Main formatter UI
-│   │   │   │   ├── DiffEditor.tsx      # Monaco diff viewer
-│   │   │   │   ├── FileUploader.tsx    # .docx upload
-│   │   │   │   ├── ModelSelector.tsx   # AI model selection
-│   │   │   │   └── ExampleToggleList.tsx # Example selection
-│   │   │   │
-│   │   │   └── ExampleEmbeddings/  # Manage RAG examples
-│   │   │       ├── ExampleEmbeddings.tsx # Main management UI
-│   │   │       ├── ExampleCard.tsx       # Display example
-│   │   │       ├── UploadDialog.tsx      # Upload new example
-│   │   │       └── ViewExampleDialog.tsx # View example details
+│   │   ├── Baker/                  # Drive scanning, breadcrumbs management
+│   │   │   ├── api.ts
+│   │   │   ├── types.ts
+│   │   │   ├── BakerPage.tsx       # Main Baker page component
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   ├── components/         # ProjectList, VideoLinksManager, BatchActions, etc.
+│   │   │   ├── hooks/              # useBakerScan, useBreadcrumbsManager, etc.
+│   │   │   ├── internal/
+│   │   │   └── utils/
 │   │   │
-│   │   ├── auth/                   # Authentication pages
-│   │   │   ├── Login.tsx           # Login form
-│   │   │   └── Register.tsx        # Registration form
+│   │   ├── BuildProject/           # File ingest, camera assignment, XState
+│   │   │   ├── api.ts
+│   │   │   ├── types.ts
+│   │   │   ├── BuildProjectPage.tsx
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   ├── components/
+│   │   │   └── hooks/
 │   │   │
-│   │   ├── UploadSprout.tsx        # Sprout Video integration
-│   │   ├── UploadTrello.tsx        # Trello integration
-│   │   ├── Posterframe.tsx         # Custom posterframe generator
-│   │   ├── Settings.tsx            # App settings and API keys
-│   │   └── ...                     # Other pages
-│   │
-│   ├── components/                 # Reusable UI components
-│   │   ├── ui/                     # Radix UI primitives
-│   │   │   ├── button.tsx          # Button component
-│   │   │   ├── dialog.tsx          # Modal dialogs
-│   │   │   ├── select.tsx          # Dropdown selects
-│   │   │   ├── progress.tsx        # Progress bars
-│   │   │   └── ...                 # 25+ UI primitives
+│   │   ├── Premiere/               # Adobe Premiere plugin management
+│   │   │   ├── api.ts
+│   │   │   ├── types.ts
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   └── components/
 │   │   │
-│   │   ├── Baker/                  # Baker-specific components
-│   │   │   ├── ProjectList.tsx     # Scanned projects list
-│   │   │   ├── VideoLinksManager.tsx # Manage video links
-│   │   │   ├── TrelloCardsManager.tsx # Manage Trello cards
-│   │   │   └── BatchActions.tsx    # Batch update controls
+│   │   ├── Settings/               # App configuration with per-domain tabs
+│   │   │   ├── api.ts
+│   │   │   ├── types.ts
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   ├── components/
+│   │   │   └── hooks/
 │   │   │
-│   │   ├── trello/                 # Trello components
-│   │   │   ├── TrelloIntegrationButton.tsx
-│   │   │   └── TrelloIntegrationModal.tsx
+│   │   ├── Trello/                 # Trello card management, video links
+│   │   │   ├── api.ts
+│   │   │   ├── types.ts
+│   │   │   ├── index.ts
+│   │   │   ├── __contracts__/
+│   │   │   ├── components/         # TrelloCardsManager, UploadTrello, etc.
+│   │   │   ├── hooks/
+│   │   │   └── internal/
 │   │   │
-│   │   ├── BreadcrumbsViewer.tsx   # Display breadcrumbs data
-│   │   └── ErrorBoundary.tsx       # Global error handling
+│   │   └── Upload/                 # Sprout Video, Posterframe, Otter
+│   │       ├── api.ts
+│   │       ├── types.ts
+│   │       ├── index.ts
+│   │       ├── __contracts__/
+│   │       ├── components/         # UploadSprout, Posterframe, UploadOtter
+│   │       ├── hooks/
+│   │       └── internal/
 │   │
-│   ├── hooks/                      # Custom React hooks (40+)
-│   │   ├── useCreateProject.ts     # Project creation orchestration
-│   │   ├── useBreadcrumb.ts        # Read/write breadcrumbs files
-│   │   ├── useBakerScan.ts         # Scan folders for projects
-│   │   ├── useCameraAutoRemap.ts   # Auto-assign camera numbers
-│   │   ├── useScriptProcessor.ts   # AI script formatting logic
-│   │   ├── useExampleManagement.ts # Manage RAG examples
-│   │   ├── useTrelloCardDetails.ts # Fetch Trello card data
-│   │   ├── useSproutVideoApi.ts    # Sprout Video operations
-│   │   ├── useAuth.ts              # Authentication state
-│   │   └── ...                     # Domain-specific hooks
+│   ├── shared/                     # Cross-feature shared code
+│   │   ├── constants/              # Timing, animation, project constants
+│   │   ├── hooks/                  # Cross-feature hooks (breadcrumb, search, API keys, mobile)
+│   │   ├── lib/                    # Query infrastructure: keys, client, utils, prefetch, perf
+│   │   ├── services/               # ProgressTracker, feedback, cache services
+│   │   ├── store/                  # Zustand stores: useAppStore, useBreadcrumbStore
+│   │   ├── types/                  # Shared domain types: media, script, breadcrumbs
+│   │   ├── ui/                     # Radix primitives, sidebar, theme, layout (NO barrel)
+│   │   └── utils/                  # Logger, storage, validation, cn(), breadcrumbs utils
 │   │
-│   ├── store/                      # Zustand global state
-│   │   ├── useBreadcrumbStore.ts   # Breadcrumbs UI state
-│   │   └── useAppStore.ts          # App-wide settings
+│   ├── app/                        # Layout shell
+│   │   └── dashboard/
+│   │       └── page.tsx            # Root layout (sidebar + outlet)
 │   │
-│   ├── services/                   # Business logic services
-│   │   ├── ai/                     # AI provider abstraction
-│   │   │   ├── modelFactory.ts     # Create AI provider instances
-│   │   │   ├── providerConfig.ts   # Provider configurations
-│   │   │   └── types.ts            # AI service types
-│   │   ├── ProgressTracker.ts      # Progress tracking utility
-│   │   └── cache-invalidation.ts   # React Query cache logic
-│   │
-│   ├── utils/                      # Utility functions
-│   │   ├── validation.ts           # Input validation helpers
-│   │   ├── breadcrumbsValidation.ts # Breadcrumbs schema validation
-│   │   ├── parseSproutVideoUrl.ts  # Extract Sprout video IDs
-│   │   ├── extractVideoInfoBlock.ts # Parse video info from text
-│   │   ├── debounce.ts             # Debounce utility
-│   │   └── ...                     # Domain utilities
-│   │
-│   ├── types/                      # TypeScript type definitions
-│   │   ├── baker.ts                # Baker workflow types
-│   │   ├── scriptFormatter.ts      # Script formatter types
-│   │   ├── exampleEmbeddings.ts    # RAG example types
-│   │   └── media.ts                # Media file types
-│   │
-│   ├── lib/                        # Shared library code
-│   │   ├── query-client-config.ts  # React Query configuration
-│   │   ├── query-keys.ts           # Centralized query key factory
-│   │   └── query-utils.ts          # Query helper functions
-│   │
-│   ├── App.tsx                     # Root React component
-│   ├── AppRouter.tsx               # React Router configuration
+│   ├── App.tsx                     # Root React component (providers, QueryClient)
+│   ├── AppRouter.tsx               # React Router configuration (lazy-loaded routes)
 │   └── index.tsx                   # App entry point
 │
 ├── src-tauri/                      # Rust backend
 │   ├── src/
-│   │   ├── commands/               # Tauri command modules
+│   │   ├── baker/                  # Baker-specific Tauri commands
+│   │   │   ├── mod.rs
+│   │   │   ├── breadcrumbs.rs      # Scan, read, update breadcrumbs
+│   │   │   ├── scanning.rs         # Folder scanning logic
+│   │   │   ├── types.rs            # Baker Rust types
+│   │   │   └── video_links.rs      # Video link + Trello card commands
+│   │   │
+│   │   ├── build_project/          # BuildProject file-transfer commands
+│   │   │   ├── mod.rs
+│   │   │   ├── commands.rs         # transfer_files_with_progress, cancel_file_transfer
+│   │   │   ├── error.rs            # Error types
+│   │   │   ├── registry.rs         # Operation registry (Arc<DashMap>)
+│   │   │   └── transfer.rs         # File copy logic
+│   │   │
+│   │   ├── commands/               # General Tauri command modules
 │   │   │   ├── mod.rs              # Command exports
 │   │   │   ├── auth.rs             # Authentication (argon2, JWT)
-│   │   │   ├── file_ops.rs         # File system operations
-│   │   │   ├── premiere.rs         # Premiere Pro integration
+│   │   │   ├── plugins.rs          # Premiere CEP plugin management
+│   │   │   ├── premiere.rs         # Premiere Pro template operations
 │   │   │   ├── sprout_upload.rs    # Sprout Video API client
 │   │   │   ├── docx.rs             # Word document processing
 │   │   │   ├── rag.rs              # RAG embeddings + vector search
@@ -199,32 +204,25 @@ bucket/
 │   │   │
 │   │   ├── utils/                  # Rust utilities
 │   │   │   ├── mod.rs
-│   │   │   └── file_copy.rs        # Optimized file copying
+│   │   │   └── macos_copyfile.rs   # macOS-optimized file copying
 │   │   │
-│   │   ├── baker.rs                # Baker workflow types
-│   │   ├── media.rs                # Media file handling
+│   │   ├── media.rs                # Media file handling (VideoLink, TrelloCard types)
 │   │   ├── lib.rs                  # Library root
-│   │   └── main.rs                 # App entry point
+│   │   └── main.rs                 # App entry point + command registration
 │   │
 │   ├── resources/                  # Bundled app resources
 │   │   ├── embeddings/
 │   │   │   └── examples.db         # SQLite vector embeddings DB
 │   │   └── examples/               # Bundled script examples
-│   │       ├── educational-lecture-1/
-│   │       └── business-presentation-1/
 │   │
 │   ├── assets/                     # Static assets
+│   │   ├── plugins/                # Premiere CEP plugin files
 │   │   ├── Premiere 4K Template 2025.prproj
 │   │   └── Premiere 4K Template 2023.prproj
 │   │
 │   ├── Cargo.toml                  # Rust dependencies
 │   ├── tauri.conf.json             # Tauri app configuration
 │   └── build.rs                    # Build script
-│
-├── specs/                          # Feature specifications (PRDs)
-│   ├── 004-embed-multiple-video/   # Multiple video links design
-│   ├── 007-frontend-script-example/ # Script examples management
-│   └── ...
 │
 ├── tests/                          # Frontend tests
 │   └── ...
@@ -234,12 +232,11 @@ bucket/
 │   └── ...
 │
 ├── docs/                           # Documentation
-│   ├── README.md                   # This file
-│   ├── ARCHITECTURE.md             # Architecture overview
+│   ├── README.md                   # Project overview
+│   ├── ARCHITECTURE.md             # Architecture overview (this file)
 │   └── API_COMMANDS.md             # Tauri commands reference
 │
-├── package.json                    # npm dependencies + scripts
-├── Cargo.toml                      # Workspace root (if applicable)
+├── package.json                    # Bun dependencies + scripts
 ├── tsconfig.json                   # TypeScript configuration
 ├── vite.config.ts                  # Vite build configuration
 └── CLAUDE.md                       # Claude Code instructions
@@ -247,62 +244,50 @@ bucket/
 
 ### Directory Purpose and Rules
 
-#### src/pages/
+#### src/features/\<Name\>/
 
-**Purpose:** Page-level components that represent routes in the application.
-
-**What goes here:**
-
-- Top-level feature pages (BuildProject, Baker, Settings, etc.)
-- Route-specific orchestrator components
-- Sub-components specific to one page (in subdirectories)
-
-**What doesn't go here:**
-
-- Reusable components (put in `components/`)
-- Business logic (put in `hooks/` or `services/`)
-- Utilities (put in `utils/`)
-
-**When to add a file:** When creating a new route/page in the application.
-
-#### src/hooks/
-
-**Purpose:** Custom React hooks that encapsulate reusable logic.
+**Purpose:** Self-contained feature modules, each with its own components, hooks, types, and I/O boundary.
 
 **What goes here:**
 
-- Tauri command wrappers (e.g., `useBreadcrumb`)
-- TanStack React Query hooks for data fetching
-- Complex state management logic
-- Reusable UI behavior (e.g., `useZoomPan`)
+- `api.ts` -- wraps ALL Tauri invoke/plugin calls (single I/O boundary)
+- `types.ts` -- shared type definitions for the module
+- `index.ts` -- barrel file with named re-exports and JSDoc
+- `__contracts__/` -- contract tests (shape, behavioral, no-bypass)
+- `components/` -- React components specific to this feature
+- `hooks/` -- React hooks specific to this feature
+- `internal/` -- internal utilities (NOT exported from barrel)
 
-**What doesn't go here:**
+**Import rules:**
 
-- Pure utility functions (put in `utils/`)
-- UI components (put in `components/`)
-- Global state stores (put in `store/`)
+- Features import shared via `@shared/*` barrel imports
+- Features import other features via `@features/*` barrel only
+- Shared NEVER imports from features
+- No direct `@tauri-apps` plugin imports in components/hooks -- all I/O goes through `api.ts`
 
-**When to add a file:** When logic is reused across 2+ components or when abstracting Tauri commands.
+**When to add a module:** When creating a new feature area in the application. See CLAUDE.md for the full checklist.
 
-#### src-tauri/src/commands/
+#### src/shared/
 
-**Purpose:** Rust functions exposed to the frontend via Tauri's IPC.
+**Purpose:** Cross-feature shared code. Dependency flows one direction: features depend on shared, never the reverse.
+
+**Subdirectories:** `constants/`, `hooks/`, `lib/`, `services/`, `store/`, `types/`, `ui/`, `utils/`
+
+**Note:** `shared/ui/` has NO barrel file -- use direct imports (e.g., `@shared/ui/button`, `@shared/ui/sidebar/Sidebar`).
+
+#### src-tauri/src/ (Rust backend)
+
+**Purpose:** Rust functions exposed to the frontend via Tauri's IPC, organized by domain.
 
 **What goes here:**
 
-- File system operations
-- API integrations (Trello, Sprout Video, Ollama)
-- Database operations (SQLite)
-- CPU-intensive operations (embeddings, file hashing)
+- `baker/` -- Baker scanning and breadcrumbs commands
+- `build_project/` -- File transfer with progress and cancellation
+- `commands/` -- General commands (auth, premiere, docx, rag, sprout, AI provider, plugins, system)
+- `state/` -- Shared state (Arc<Mutex<T>>)
+- `utils/` -- Rust utilities (macOS-optimized file copying)
 
-**What doesn't go here:**
-
-- UI logic (stays in React)
-- Simple data transformations (do in TypeScript unless performance-critical)
-
-**When to add a file:** When adding new Rust functionality that the frontend needs to call.
-
-**Naming convention:** Functions are annotated with `#[tauri::command]` and use snake_case (e.g., `create_project_folder`).
+**Naming convention:** Functions are annotated with `#[tauri::command]` and use snake_case (e.g., `transfer_files_with_progress`, `baker_start_scan`).
 
 ## Data Flow
 
@@ -322,42 +307,40 @@ User Interaction → React Component → Tauri Command → File System
 
 **Step-by-step:**
 
-1. **User selects files** in `ProjectFileList.tsx`
+1. **User selects files** in `BuildProjectPage.tsx`
    - User clicks "Select Files" button
-   - Calls `useFileSelector` hook
+   - File selection goes through the feature's `api.ts` I/O boundary
    - Hook invokes `open()` from `@tauri-apps/plugin-dialog`
    - Returns file paths array
 
 2. **User assigns cameras**
    - Files displayed in list with camera number inputs
-   - Auto-assign button triggers `useCameraAutoRemap` hook
-   - Validates that cameras 1 to N are all assigned
+   - Auto-assign logic validates that cameras 1 to N are all assigned
 
 3. **User creates project**
-   - Clicks "Create Project" in `ProjectActions.tsx`
-   - Calls `useCreateProject` hook
+   - Clicks "Create Project" in `BuildProjectPage.tsx`
    - Hook validates inputs (title, folder, camera assignments)
 
 4. **Frontend invokes Tauri command**
-   - `useCreateProject` calls `invoke('create_project_folder', { ... })`
+   - Calls `invoke('transfer_files_with_progress', { ... })` via `api.ts`
    - Tauri IPC serializes arguments to JSON
    - Rust backend receives command
 
-5. **Backend creates project**
-   - `create_project_folder()` in `file_ops.rs`
+5. **Backend transfers files**
+   - `transfer_files_with_progress()` in `build_project/commands.rs`
    - Creates folder structure: `Footage/Camera 1/`, `Footage/Camera 2/`, etc.
    - Copies files to appropriate camera folders with progress callbacks
-   - Emits progress events via `window.emit('copy_progress', ...)`
+   - Supports cancellation via `cancel_file_transfer()` and an `OperationRegistry`
    - Generates breadcrumbs.json
 
 6. **Backend copies Premiere template**
-   - `copy_premiere_template()` in `premiere.rs`
+   - `copy_premiere_project()` in `commands/premiere.rs`
    - Reads template from `assets/Premiere 4K Template 2025.prproj`
    - Copies to `Projects/[title].prproj`
    - Uses `file.sync_all()` to prevent corruption (v0.9.1 fix)
 
 7. **Frontend updates progress**
-   - `useCopyProgress` hook listens to `copy_progress` events
+   - Progress events streamed from backend
    - Updates progress bar in real-time
    - Shows file-by-file status
 
@@ -374,33 +357,28 @@ User Interaction → React Component → Tauri Command → File System
 
 **Step-by-step:**
 
-1. **User uploads .docx** in `FileUploader.tsx`
+1. **User uploads .docx** in ScriptFormatter
    - File selected via `<input type="file" accept=".docx" />`
-   - `useScriptFileUpload` hook reads file as ArrayBuffer
-   - Calls `invoke('parse_docx', { fileData: Array.from(buffer) })`
+   - Upload hook reads file as ArrayBuffer
+   - Calls `invoke('parse_docx_file', { filePath })` via `api.ts`
 
 2. **Backend parses Word document**
-   - `parse_docx()` in `docx.rs`
-   - Uses `mammoth` crate to extract text
-   - Returns plain text string
+   - `parse_docx_file()` in `commands/docx.rs`
+   - Extracts text content and formatting metadata
+   - Returns `ParseResult` with text, HTML, and formatting info
 
 3. **Frontend chunks text**
    - `useScriptProcessor` splits text into semantic chunks
    - Each chunk ~500 tokens for context window efficiency
 
-4. **Backend generates embeddings**
-   - Frontend calls `invoke('embed_text_ollama', { text, model })`
-   - `embed_text_ollama()` in `rag.rs`
-   - Sends text to Ollama embedding endpoint
-   - Returns vector embedding (e.g., 768 dimensions for nomic-embed-text)
-
-5. **Backend retrieves similar examples**
-   - `find_similar_examples()` in `rag.rs`
-   - Performs cosine similarity search in SQLite
+4. **Backend searches for similar examples**
+   - Frontend calls `invoke('search_similar_scripts', { ... })` via `api.ts`
+   - `search_similar_scripts()` in `commands/rag.rs`
+   - Generates embedding, then performs cosine similarity search in SQLite
    - Uses `SELECT ... ORDER BY similarity DESC LIMIT 3`
    - Returns top 3 most relevant examples
 
-6. **Frontend calls LLM**
+5. **Frontend calls LLM**
    - `useScriptProcessor` constructs prompt:
      - System prompt: "Format this autocue script..."
      - Examples: Retrieved before/after pairs
@@ -408,13 +386,13 @@ User Interaction → React Component → Tauri Command → File System
    - Calls Ollama API via Vercel AI SDK
    - Streams response chunks
 
-7. **Frontend displays diff**
+6. **Frontend displays diff**
    - `DiffEditor.tsx` uses Monaco Editor
    - Original text (left pane)
    - Formatted text (right pane)
    - User can edit right pane
 
-8. **User exports**
+7. **User exports**
    - Clicks "Download Formatted Script"
    - `useDocxGenerator` creates .docx from formatted text
    - Uses `docx` library to generate Word document
@@ -453,7 +431,7 @@ Application State
    - Automatically caches responses
    - Handles loading/error states
    - Supports optimistic updates
-   - Example: `useQuery(['breadcrumbs', filePath], () => invoke('read_breadcrumbs', { filePath }))`
+   - Example: `useQuery({ queryKey: queryKeys.breadcrumbs(filePath), queryFn: () => api.readBreadcrumbs(filePath) })`
 
 3. **Local state (useState):** Use for component-specific UI state
    - Form inputs before submission
@@ -540,14 +518,14 @@ useEffect(() => {
     })
 }, [filePath])
 
-// NEW: React Query (current)
+// NEW: React Query (current) -- invoked via feature api.ts
 const {
   data: breadcrumbs,
   isLoading,
   error
 } = useQuery({
-  queryKey: ['breadcrumbs', filePath],
-  queryFn: () => invoke('read_breadcrumbs', { filePath })
+  queryKey: queryKeys.breadcrumbs(filePath),
+  queryFn: () => api.readBreadcrumbs(filePath)
 })
 ```
 
@@ -648,49 +626,48 @@ LIMIT 3;
 ### Dependency Graph (Frontend)
 
 ```
-pages/
-  └─→ components/
-        └─→ hooks/
-              └─→ lib/ (React Query config)
-                    └─→ services/
-                          └─→ utils/
+features/<Name>/
+  └─→ @shared/* (constants, hooks, lib, services, store, types, utils, ui)
+  └─→ @features/<Other>/ (via barrel only, cross-feature imports)
 
-store/
-  └─→ (no dependencies, stores are independent)
-
-hooks/
-  └─→ services/ (AI provider abstraction)
-  └─→ lib/ (query utilities)
+shared/
+  └─→ (never imports from features -- dependency flows one direction)
 ```
 
 **Dependency rules:**
 
 1. **No circular dependencies**
-   - Enforced by TypeScript and Rust module system
+   - Enforced by TypeScript module system and ESLint boundaries plugin
    - Use dependency injection or events if needed
 
-2. **Lower layers can't depend on higher layers**
-   - ❌ `hooks/` can't import from `pages/`
-   - ✅ `pages/` can import from `hooks/`
+2. **Features import shared, never the reverse**
+   - ❌ `@shared/hooks/` can't import from `@features/Baker/`
+   - ✅ `@features/Baker/` can import from `@shared/hooks/`
 
-3. **Services are UI-agnostic**
-   - Don't import React components in `services/`
-   - Keep business logic separate from UI
+3. **Cross-feature imports go through barrels only**
+   - ❌ `import { X } from '@features/Trello/components/TrelloCardsManager'`
+   - ✅ `import { TrelloCardsManager } from '@features/Trello'`
+
+4. **All Tauri I/O goes through `api.ts`**
+   - No direct `@tauri-apps` plugin imports in components/hooks
+   - Enforced by no-bypass contract tests in each feature's `__contracts__/`
 
 ### External Dependencies (Key Packages)
 
-| Package                   | Version | Used For                 | Notes                                            |
-| ------------------------- | ------- | ------------------------ | ------------------------------------------------ |
-| **@tauri-apps/api**       | 2.9.0   | Tauri IPC bridge         | Invoke Rust commands from React                  |
-| **@tanstack/react-query** | 5.90.3  | Async state management   | Replaces useEffect for data fetching             |
-| **zustand**               | 5.0.8   | Global state             | Lightweight alternative to Redux                 |
-| **@radix-ui/react-\***    | 1.x     | Accessible UI primitives | Headless components for dialogs, dropdowns, etc. |
-| **ai** (Vercel AI SDK)    | 5.0.72  | AI provider abstraction  | Unified interface for Ollama, OpenAI, etc.       |
-| **@monaco-editor/react**  | 4.7.0   | Code/diff editor         | Script formatting diff view                      |
-| **docx**                  | 9.5.1   | Word document generation | Export formatted scripts                         |
-| **mammoth**               | 1.11.0  | Word document parsing    | Import .docx scripts                             |
-| **fuse.js**               | 7.1.0   | Fuzzy search             | Search projects in Baker                         |
-| **vite**                  | 7.1.10  | Build tool               | Fast dev server, production builds               |
+| Package                   | Version  | Used For                 | Notes                                            |
+| ------------------------- | -------- | ------------------------ | ------------------------------------------------ |
+| **@tauri-apps/api**       | ~2.10.1  | Tauri IPC bridge         | Invoke Rust commands from React                  |
+| **@tanstack/react-query** | ^5.90.3  | Async state management   | Replaces useEffect for data fetching             |
+| **zustand**               | ^5.0.8   | Global state             | Lightweight alternative to Redux                 |
+| **@radix-ui/react-\***    | 1.x--2.x | Accessible UI primitives | Headless components for dialogs, dropdowns, etc. |
+| **ai** (Vercel AI SDK)    | ^6.0.199 | AI provider abstraction  | Unified interface for Ollama, OpenAI, etc.       |
+| **@monaco-editor/react**  | ^4.7.0   | Code/diff editor         | Script formatting diff view                      |
+| **docx**                  | ^9.5.1   | Word document generation | Export formatted scripts                         |
+| **mammoth**               | ^1.12.0  | Word document parsing    | Import .docx scripts                             |
+| **fuse.js**               | ^7.1.0   | Fuzzy search             | Search projects in Baker                         |
+| **vite**                  | ^7.3.2   | Build tool               | Fast dev server, production builds               |
+| **xstate**                | ^5.24.0  | State machines           | BuildProject workflow orchestration              |
+| **react-router-dom**      | ^7.17.0  | Client-side routing      | Lazy-loaded routes via React.lazy()              |
 
 **Rust dependencies:** See `src-tauri/Cargo.toml` for full list.
 
@@ -708,44 +685,46 @@ Key Rust crates:
 
 ### Adding a New Feature Page
 
-To add a new feature page (e.g., "Timeline" page):
+To add a new feature page (e.g., "Timeline" page), follow the feature-module pattern:
 
-1. **Create page component:**
+1. **Create feature module:**
 
    ```
-   src/pages/Timeline/
-   ├── Timeline.tsx           # Main page component
-   ├── TimelineView.tsx       # Sub-component
-   └── TimelineControls.tsx   # Sub-component
+   src/features/Timeline/
+   ├── api.ts              # I/O boundary -- wraps ALL Tauri invoke/plugin calls
+   ├── types.ts            # Shared type definitions
+   ├── index.ts            # Barrel file -- named re-exports with JSDoc
+   ├── __contracts__/      # Contract tests (shape, behavioral, no-bypass)
+   ├── TimelinePage.tsx    # Main page component
+   ├── components/         # Sub-components
+   └── hooks/              # Feature-specific hooks
    ```
 
-2. **Add route:**
+2. **Add lazy-loaded route:**
    - Open `src/AppRouter.tsx`
-   - Add route: `<Route path="/timeline" element={<Timeline />} />`
-
-3. **Add sidebar navigation:**
-   - Open `src/components/nav-main.tsx`
-   - Add menu item:
+   - Add lazy import and route:
      ```tsx
-     {
-       title: "Timeline",
-       url: "/timeline",
-       icon: Calendar,
-     }
+     const TimelinePage = React.lazy(() =>
+       import('@features/Timeline').then((m) => ({ default: m.TimelinePage }))
+     )
+     // Inside <Routes>:
+     <Route path="timeline" element={<TimelinePage />} />
      ```
 
-4. **Create hooks (if needed):**
-   - `src/hooks/useTimelineData.ts` - Fetch timeline data
-   - Use React Query for data fetching
+3. **Add sidebar navigation:**
+   - Open `src/shared/ui/layout/app-sidebar.tsx`
+   - Add menu item to the appropriate section
 
-5. **Add Tauri commands (if needed):**
-   - Create `src-tauri/src/commands/timeline.rs`
-   - Implement Rust functions
-   - Export in `src-tauri/src/commands/mod.rs`
-   - Add to Tauri builder in `src-tauri/src/main.rs`
+4. **Add Tauri commands (if needed):**
+   - Create `src-tauri/src/commands/timeline.rs` (or a `src-tauri/src/timeline/` module)
+   - Implement Rust functions with `#[tauri::command]`
+   - Export in the appropriate `mod.rs`
+   - Register in `src-tauri/src/main.rs` invoke_handler
 
-6. **Add types:**
-   - `src/types/timeline.ts` - TypeScript types for timeline feature
+5. **Run linting to verify boundary compliance:**
+   ```bash
+   bun run eslint:fix
+   ```
 
 ### Adding a New Tauri Command
 
@@ -776,27 +755,31 @@ pub use my_feature::*;
 
 ```rust
 // src-tauri/src/main.rs
-fn main() {
-    tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![
-            // ... existing commands
-            my_command,
-        ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-}
+// Add to the invoke_handler list:
+.invoke_handler(tauri::generate_handler![
+    // ... existing commands
+    my_command,
+])
 ```
 
-4. **Call from React:**
+4. **Call from React (via feature api.ts):**
 
 ```typescript
-// src/hooks/useMyFeature.ts
+// src/features/MyFeature/api.ts
 import { invoke } from '@tauri-apps/api/core'
+
+export async function myCommand(arg1: string, arg2: number): Promise<string> {
+  return invoke<string>('my_command', { arg1, arg2 })
+}
+
+// src/features/MyFeature/hooks/useMyFeature.ts
+import { useMutation } from '@tanstack/react-query'
+import { myCommand } from '../api'
 
 export function useMyFeature() {
   return useMutation({
     mutationFn: async (args: { arg1: string; arg2: number }) => {
-      return await invoke<string>('my_command', args)
+      return await myCommand(args.arg1, args.arg2)
     }
   })
 }
@@ -818,7 +801,7 @@ To add a new bundled script example for RAG:
 2. **Generate embeddings:**
 
    ```bash
-   npm run embed:examples:ollama
+   bun run embed:examples:ollama
    ```
 
    This script:
@@ -828,7 +811,7 @@ To add a new bundled script example for RAG:
 
 3. **Rebuild app:**
    ```bash
-   npm run build:tauri
+   bun run build:tauri
    ```
 
 Examples are bundled with the app in the resources directory.
@@ -923,8 +906,8 @@ Examples are bundled with the app in the resources directory.
 
 | Environment          | Purpose                           | How to Run            |
 | -------------------- | --------------------------------- | --------------------- |
-| **Development**      | Local development with hot reload | `npm run dev:tauri`   |
-| **Production Build** | Release builds for distribution   | `npm run build:tauri` |
+| **Development**      | Local development with hot reload | `bun run dev:tauri`   |
+| **Production Build** | Release builds for distribution   | `bun run build:tauri` |
 
 No staging/preview environments (desktop app, not web app).
 
@@ -932,15 +915,15 @@ No staging/preview environments (desktop app, not web app).
 
 ```bash
 # Development build (debug, fast compilation)
-npm run dev:tauri
+bun run dev:tauri
 
 # Production build (optimized, stripped)
-npm run build:tauri
+bun run build:tauri
 ```
 
 **Production build steps:**
 
-1. **Pre-build:** Embed script examples (`npm run embed:examples:ollama`)
+1. **Pre-build:** Embed script examples (`bun run embed:examples:ollama`)
 2. **Frontend build:** Vite builds React app → `dist/`
 3. **Rust build:** Cargo compiles Rust → `target/release/`
 4. **Tauri bundle:** Packages app + webview → Platform-specific installer
@@ -950,9 +933,9 @@ npm run build:tauri
 
 **Build artifacts:**
 
-- macOS: `src-tauri/target/release/bundle/dmg/Bucket_0.9.3_universal.dmg`
-- Windows: `src-tauri/target/release/bundle/msi/Bucket_0.9.3_x64_en-US.msi`
-- Linux: `src-tauri/target/release/bundle/appimage/bucket_0.9.3_amd64.AppImage`
+- macOS: `src-tauri/target/release/bundle/dmg/Bucket_<version>_universal.dmg`
+- Windows: `src-tauri/target/release/bundle/msi/Bucket_<version>_x64_en-US.msi`
+- Linux: `src-tauri/target/release/bundle/appimage/bucket_<version>_amd64.AppImage`
 
 ### Auto-Updates (Tauri Updater)
 
@@ -978,7 +961,7 @@ Bucket supports automatic updates via Tauri's updater plugin:
 
 **Log destinations:**
 
-- **Development:** Terminal output (`RUST_LOG=debug npm run dev:tauri`)
+- **Development:** Terminal output (`RUST_LOG=debug bun run dev:tauri`)
 - **Production:** Tauri logs to app data directory (macOS: `~/Library/Logs/com.bucket.app/`)
 
 **TypeScript logging:**
@@ -1004,9 +987,10 @@ Currently no telemetry/metrics collection (privacy-focused desktop app).
 - **Symptoms:** `Error: Command 'my_command' not found` in browser console
 - **Cause:** Command not registered in `main.rs` or wrong function name
 - **Solution:**
-  1. Check `src-tauri/src/main.rs` → `invoke_handler!([..., my_command])`
+  1. Check `src-tauri/src/main.rs` → `generate_handler![..., my_command]`
   2. Verify function has `#[tauri::command]` attribute
-  3. Rebuild Rust: `cd src-tauri && cargo build`
+  3. Verify the module is imported in `main.rs` (via `use` or `mod`)
+  4. Rebuild Rust: `cd src-tauri && cargo build`
 
 **Issue: React Query not refetching**
 
@@ -1029,10 +1013,10 @@ Currently no telemetry/metrics collection (privacy-focused desktop app).
 
 - **Symptoms:** Files not copied, no error message
 - **Cause:** Tauri command threw error but wasn't caught
-- **Solution:** Wrap Tauri calls in try-catch:
+- **Solution:** Wrap Tauri calls in try-catch (via the feature's api.ts):
   ```typescript
   try {
-    await invoke('copy_files', args)
+    await api.transferFiles(args)
   } catch (error) {
     console.error('Copy failed:', error)
     toast.error(`Failed to copy files: ${error}`)
@@ -1059,6 +1043,6 @@ Currently no telemetry/metrics collection (privacy-focused desktop app).
 
 ---
 
-**Document Version:** 1.0.0
-**Last Updated:** January 2025
-**Applies to:** Bucket v0.9.3
+**Document Version:** 2.0.0
+**Last Updated:** July 2026
+**Applies to:** Bucket v0.16.0

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -18,7 +18,7 @@ Welcome to Bucket! This guide will help you get started contributing to the code
 Before starting, ensure you have:
 
 - **macOS, Windows, or Linux** (primary development on macOS)
-- **Node.js** 18+ or **Bun** (recommended for faster installs)
+- **Bun** (required -- the project's standard package manager)
 - **Rust** 1.70+ ([install from rustup.rs](https://rustup.rs))
 - **Git** for version control
 - **Code editor** (VS Code recommended with Rust Analyzer extension)
@@ -41,16 +41,8 @@ cd bucket
 
 ### Install Dependencies
 
-Using **Bun** (recommended - faster):
-
 ```bash
 bun install
-```
-
-Or using **npm**:
-
-```bash
-npm install
 ```
 
 This installs:
@@ -80,7 +72,7 @@ source $HOME/.cargo/env
 ### Start Development Mode
 
 ```bash
-npm run dev:tauri
+bun run dev:tauri
 ```
 
 This will:
@@ -111,25 +103,31 @@ This will:
 
 ```
 bucket/
-├── src/                    # React frontend (TypeScript)
-│   ├── pages/              # Page components (routes)
-│   ├── components/         # Reusable UI components
-│   ├── hooks/              # Custom React hooks
-│   ├── store/              # Global state (Zustand)
-│   └── lib/                # Shared utilities
+├── src/                        # React frontend (TypeScript)
+│   ├── features/               # Feature modules (AITools, Auth, Baker,
+│   │                           #   BuildProject, Premiere, Settings, Trello, Upload)
+│   ├── shared/                 # Cross-feature code
+│   │   ├── constants/          # Timing, animation, project constants
+│   │   ├── hooks/              # Cross-feature hooks
+│   │   ├── lib/                # Query infrastructure
+│   │   ├── services/           # ProgressTracker, feedback, cache
+│   │   ├── store/              # Zustand stores (appStore, breadcrumbStore)
+│   │   ├── types/              # Shared domain types
+│   │   ├── ui/                 # Radix primitives, sidebar, theme, layout
+│   │   └── utils/              # Logger, storage, validation, cn()
+│   ├── App.tsx                 # Root React component
+│   └── AppRouter.tsx           # Route definitions (lazy-loaded)
 │
-├── src-tauri/              # Rust backend
-│   ├── src/commands/       # Tauri commands (API for frontend)
-│   ├── src/state/          # Shared Rust state
-│   └── Cargo.toml          # Rust dependencies
+├── src-tauri/                  # Rust backend
+│   ├── src/commands/           # Tauri commands (API for frontend)
+│   ├── src/state/              # Shared Rust state
+│   └── Cargo.toml              # Rust dependencies
 │
-├── docs/                   # Documentation
-│   ├── README.md           # User-facing documentation
-│   ├── ARCHITECTURE.md     # System architecture
-│   ├── API_COMMANDS.md     # Tauri commands reference
-│   └── ONBOARDING.md       # This file
-│
-└── specs/                  # Feature specifications
+└── docs/                       # Documentation
+    ├── README.md               # User-facing documentation
+    ├── ARCHITECTURE.md         # System architecture
+    ├── API_COMMANDS.md         # Tauri commands reference
+    └── ONBOARDING.md           # This file
 ```
 
 ### Key Files to Know
@@ -150,6 +148,7 @@ Before making changes, skim these docs:
 1. **[README.md](./README.md)** - Get familiar with features
 2. **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Understand system design
 3. **[API_COMMANDS.md](./API_COMMANDS.md)** - Learn Tauri command API
+4. **[CLAUDE.md](../CLAUDE.md)** - Module conventions and import rules
 
 **Time investment:** 15-20 minutes of reading will save hours later.
 
@@ -166,7 +165,7 @@ Let's make a simple change to see the development workflow.
 1. **Open the file:**
 
    ```bash
-   code src/pages/Settings.tsx
+   code src/features/Settings/components/SettingsPage.tsx
    ```
 
 2. **Find the return statement** (around line 50)
@@ -239,27 +238,31 @@ Let's make a simple change to see the development workflow.
 
 5. **Call from frontend:**
 
-   Create `src/hooks/useTimestamp.ts`:
+   Create a hook in your feature's `hooks/` directory (e.g., `src/features/Settings/hooks/useTimestamp.ts`):
 
    ```typescript
    import { useQuery } from '@tanstack/react-query'
-   import { invoke } from '@tauri-apps/api/core'
+
+   import { getTimestamp } from '../api'
 
    export function useTimestamp() {
      return useQuery({
        queryKey: ['timestamp'],
-       queryFn: () => invoke<string>('get_timestamp'),
+       queryFn: getTimestamp,
        refetchInterval: 1000 // Update every second
      })
    }
    ```
 
+   > **Convention:** Never import `@tauri-apps` directly in hooks or components.
+   > All Tauri calls go through the feature's `api.ts` file (see CLAUDE.md).
+
 6. **Use in a component:**
 
-   Edit `src/pages/Settings.tsx`:
+   Edit `src/features/Settings/components/SettingsPage.tsx`:
 
    ```tsx
-   import { useTimestamp } from '@/hooks/useTimestamp'
+   import { useTimestamp } from '../hooks/useTimestamp'
 
    export function Settings() {
      const { data: timestamp } = useTimestamp()
@@ -273,7 +276,7 @@ Let's make a simple change to see the development workflow.
    }
    ```
 
-7. **Restart the app** (Ctrl+C, then `npm run dev:tauri`)
+7. **Restart the app** (Ctrl+C, then `bun run dev:tauri`)
 
 8. **Verify:** You should see a live-updating timestamp!
 
@@ -287,10 +290,10 @@ Before committing code, always run these checks:
 
 ```bash
 # Fix formatting issues
-npm run prettier:fix
+bun run prettier:fix
 
 # Fix linting issues
-npm run eslint:fix
+bun run eslint:fix
 ```
 
 **Formatting rules:**
@@ -304,16 +307,16 @@ npm run eslint:fix
 
 ```bash
 # Run all tests
-npm run test
+bun run test
 
 # Run tests in watch mode (useful during development)
-npm run test:ui
+bun run test:ui
 ```
 
 **Coverage check:**
 
 ```bash
-npm run test:coverage
+bun run test:coverage
 ```
 
 ### Rust Code Quality
@@ -335,9 +338,9 @@ cargo test
 
 Before every commit:
 
-- [ ] Code formatted: `npm run prettier:fix`
-- [ ] Linting passes: `npm run eslint:fix`
-- [ ] Tests pass: `npm run test`
+- [ ] Code formatted: `bun run prettier:fix`
+- [ ] Linting passes: `bun run eslint:fix`
+- [ ] Tests pass: `bun run test`
 - [ ] Rust formatted: `cargo fmt`
 - [ ] No compiler warnings
 
@@ -392,7 +395,7 @@ git commit -m "docs: update architecture documentation"
 # Push to GitHub
 git push origin feature/my-new-feature
 
-# Open GitHub and create a Pull Request to the 'release' branch
+# Open GitHub and create a Pull Request to the 'master' branch
 ```
 
 **PR Description Template:**
@@ -409,9 +412,9 @@ Explain the motivation
 ## Testing
 
 - [ ] Tested locally in dev mode
-- [ ] Tests pass (`npm run test`)
-- [ ] Linting passes (`npm run eslint`)
-- [ ] Formatted code (`npm run prettier:fix`)
+- [ ] Tests pass (`bun run test`)
+- [ ] Linting passes (`bun run eslint:fix`)
+- [ ] Formatted code (`bun run prettier:fix`)
 
 ## Screenshots (if UI changes)
 
@@ -422,31 +425,25 @@ Explain the motivation
 
 ## Common Development Tasks
 
-### Adding a New Page
+### Adding a New Feature Module
 
-1. **Create page component:**
+See CLAUDE.md section "How to Add a New Feature Module" for the full checklist. In short:
+
+1. **Create feature directory** with `api.ts`, `types.ts`, `index.ts`, `components/`, `hooks/`, `__contracts__/`
 
    ```bash
-   mkdir src/pages/MyFeature
-   code src/pages/MyFeature/MyFeature.tsx
+   mkdir -p src/features/MyFeature/{components,hooks,__contracts__}
    ```
 
-2. **Add route:**
-   Edit `src/AppRouter.tsx`:
+2. **Add lazy route** in `src/AppRouter.tsx`:
 
    ```tsx
-   <Route path="/my-feature" element={<MyFeature />} />
+   const MyFeaturePage = React.lazy(() =>
+     import('@features/MyFeature').then(m => ({ default: m.MyFeaturePage }))
+   )
    ```
 
-3. **Add to sidebar:**
-   Edit `src/components/nav-main.tsx`:
-   ```tsx
-   {
-     title: "My Feature",
-     url: "/my-feature",
-     icon: Sparkles,
-   }
-   ```
+3. **Add to sidebar** in `src/shared/ui/sidebar/SidebarMenu.tsx`
 
 ### Adding a New Tauri Command
 
@@ -457,8 +454,9 @@ See [Step 4: Backend Change Example](#backend-change-example) above.
 1. Create command in `src-tauri/src/commands/`
 2. Export in `mod.rs`
 3. Register in `main.rs`
-4. Create hook in `src/hooks/`
-5. Use in component
+4. Wrap the invoke call in the feature's `api.ts`
+5. Create hook in the feature's `hooks/` directory
+6. Use in component
 
 ### Adding a New Dependency
 
@@ -466,8 +464,6 @@ See [Step 4: Backend Change Example](#backend-change-example) above.
 
 ```bash
 bun add package-name
-# or
-npm install package-name
 ```
 
 **Backend:**
@@ -489,10 +485,10 @@ cargo add crate-name
 
 ```bash
 # Enable detailed Rust logs
-RUST_LOG=debug npm run dev:tauri
+RUST_LOG=debug bun run dev:tauri
 
 # View logs for specific module
-RUST_LOG=app_lib::commands=debug npm run dev:tauri
+RUST_LOG=app_lib::commands=debug bun run dev:tauri
 ```
 
 **Common issues:**
@@ -534,7 +530,7 @@ const { data } = useQuery({
 **Example:**
 
 ```typescript
-// src/store/useMyStore.ts
+// src/shared/store/useMyStore.ts
 import { create } from 'zustand'
 
 interface MyStore {
@@ -584,7 +580,7 @@ Write tests for:
 **Example test:**
 
 ```typescript
-import { myFunction } from '@/utils/myFunction'
+import { myFunction } from '@shared/utils/myFunction'
 import { describe, expect, it } from 'vitest'
 
 describe('myFunction', () => {
@@ -603,6 +599,7 @@ describe('myFunction', () => {
 - **[README.md](./README.md)** - Features and setup guide
 - **[ARCHITECTURE.md](./ARCHITECTURE.md)** - System design and patterns
 - **[API_COMMANDS.md](./API_COMMANDS.md)** - Tauri commands reference
+- **[BRANCHING_STRATEGY.md](./BRANCHING_STRATEGY.md)** - Git branching workflow
 - **[CLAUDE.md](../CLAUDE.md)** - Project conventions and patterns
 
 ### External Resources
@@ -615,8 +612,8 @@ describe('myFunction', () => {
 
 **Tauri:**
 
-- [Tauri Documentation](https://tauri.app/v2/guides/)
-- [Tauri Commands Guide](https://tauri.app/v2/guides/features/commands/)
+- [Tauri Documentation](https://tauri.app/start/)
+- [Tauri Commands Guide](https://tauri.app/develop/calling-rust/)
 
 **Rust:**
 
@@ -627,9 +624,9 @@ describe('myFunction', () => {
 
 **Study these well-implemented features:**
 
-1. **BuildProject workflow** (`src/pages/BuildProject/`) - Complex multi-step flow
-2. **Baker** (`src/pages/Baker/`) - Folder scanning and batch operations
-3. **ScriptFormatter** (`src/pages/AI/ScriptFormatter/`) - AI integration pattern
+1. **BuildProject workflow** (`src/features/BuildProject/`) - Complex multi-step flow with XState
+2. **Baker** (`src/features/Baker/`) - Folder scanning and batch operations
+3. **AITools** (`src/features/AITools/`) - AI integration pattern (ScriptFormatter + ExampleEmbeddings)
 4. **RAG commands** (`src-tauri/src/commands/rag.rs`) - Database + embedding pattern
 
 ---
@@ -638,9 +635,9 @@ describe('myFunction', () => {
 
 ### Within the Codebase
 
-1. **Check existing code** - Search for similar patterns
-2. **Read specs/** - Feature specifications and PRDs
-3. **Read CLAUDE.md** - Project conventions and decisions
+1. **Check existing code** - Search for similar patterns in `src/features/`
+2. **Read CLAUDE.md** - Project conventions and decisions
+3. **Read ARCHITECTURE.md** - System design and patterns
 
 ### Community
 
@@ -654,7 +651,7 @@ describe('myFunction', () => {
 1. Check the error message carefully
 2. Search existing GitHub issues
 3. Try `cargo clean && cargo build` (Rust issues)
-4. Try deleting `node_modules` and reinstalling (frontend issues)
+4. Try deleting `node_modules` and reinstalling with `bun install` (frontend issues)
 
 **When asking for help, include:**
 
@@ -698,6 +695,6 @@ Happy coding! 🚀
 
 ---
 
-**Document Version:** 1.0.0
-**Last Updated:** January 2025
+**Document Version:** 1.1.0
+**Last Updated:** July 2026
 **Maintainer:** Check GitHub for current maintainers

--- a/docs/PREMIERE_PLUGINS.md
+++ b/docs/PREMIERE_PLUGINS.md
@@ -248,7 +248,7 @@ PluginInfo {
 #### 4. Rebuild Bucket
 
 ```bash
-npm run build:tauri
+bun run build:tauri
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Get up and running in under 5 minutes:
 
 ### Prerequisites
 
-- **Node.js** 18+ or **Bun** (recommended)
+- **Bun** (required -- the project's standard package manager)
 - **Rust** 1.70+ (for building from source)
 - **Ollama** (optional - for AI Script Formatter feature)
   - Download from [ollama.com](https://ollama.com)
@@ -31,11 +31,11 @@ Get up and running in under 5 minutes:
 git clone https://github.com/twentynineteen/bucket.git
 cd bucket
 
-# Install dependencies (using Bun - recommended)
+# Install dependencies
 bun install
 
 # Build the desktop app
-npm run build:tauri
+bun run build:tauri
 
 # On macOS, the app will be in /target/build/dmg
 # Open the DMG and copy Bucket.app to Applications
@@ -58,10 +58,10 @@ For active development with hot reload:
 bun install
 
 # Run in development mode (starts Tauri with devtools)
-npm run dev:tauri
+bun run dev:tauri
 
 # In a separate terminal, run tests
-npm run test
+bun run test
 ```
 
 ## Project Structure
@@ -69,58 +69,46 @@ npm run test
 ```
 bucket/
 ├── src/                           # Frontend React/TypeScript code
-│   ├── pages/                     # Page-level components (routes)
-│   │   ├── BuildProject/          # Main project creation workflow
-│   │   ├── Baker/                 # Batch breadcrumbs management
-│   │   ├── AI/                    # AI-powered features
-│   │   │   ├── ScriptFormatter/   # Script formatting with LLMs
-│   │   │   └── ExampleEmbeddings/ # RAG example management
-│   │   ├── auth/                  # Login and registration
-│   │   ├── UploadSprout.tsx       # Sprout Video integration
-│   │   ├── UploadTrello.tsx       # Trello integration
-│   │   ├── Posterframe.tsx        # Custom posterframe generation
-│   │   └── Settings.tsx           # App configuration
-│   ├── components/                # Reusable UI components
-│   │   ├── ui/                    # Radix UI components (buttons, dialogs, etc.)
-│   │   ├── Baker/                 # Baker-specific components
-│   │   └── trello/                # Trello integration components
-│   ├── hooks/                     # Custom React hooks
-│   │   ├── useBreadcrumb.ts       # Breadcrumbs file operations
-│   │   ├── useCreateProject.ts    # Project creation logic
-│   │   ├── useBakerScan.ts        # Folder scanning for Baker
-│   │   ├── useScriptProcessor.ts  # AI script formatting
-│   │   └── ...                    # 40+ specialized hooks
-│   ├── store/                     # Zustand state management
-│   │   ├── useBreadcrumbStore.ts  # Breadcrumbs state
-│   │   └── useAppStore.ts         # Global app state
-│   ├── services/                  # Business logic services
-│   ├── utils/                     # Utility functions
-│   ├── types/                     # TypeScript type definitions
-│   └── lib/                       # Shared libraries and configs
+│   ├── features/                  # Feature modules (each with api.ts, index.ts, types.ts)
+│   │   ├── AITools/               # ScriptFormatter + ExampleEmbeddings
+│   │   ├── Auth/                  # Login, registration, token management
+│   │   ├── Baker/                 # Drive scanning, breadcrumbs management
+│   │   ├── BuildProject/          # File ingest, camera assignment, XState
+│   │   ├── Premiere/              # Adobe Premiere plugin management
+│   │   ├── Settings/              # App configuration with per-domain tabs
+│   │   ├── Trello/                # Trello card management, video links
+│   │   └── Upload/                # Sprout Video, Posterframe, Otter
+│   ├── shared/                    # Cross-feature code
+│   │   ├── constants/             # Timing, animation, project constants
+│   │   ├── hooks/                 # Cross-feature hooks
+│   │   ├── lib/                   # Query infrastructure
+│   │   ├── services/              # ProgressTracker, feedback, cache
+│   │   ├── store/                 # Zustand stores (appStore, breadcrumbStore)
+│   │   ├── types/                 # Shared domain types
+│   │   ├── ui/                    # Radix primitives, sidebar, theme, layout
+│   │   └── utils/                 # Logger, storage, validation, cn()
+│   ├── App.tsx                    # Root React component
+│   └── AppRouter.tsx              # Route definitions (lazy-loaded)
 │
 ├── src-tauri/                     # Rust backend (Tauri)
 │   ├── src/
 │   │   ├── commands/              # Tauri command handlers
 │   │   │   ├── auth.rs            # User authentication (argon2 + JWT)
-│   │   │   ├── file_ops.rs        # File operations with progress tracking
 │   │   │   ├── premiere.rs        # Adobe Premiere integration
 │   │   │   ├── sprout_upload.rs   # Sprout Video API
 │   │   │   ├── docx.rs            # Word document processing
 │   │   │   ├── rag.rs             # RAG embeddings for script formatting
 │   │   │   └── ai_provider.rs     # AI provider management
+│   │   ├── baker/                 # Baker workflow logic
+│   │   ├── build_project/         # Build project file operations
 │   │   ├── state/                 # Shared state management
 │   │   ├── utils/                 # Rust utility functions
-│   │   ├── baker.rs               # Baker workflow logic
 │   │   └── media.rs               # Media file handling
 │   ├── Cargo.toml                 # Rust dependencies
 │   ├── tauri.conf.json            # Tauri app configuration
 │   └── resources/                 # Bundled resources
 │       └── embeddings/            # Pre-computed script examples database
 │
-├── specs/                         # Feature specifications (PRDs)
-│   ├── 004-embed-multiple-video/  # Multiple video links feature
-│   ├── 007-frontend-script-example/ # Script example management
-│   └── ...
 ├── tests/                         # Vitest test suite
 ├── .claude/                       # Claude Code configuration
 │   └── skills/                    # Custom Claude skills
@@ -129,15 +117,13 @@ bucket/
 
 ### Key Directories Explained
 
-**src/pages/** - Top-level page components that map to routes. Each page represents a major feature (BuildProject, Baker, AI tools, etc.). Add new pages here when creating new top-level features.
+**src/features/** - Feature modules, each self-contained with `api.ts` (I/O boundary), `index.ts` (barrel), `types.ts`, `components/`, `hooks/`, and `__contracts__/` (contract tests). All Tauri invoke calls go through `api.ts`. See CLAUDE.md for conventions.
 
-**src/components/** - Reusable UI components. Organized by feature (Baker/, trello/) or as general UI primitives (ui/). Components here should be presentational and reusable across multiple pages.
+**src/shared/** - Cross-feature code. Shared modules never import from features. Contains constants, hooks, lib (query infrastructure), services, store, types, ui (Radix primitives), and utils.
 
-**src/hooks/** - Custom React hooks that encapsulate business logic, API calls, and complex state management. Use TanStack React Query for data fetching (preferred over useEffect). Add hooks here when logic is reused across 2+ components.
+**src-tauri/src/commands/** - Rust functions exposed to the frontend via Tauri's IPC bridge. Each module represents a functional domain (authentication, AI, Premiere, etc.). Add new commands here for any Rust-side functionality.
 
-**src-tauri/src/commands/** - Rust functions exposed to the frontend via Tauri's IPC bridge. Each module represents a functional domain (file operations, authentication, AI, etc.). Add new commands here for any Rust-side functionality.
-
-**src/store/** - Zustand stores for global state management. Currently contains breadcrumbs state and app-wide settings. Prefer local state or React Query for component-specific data.
+**src/shared/store/** - Zustand stores for global state management. Currently contains breadcrumbs state and app-wide settings. Prefer local state or React Query for component-specific data.
 
 ## Key Concepts
 
@@ -323,16 +309,16 @@ Not currently used. Configuration is stored in Tauri's app data directory and ma
 
 ```bash
 # Run all tests (Vitest)
-npm run test
+bun run test
 
 # Run tests in watch mode
-npm run test:ui
+bun run test:ui
 
 # Run tests with coverage
-npm run test:coverage
+bun run test:coverage
 
 # Run tests once (CI mode)
-npm run test:run
+bun run test:run
 
 # Run Rust tests
 cd src-tauri
@@ -353,16 +339,16 @@ cargo test
 
 ```bash
 # Check formatting
-npm run prettier
+bun run prettier
 
 # Fix formatting issues
-npm run prettier:fix
+bun run prettier:fix
 
 # Check linting
-npm run eslint
+bun run eslint
 
 # Fix linting issues
-npm run eslint:fix
+bun run eslint:fix
 ```
 
 **Backend (Rust):**
@@ -389,7 +375,7 @@ Development mode includes React DevTools and TanStack Query DevTools:
 
 ```bash
 # Start with devtools open
-npm run dev:tauri
+bun run dev:tauri
 ```
 
 Open the devtools in the app window (right-click → Inspect Element)
@@ -400,10 +386,10 @@ Rust logs are output to the terminal when running in dev mode:
 
 ```bash
 # Enable detailed Rust logs
-RUST_LOG=debug npm run dev:tauri
+RUST_LOG=debug bun run dev:tauri
 
 # Enable logs for specific modules
-RUST_LOG=app_lib::commands=debug npm run dev:tauri
+RUST_LOG=app_lib::commands=debug bun run dev:tauri
 ```
 
 **Common debugging commands:**
@@ -450,7 +436,7 @@ ollama pull llama3.1:latest
 
 ### Build Errors (Missing Dependencies)
 
-**Problem:** `npm run build:tauri` fails with missing dependency errors
+**Problem:** `bun run build:tauri` fails with missing dependency errors
 
 **Solution:**
 
@@ -465,7 +451,7 @@ cargo clean
 
 # 3. Rebuild
 cd ..
-npm run build:tauri
+bun run build:tauri
 
 # 4. If still failing, check Rust version
 rustc --version  # Should be 1.70+
@@ -529,14 +515,32 @@ ProjectFolder/
 
 ## Additional Documentation
 
-- **[PREMIERE_PLUGINS.md](./PREMIERE_PLUGINS.md)** - Install and manage Premiere Pro CEP extensions
-- **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Detailed system architecture and design decisions
+### Root-level docs
+
 - **[API_COMMANDS.md](./API_COMMANDS.md)** - Complete Tauri command reference
+- **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Detailed system architecture and design decisions
+- **[BRANCHING_STRATEGY.md](./BRANCHING_STRATEGY.md)** - Git branching workflow (master + release branches)
+- **[ONBOARDING.md](./ONBOARDING.md)** - Developer onboarding guide (first-day setup)
+- **[PREMIERE_PLUGINS.md](./PREMIERE_PLUGINS.md)** - Install and manage Premiere Pro CEP extensions
 - **[apple-code-signing.md](./apple-code-signing.md)** - Apple Developer code signing and notarization setup
-- **[apple-code-signing-checklist.md](./apple-code-signing-checklist.md)** - Quick reference for code signing setup
+- **[apple-code-signing-checklist.md](./apple-code-signing-checklist.md)** - Quick reference checklist for code signing
+- **[macos-window-styling.md](./macos-window-styling.md)** - macOS native window styling and vibrancy
+- **[npm-to-bun-migration.md](./npm-to-bun-migration.md)** - Migration notes from npm to Bun
+- **[react-query-patterns.md](./react-query-patterns.md)** - TanStack React Query usage patterns
+- **[security-audit.md](./security-audit.md)** - Security audit notes and findings
+- **[theme-architecture.md](./theme-architecture.md)** - Theme system architecture (8 themes)
+- **[theme-customization.md](./theme-customization.md)** - Guide to customizing and extending themes
+
+### Subdirectories
+
+- **[readme/](./readme/)** - Sectioned README content (overview, features, installation, Ollama setup, workflow, tech stack, Premiere plugins)
+- **[ui/](./ui/)** - UI audit reports (BuildProject comprehensive audit, Tailwind audit)
+- **[ux/](./ux/)** - UX animation planning and implementation status
+
+### Project-root references
+
 - **[CLAUDE.md](../CLAUDE.md)** - Instructions for Claude Code when working with this codebase
 - **[CHANGELOG.md](../CHANGELOG.md)** - Version history and release notes
-- **[specs/](../specs/)** - Feature specifications and PRDs for each major feature
 
 ## Getting Help
 
@@ -550,6 +554,6 @@ This project is proprietary software. All rights reserved. Unauthorized copying,
 
 ---
 
-**Version:** 0.9.3
-**Last Updated:** January 2025
+**Version:** 0.16.0
+**Last Updated:** July 2026
 **Platform Support:** macOS, Windows, Linux

--- a/docs/README.md
+++ b/docs/README.md
@@ -528,7 +528,7 @@ ProjectFolder/
 - **[npm-to-bun-migration.md](./npm-to-bun-migration.md)** - Migration notes from npm to Bun
 - **[react-query-patterns.md](./react-query-patterns.md)** - TanStack React Query usage patterns
 - **[security-audit.md](./security-audit.md)** - Security audit notes and findings
-- **[theme-architecture.md](./theme-architecture.md)** - Theme system architecture (8 themes)
+- **[theme-architecture.md](./theme-architecture.md)** - Theme system architecture (13 themes)
 - **[theme-customization.md](./theme-customization.md)** - Guide to customizing and extending themes
 
 ### Subdirectories

--- a/docs/macos-window-styling.md
+++ b/docs/macos-window-styling.md
@@ -73,10 +73,10 @@ Bucket uses native macOS window styling features to provide a seamless, OS-integ
 
 #### Apply Vibrancy to Sidebar
 
-**File:** `src/components/app-sidebar.tsx`
+**File:** `src/shared/ui/layout/app-sidebar.tsx`
 
 ```typescript
-import { useMacOSEffects } from '@/hooks/useMacOSEffects'
+import { useMacOSEffects } from '@shared/hooks/useMacOSEffects'
 
 export function AppSidebar() {
   // Apply macOS sidebar vibrancy effect
@@ -95,8 +95,8 @@ export function AppSidebar() {
 **File:** `src/App.tsx`
 
 ```typescript
-import { TitleBar } from './components/TitleBar'
-import { useWindowState } from './hooks/useWindowState'
+import { TitleBar } from '@shared/ui/layout/TitleBar'
+import { useWindowState } from '@shared/hooks/useWindowState'
 
 const App: React.FC = () => {
   // Persist window position and size
@@ -117,11 +117,11 @@ const App: React.FC = () => {
 
 Apply native macOS vibrancy effects to windows.
 
-**Location:** `src/hooks/useMacOSEffects.ts`
+**Location:** `src/shared/hooks/useMacOSEffects.ts`
 
 **Usage:**
 ```typescript
-import { useMacOSEffects } from '@/hooks/useMacOSEffects'
+import { useMacOSEffects } from '@shared/hooks/useMacOSEffects'
 
 function MyComponent() {
   useMacOSEffects({
@@ -151,11 +151,11 @@ function MyComponent() {
 
 Detect and respond to macOS system theme changes.
 
-**Location:** `src/hooks/useSystemTheme.ts`
+**Location:** `src/shared/hooks/useSystemTheme.ts`
 
 **Usage:**
 ```typescript
-import { useSystemTheme } from '@/hooks/useSystemTheme'
+import { useSystemTheme } from '@shared/hooks/useSystemTheme'
 
 function MyComponent() {
   const theme = useSystemTheme()  // 'light' | 'dark' | null
@@ -174,11 +174,11 @@ function MyComponent() {
 
 Persist window position and size across sessions.
 
-**Location:** `src/hooks/useWindowState.ts`
+**Location:** `src/shared/hooks/useWindowState.ts`
 
 **Usage:**
 ```typescript
-import { useWindowState } from '@/hooks/useWindowState'
+import { useWindowState } from '@shared/hooks/useWindowState'
 
 function App() {
   useWindowState()  // Automatically saves and restores window state
@@ -193,7 +193,7 @@ function App() {
 
 Custom title bar component for macOS overlay mode.
 
-**Location:** `src/components/TitleBar.tsx`
+**Location:** `src/shared/ui/layout/TitleBar.tsx`
 
 **Features:**
 - Only renders on macOS
@@ -204,7 +204,7 @@ Custom title bar component for macOS overlay mode.
 
 **Customization:**
 ```typescript
-// Edit src/components/TitleBar.tsx to add custom elements
+// Edit src/shared/ui/layout/TitleBar.tsx to add custom elements
 <div style={{ WebkitAppRegion: 'no-drag' }}>
   {/* Add custom controls, search, etc. */}
 </div>
@@ -387,13 +387,13 @@ This provides a standard macOS window without custom styling but is App Store co
 - `src-tauri/tauri.conf.json` - Window configuration
 
 ### Components
-- `src/components/TitleBar.tsx` - Custom title bar
-- `src/components/app-sidebar.tsx` - Sidebar with vibrancy
+- `src/shared/ui/layout/TitleBar.tsx` - Custom title bar
+- `src/shared/ui/layout/app-sidebar.tsx` - Sidebar with vibrancy
 
 ### Hooks
-- `src/hooks/useMacOSEffects.ts` - Vibrancy effects
-- `src/hooks/useSystemTheme.ts` - Theme detection
-- `src/hooks/useWindowState.ts` - Window persistence
+- `src/shared/hooks/useMacOSEffects.ts` - Vibrancy effects
+- `src/shared/hooks/useSystemTheme.ts` - Theme detection
+- `src/shared/hooks/useWindowState.ts` - Window persistence
 
 ### Styles
 - `src/index.css` - Drag regions and transitions
@@ -473,7 +473,6 @@ This provides a standard macOS window without custom styling but is App Store co
 
 ### Project Documentation
 - [CLAUDE.md](../CLAUDE.md) - Project overview and conventions
-- [macos-window-styling-plan.md](../macos-window-styling-plan.md) - Implementation plan
 
 ## Maintenance
 
@@ -494,7 +493,6 @@ This provides a standard macOS window without custom styling but is App Store co
 
 ### Getting Help
 - Check this documentation first
-- Review the implementation plan: [macos-window-styling-plan.md](../macos-window-styling-plan.md)
 - Search Tauri GitHub issues
 - Ask in Tauri Discord #help channel
 - Review browser console for error messages

--- a/docs/npm-to-bun-migration.md
+++ b/docs/npm-to-bun-migration.md
@@ -1,8 +1,11 @@
 # NPM to Bun Migration Task Tracker
 
+> *Migration completed December 2025 (PR #66). Bun is now the sole package manager.
+> This document is retained as a historical record of the migration process.*
+
 **Branch:** `chore/complete-bun-migration`
 **Date Started:** 2025-12-10
-**Status:** In Progress
+**Status:** Complete
 
 ---
 

--- a/docs/react-query-patterns.md
+++ b/docs/react-query-patterns.md
@@ -20,7 +20,7 @@ This document outlines the React Query patterns and best practices implemented d
 The React Query implementation follows a layered architecture:
 
 ```
-src/
+src/shared/
 ├── lib/
 │   ├── query-utils.ts          # Core query utilities and helpers
 │   ├── query-keys.ts           # Centralized query key factory
@@ -29,13 +29,9 @@ src/
 │   └── performance-monitor.ts  # Performance monitoring
 ├── services/
 │   └── cache-invalidation.ts   # Cache management service
-├── hooks/
-│   ├── useBreadcrumb.ts       # Navigation state management
-│   ├── useTrelloBoard.ts      # Trello API integration
-│   ├── useImageRefresh.ts     # Auto-refreshing image data
-│   └── [other hooks...]       # Various domain-specific hooks
-└── components/
-    └── ErrorBoundary.tsx       # Global error handling
+└── hooks/
+    ├── useBreadcrumb.ts       # Navigation state management
+    └── [other hooks...]       # Various domain-specific hooks
 ```
 
 ### Key Principles
@@ -51,8 +47,8 @@ src/
 ### Basic Query Pattern
 
 ```typescript
-import { queryKeys } from '@lib/query-keys'
-import { createQueryError, createQueryOptions, shouldRetry } from '@lib/query-utils'
+import { queryKeys } from '@shared/lib/query-keys'
+import { createQueryError, createQueryOptions, shouldRetry } from '@shared/lib/query-utils'
 import { useQuery } from '@tanstack/react-query'
 
 function useUserData(userId: string) {

--- a/docs/readme/03-installation.md
+++ b/docs/readme/03-installation.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites
 
-- Node.js (npm) or Bun
+- Bun (required package manager)
 - Rust (for development)
 - **Ollama** (for AI Script Formatter feature) - see [Ollama Setup](#ollama-setup) below
 
@@ -19,14 +19,12 @@
 
    ```bash
    bun install
-   # or
-   npm install
    ```
 
 3. Build the application:
 
    ```bash
-   npm run build:tauri
+   bun run build:tauri
    ```
 
 4. On macOS, open the DMG file in `/target/build/dmg` and copy the app to your Applications folder.
@@ -36,5 +34,5 @@
 To run in development mode:
 
 ```bash
-npm run dev:tauri
+bun run dev:tauri
 ```

--- a/docs/readme/06-tech-stack.md
+++ b/docs/readme/06-tech-stack.md
@@ -1,6 +1,6 @@
 ## Tech Stack
 
-- **Frontend**: React 18 + TypeScript + TailwindCSS
+- **Frontend**: React 19 + TypeScript + TailwindCSS
 - **Backend**: Tauri 2.0 (Rust)
 - **UI Components**: Radix UI + Lucide icons
 - **State Management**: Zustand + TanStack React Query

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,5 +1,11 @@
 # Security Audit Process
 
+> *Historical snapshot (v0.8.1, circa December 2024). The TypeScript service classes
+> referenced below (`SecurityAuditor`, `SecurityVulnerability`, `PackageUpdateWorkflow`)
+> were never merged into the codebase. The shell script `scripts/security-audit.sh` and
+> `scripts/validate-lock-sync.sh` do exist and remain usable. Treat the service-layer
+> sections as aspirational design notes, not as documentation of shipped code.*
+
 ## Overview
 
 Bucket implements a comprehensive security audit process to identify, assess, and resolve security vulnerabilities in dependencies. This process is integrated into the package update workflow and follows security-first principles.

--- a/docs/theme-architecture.md
+++ b/docs/theme-architecture.md
@@ -24,49 +24,40 @@ This document explains the multi-theme system architecture in Bucket, designed f
 ## File Structure
 
 ```
+src/shared/ui/theme/
+├── themes.ts                          # Theme metadata registry
+├── ThemeSelector.tsx                   # Main theme selector UI
+├── ThemeColorSwatch.tsx               # Color preview component
+├── theme-toggle.tsx                   # Quick theme toggle
+├── useThemePreview.ts                 # Live preview functionality
+├── themeMapper.ts                     # Legacy migration utilities
+├── themeLoader.ts                     # Custom theme loader (future)
+└── customTheme.ts                     # Custom theme type definitions
+
 src/
-├── constants/
-│   └── themes.ts                      # Theme metadata registry
-├── components/
-│   └── Settings/
-│       ├── ThemeSelector.tsx          # Main theme selector UI
-│       ├── ThemeColorSwatch.tsx       # Color preview component
-│       └── ThemeImport.tsx            # Custom theme import (stub)
-├── hooks/
-│   └── useThemePreview.ts             # Live preview functionality
-├── utils/
-│   ├── themeMapper.ts                 # Legacy migration utilities
-│   └── themeLoader.ts                 # Custom theme loader (future)
-├── types/
-│   └── customTheme.ts                 # Custom theme type definitions
 ├── index.css                           # Theme CSS variables
 └── App.tsx                            # ThemeProvider configuration
 
 docs/
 ├── theme-customization.md             # User documentation
 └── theme-architecture.md              # This file
-
-tests/
-└── unit/
-    ├── constants/themes.test.ts       # Theme registry tests
-    ├── utils/themeMapper.test.ts      # Migration utility tests
-    └── components/Settings/
-        ├── ThemeSelector.test.tsx     # Component tests
-        └── ThemeColorSwatch.test.tsx  # Swatch tests
 ```
 
 ---
 
 ## Core Components
 
-### 1. Theme Registry ([themes.ts](../src/constants/themes.ts))
+### 1. Theme Registry ([themes.ts](../src/shared/ui/theme/themes.ts))
 
 Central source of truth for all theme metadata.
 
 **Key Exports:**
 ```typescript
-export type ThemeId = 'system' | 'light' | 'dark' | 'dracula' | ...
-export interface ThemeMetadata { id, name, description, category, colorSwatch, author, isDark }
+export type ThemeId =
+  | 'system' | 'light' | 'dark' | 'dracula' | 'tokyo-night'
+  | 'catppuccin-latte' | 'catppuccin-frappe' | 'catppuccin-macchiato' | 'catppuccin-mocha'
+  | 'solarized-light' | 'github-light' | 'nord-light' | 'one-light'
+export interface ThemeMetadata { id, name, description, category, colorSwatch, author?, isDark }
 export const THEMES: Record<ThemeId, ThemeMetadata>
 export function getAllThemeIds(): ThemeId[]
 export function getThemeById(id: string): ThemeMetadata | undefined
@@ -76,7 +67,7 @@ export function getGroupedThemes(): ThemeGroup[]
 
 **Usage:**
 ```typescript
-import { THEMES, getGroupedThemes } from '@/constants/themes'
+import { THEMES, getGroupedThemes } from '@shared/ui/theme/themes'
 
 // Get theme info
 const dracula = THEMES.dracula
@@ -93,11 +84,13 @@ const groups = getGroupedThemes()
 <ThemeProvider
   attribute="class"              // Apply theme via class name
   defaultTheme="system"          // Default to system preference
-  themes={[                      // Explicitly list all themes
+  themes={[                      // Explicitly list all 13 themes
     'system', 'light', 'dark',
-    'dracula',
+    'dracula', 'tokyo-night',
     'catppuccin-latte', 'catppuccin-frappe',
-    'catppuccin-macchiato', 'catppuccin-mocha'
+    'catppuccin-macchiato', 'catppuccin-mocha',
+    'solarized-light', 'github-light',
+    'nord-light', 'one-light'
   ]}
   enableSystem                   // Allow system theme detection
   storageKey="theme"             // LocalStorage key
@@ -125,7 +118,7 @@ const groups = getGroupedThemes()
   .dark { /* Dark theme overrides */ }
   .dracula { /* Dracula theme overrides */ }
   .catppuccin-latte { /* Latte theme overrides */ }
-  /* ...5 more themes */
+  /* ...9 more themes */
 }
 ```
 
@@ -146,7 +139,7 @@ const groups = getGroupedThemes()
 </div>
 ```
 
-### 4. ThemeSelector Component ([ThemeSelector.tsx](../src/components/Settings/ThemeSelector.tsx))
+### 4. ThemeSelector Component ([ThemeSelector.tsx](../src/shared/ui/theme/ThemeSelector.tsx))
 
 **Features:**
 - Radix UI Select dropdown
@@ -166,12 +159,12 @@ interface ThemeSelectorProps {
 
 **Integration:**
 ```tsx
-import { ThemeSelector } from '@/components/Settings/ThemeSelector'
+import { ThemeSelector } from '@shared/ui/theme/ThemeSelector'
 
 <ThemeSelector label="Theme" />
 ```
 
-### 5. Live Preview Hook ([useThemePreview.ts](../src/hooks/useThemePreview.ts))
+### 5. Live Preview Hook ([useThemePreview.ts](../src/shared/ui/theme/useThemePreview.ts))
 
 **Purpose:** Temporarily apply a theme on hover without persisting it.
 
@@ -196,7 +189,7 @@ stopPreview() // Restores 'dark' theme
 4. Adds preview theme class (e.g., `.dracula`)
 5. On mouse leave, restores original theme class
 
-### 6. Theme Color Swatch ([ThemeColorSwatch.tsx](../src/components/Settings/ThemeColorSwatch.tsx))
+### 6. Theme Color Swatch ([ThemeColorSwatch.tsx](../src/shared/ui/theme/ThemeColorSwatch.tsx))
 
 **Purpose:** Visual preview of theme colors (4-color bar).
 
@@ -273,7 +266,7 @@ In `src/index.css`, add a new class selector:
 
 ### Step 2: Add to Theme Registry
 
-In `src/constants/themes.ts`:
+In `src/shared/ui/theme/themes.ts`:
 
 ```typescript
 export type ThemeId =
@@ -281,10 +274,15 @@ export type ThemeId =
   | 'light'
   | 'dark'
   | 'dracula'
+  | 'tokyo-night'
   | 'catppuccin-latte'
   | 'catppuccin-frappe'
   | 'catppuccin-macchiato'
   | 'catppuccin-mocha'
+  | 'solarized-light'
+  | 'github-light'
+  | 'nord-light'
+  | 'one-light'
   | 'my-new-theme' // Add here
 
 export const THEMES: Record<ThemeId, ThemeMetadata> = {
@@ -313,9 +311,10 @@ In `src/App.tsx`:
 ```tsx
 <ThemeProvider
   themes={[
-    'system', 'light', 'dark', 'dracula',
+    'system', 'light', 'dark', 'dracula', 'tokyo-night',
     'catppuccin-latte', 'catppuccin-frappe',
     'catppuccin-macchiato', 'catppuccin-mocha',
+    'solarized-light', 'github-light', 'nord-light', 'one-light',
     'my-new-theme' // Add here
   ]}
   ...
@@ -327,9 +326,9 @@ In `src/App.tsx`:
 In `tests/unit/constants/themes.test.ts`:
 
 ```typescript
-it('contains all 9 themes', () => { // Update count
+it('contains all 14 themes', () => { // Update count
   const themeIds = Object.keys(THEMES)
-  expect(themeIds).toHaveLength(9)
+  expect(themeIds).toHaveLength(14)
   expect(themeIds).toContain('my-new-theme')
 })
 ```
@@ -344,7 +343,7 @@ Update `docs/theme-customization.md` with theme details.
 
 ### Architecture (Already in Place)
 
-**Type Definition** (`src/types/customTheme.ts`):
+**Type Definition** (`src/shared/ui/theme/customTheme.ts`):
 ```typescript
 export interface CustomThemeDefinition {
   id: string
@@ -356,7 +355,7 @@ export interface CustomThemeDefinition {
 }
 ```
 
-**Theme Loader** (`src/utils/themeLoader.ts`):
+**Theme Loader** (`src/shared/ui/theme/themeLoader.ts`):
 ```typescript
 export function loadCustomTheme(theme: CustomThemeDefinition): { success: boolean, error?: string }
 export function saveCustomThemesToStorage(themes: CustomThemeDefinition[]): void
@@ -375,7 +374,7 @@ export const CustomThemeSchema = z.object({
 
 ### Implementation Plan (When Ready)
 
-1. **UI Component**: Complete `ThemeImport.tsx` with file picker
+1. **UI Component**: Create a `ThemeImport.tsx` component with file picker
 2. **Validation**: Use Zod schema to validate JSON imports
 3. **Dynamic CSS Injection**: Use `themeLoader.loadCustomTheme()`
 4. **Persistence**: Save to localStorage under `bucket-custom-themes`
@@ -389,7 +388,7 @@ export const CustomThemeSchema = z.object({
 
 Users upgrading from old versions have their themes automatically migrated:
 
-**themeMapper.ts:**
+**src/shared/ui/theme/themeMapper.ts:**
 ```typescript
 export function migrateLegacyTheme(legacyThemeId: string): ThemeId {
   const migrations: Record<string, ThemeId> = {
@@ -443,7 +442,7 @@ bun test ThemeColorSwatch
 ### Manual Testing Checklist
 
 - [ ] Theme selector appears in Settings → Appearance
-- [ ] All 8 themes listed with correct names
+- [ ] All 13 themes listed with correct names
 - [ ] Color swatches display for each theme
 - [ ] Live preview works on hover
 - [ ] Theme persists after page refresh
@@ -514,7 +513,6 @@ bun test ThemeColorSwatch
 6. **Font Size Themes**: Accessibility presets
 
 ### Extension Points
-- `ThemeImport.tsx`: Stubbed for future implementation
 - `themeLoader.ts`: Fully functional custom theme loader
 - `customTheme.ts`: Type definitions ready
 - localStorage: Architecture supports unlimited custom themes
@@ -580,8 +578,9 @@ function initializeCustomThemes(): void
 
 ## Changelog
 
-### v0.11.0 (Current)
+### v0.11.0
 - ✨ Added 8-theme system (System, Light, Dark, Dracula, 4x Catppuccin)
+- ✨ Later expanded to 13 themes (added Tokyo Night, Solarized Light, GitHub Light, Nord Light, One Light)
 - ✨ Live preview on hover
 - ✨ Color swatches in theme selector
 - ✨ Settings → Appearance section

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -1,6 +1,6 @@
 # Theme Customization Guide
 
-Bucket supports multiple color themes to personalize your workspace. Choose from 8 beautiful themes including light, dark, and specialty themes like Dracula and Catppuccin variants.
+Bucket supports multiple color themes to personalize your workspace. Choose from 13 built-in themes including light, dark, and specialty themes like Dracula, Tokyo Night, Catppuccin variants, Solarized Light, GitHub Light, Nord Light, and One Light.
 
 ## Available Themes
 
@@ -21,6 +21,30 @@ Bucket supports multiple color themes to personalize your workspace. Choose from
 - **Best For**: Reduced eye strain in bright environments
 - **Author**: Catppuccin
 
+#### Solarized Light
+- **Description**: Classic warm theme with cream tones and blue accents
+- **Colors**: Cream background, dark teal text, blue and cyan accents
+- **Best For**: Extended reading and editing sessions
+- **Author**: Ethan Schoonover
+
+#### GitHub Light
+- **Description**: Clean minimal theme inspired by GitHub
+- **Colors**: White background, dark gray text, blue and green accents
+- **Best For**: Familiar GitHub-style coding environment
+- **Author**: GitHub
+
+#### Nord Light
+- **Description**: Cool arctic-inspired theme with muted tones
+- **Colors**: Light gray background, dark text, muted blue accents
+- **Best For**: Calm, distraction-free working
+- **Author**: Arctic Ice Studio
+
+#### One Light
+- **Description**: Atom editor's popular warm light theme
+- **Colors**: Off-white background, dark gray text, blue and purple accents
+- **Best For**: Atom editor fans
+- **Author**: Atom
+
 ### Dark Themes
 
 #### Dark
@@ -33,6 +57,12 @@ Bucket supports multiple color themes to personalize your workspace. Choose from
 - **Colors**: Dark gray background, purple primary, pink accents, cyan highlights
 - **Best For**: High contrast lovers, vibrant color enthusiasts
 - **Author**: Zeno Rocha
+
+#### Tokyo Night
+- **Description**: Deep blue dark theme inspired by Tokyo at night
+- **Colors**: Deep blue background, soft blue-gray text, cyan and blue accents
+- **Best For**: Fans of deep blue-toned dark themes
+- **Author**: enkia
 
 #### Catppuccin Frappé
 - **Description**: Medium-dark theme with cool blue-gray tones
@@ -172,7 +202,7 @@ The architecture is already in place. Stay tuned for this feature!
 ### Theme Storage
 - Location: `localStorage` key `"theme"`
 - Format: String (theme ID)
-- Values: `"system"`, `"light"`, `"dark"`, `"dracula"`, `"catppuccin-latte"`, `"catppuccin-frappe"`, `"catppuccin-macchiato"`, `"catppuccin-mocha"`
+- Values: `"system"`, `"light"`, `"dark"`, `"dracula"`, `"tokyo-night"`, `"catppuccin-latte"`, `"catppuccin-frappe"`, `"catppuccin-macchiato"`, `"catppuccin-mocha"`, `"solarized-light"`, `"github-light"`, `"nord-light"`, `"one-light"`
 
 ### CSS Variables
 All themes use CSS custom properties (variables) defined in `src/index.css`:
@@ -184,15 +214,21 @@ All themes use CSS custom properties (variables) defined in `src/index.css`:
 
 ### Theme Classes
 Themes are applied via class names on the `<html>` element:
-- `.light`, `.dark`, `.dracula`
+- `.light`, `.dark`, `.dracula`, `.tokyo-night`
 - `.catppuccin-latte`, `.catppuccin-frappe`, `.catppuccin-macchiato`, `.catppuccin-mocha`
+- `.solarized-light`, `.github-light`, `.nord-light`, `.one-light`
 
 ---
 
 ## Credits
 
 - **Dracula**: Created by [Zeno Rocha](https://github.com/dracula/dracula-theme)
+- **Tokyo Night**: Created by [enkia](https://github.com/enkia/tokyo-night-vscode-theme)
 - **Catppuccin**: Created by the [Catppuccin team](https://github.com/catppuccin/catppuccin)
+- **Solarized**: Created by [Ethan Schoonover](https://ethanschoonover.com/solarized/)
+- **Nord**: Created by [Arctic Ice Studio](https://www.nordtheme.com/)
+- **One Light**: Inspired by [Atom](https://github.com/atom/one-light-syntax)
+- **GitHub Light**: Inspired by [GitHub](https://github.com)
 - **Light/Dark**: Custom themes by the Bucket team
 
 ---


### PR DESCRIPTION
## Summary

Reevaluates and updates all project documentation — README, CLAUDE.md, CHANGELOG, and the `docs/` directory — verifying every claim against the code at v0.16.0. Most docs were frozen at the March module refactor and predated the Baker UI refresh (#117), Trello self-assign (#122), and the React 19 / Vite 7 stack upgrades.

### What changed
- **README.md** — full rewrite. Blueprint-generator markup removed (the tool was deleted in #125), stack corrected to React 19.2 / TS 5.9 / Vite 7.3 / Tailwind 4, only real package.json scripts documented, platform claim fixed to macOS-primary, "Getting Bucket" points at actual GitHub Releases.
- **CLAUDE.md** — 17 corrections: main branch is `master` (was `main`), stack versions, all 15 barrel-export counts re-counted, theme count (13), dependency map verified.
- **CHANGELOG.md** — reconstructed 24 missing releases (0.8.2 → 0.16.0) from version-bump commits and merged PRs; it previously stopped at 0.8.1 (Dec 2024). Versions 0.9.3 / 0.11.0 / 0.12.1 / 0.14.6 never shipped and are intentionally absent.
- **docs/API_COMMANDS.md** — rewritten to match the actual `generate_handler!` registration: 50 commands (was 15), 6 dead commands removed, 3 wrong signatures corrected, 37 missing commands documented.
- **docs/ARCHITECTURE.md** — 17 corrections: directory tree rewritten for the feature-module layout, BuildProject/AI flows updated to real command names, React Query examples moved to the api.ts + queryKeys pattern.
- **docs/ONBOARDING.md + docs/README.md index** — npm → bun throughout, feature-module paths, PR target `master`, dead `specs/` references removed, index now matches actual docs/ contents.
- **Misc docs** — theme docs updated for the 13-theme set, react-query-patterns alias fixes, window-styling paths, PREMIERE_PLUGINS bun command; dated historical banners on security-audit.md and PRD.md; code-signing and branching docs verified accurate as-is.

### Verification
A final adversarial fact-check pass independently re-verified: all commands vs package.json, all cited file paths, 10 sampled Tauri command signatures vs the Rust source, version claims, 4 re-counted barrel exports, internal cross-links, 3 changelog dates vs git evidence, `master` branch consistency, and zero remaining npm instructions. The two errors it found (stale 8-theme claims) are fixed in the final commit.

### Follow-up candidates (not touched, per query-first rule)
`docs/readme/` (7 unreferenced README fragments), `docs/ui/` (3 Dec-2025 audit reports), `docs/ux/` (2 completed UX plans) are stale and referenced by nothing — deletion candidates for a future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)