### PR TITLE
fix(build-project): skip file transfer stage for zero-footage projects

### DIFF
--- a/src/features/build-project/__tests__/buildProjectMachine.test.ts
+++ b/src/features/build-project/__tests__/buildProjectMachine.test.ts
@@ -301,6 +301,70 @@ describe('BuildProject State Machine', () => {
   })
 
   // ============================================================================
+  // Zero-Footage Workflow (skip file transfer)
+  // ============================================================================
+
+  describe('zero-footage workflow', () => {
+    it('should reach success without entering transferringFiles when no files are added', async () => {
+      vi.mocked(exists).mockResolvedValue(false)
+      vi.mocked(mkdir).mockResolvedValue(undefined)
+      vi.mocked(invoke).mockResolvedValue(undefined)
+      vi.mocked(writeTextFile).mockResolvedValue(undefined)
+      // User confirms the "no files added" dialog during validation
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const actor = createActor(buildProjectMachine)
+      actor.start()
+
+      const visitedStates: string[] = []
+      actor.subscribe((snapshot) => {
+        visitedStates.push(String(snapshot.value))
+      })
+
+      actor.send({ type: 'START', input: createValidInput({ files: [] }) })
+
+      await waitForState(actor, 'success')
+
+      const finalState = actor.getSnapshot()
+      expect(finalState.value).toBe('success')
+      expect(finalState.context.currentStage).toBe('success')
+      expect(finalState.context.progress).toBe(100)
+      expect(finalState.context.error).toBeNull()
+
+      // The transfer stage must be skipped entirely
+      expect(visitedStates).not.toContain('transferringFiles')
+      expect(vi.mocked(invoke)).not.toHaveBeenCalledWith(
+        'transfer_files_with_progress',
+        expect.anything()
+      )
+
+      actor.stop()
+    })
+
+    it('should still write breadcrumbs with an empty files array', async () => {
+      vi.mocked(exists).mockResolvedValue(false)
+      vi.mocked(mkdir).mockResolvedValue(undefined)
+      vi.mocked(invoke).mockResolvedValue(undefined)
+      vi.mocked(writeTextFile).mockResolvedValue(undefined)
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const actor = createActor(buildProjectMachine)
+      actor.start()
+
+      actor.send({ type: 'START', input: createValidInput({ files: [] }) })
+
+      await waitForState(actor, 'success')
+
+      const breadcrumbs = actor.getSnapshot().context.breadcrumbs
+      expect(breadcrumbs).not.toBeNull()
+      expect(breadcrumbs?.files).toEqual([])
+      expect(vi.mocked(writeTextFile)).toHaveBeenCalled()
+
+      actor.stop()
+    })
+  })
+
+  // ============================================================================
   // Error Handling and Transitions
   // ============================================================================
 

--- a/src/features/build-project/machine/buildProjectMachine.ts
+++ b/src/features/build-project/machine/buildProjectMachine.ts
@@ -364,7 +364,11 @@ export const buildProjectMachine = setup({
   },
   guards: {
     hasRetryableError: ({ context }) =>
-      context.error !== null && context.error !== 'Project creation cancelled by user.'
+      context.error !== null && context.error !== 'Project creation cancelled by user.',
+    // Zero-footage projects are valid (validateInput confirms with the user),
+    // but the transfer stage treats an empty file list as an error — so it
+    // must be skipped entirely when there is nothing to transfer.
+    hasNoFiles: ({ context }) => context.files.length === 0
   }
 }).createMachine({
   id: 'buildProject',
@@ -499,10 +503,19 @@ export const buildProjectMachine = setup({
           projectFolder: context.projectFolder!,
           breadcrumbs: context.breadcrumbs!
         }),
-        onDone: {
-          target: 'transferringFiles',
-          actions: assign({ currentStage: 'transferringFiles' as const })
-        },
+        onDone: [
+          {
+            // No footage to transfer — the project is already complete on disk
+            // (folders, template, breadcrumbs), so go straight to success.
+            guard: 'hasNoFiles',
+            target: 'success',
+            actions: 'markSuccess'
+          },
+          {
+            target: 'transferringFiles',
+            actions: assign({ currentStage: 'transferringFiles' as const })
+          }
+        ],
         onError: {
           target: 'error',
           actions: assign({


### PR DESCRIPTION
## Summary

Fixes #131.

Creating a project in **Build a Project** with no footage files (an explicitly supported flow — `validateInput` asks the user to confirm) created the project fully on disk but the UI never showed completion: the progress bar stalled at 80%, an error toast `No files provided for transfer` appeared, and the success section never rendered.

**Root cause:** the state machine unconditionally chained `savingBreadcrumbs → transferringFiles`, and `transferFiles()` treats an empty file list as a hard validation failure, sending the machine to `error` instead of `success`.

## Changes

- Add a `hasNoFiles` guard to `buildProjectMachine` and branch the `savingBreadcrumbs` `onDone` transition: with zero files the machine skips `transferringFiles` and goes straight to `success` (via `markSuccess`, so progress hits 100).
- Keep the empty-list validation inside `transferFiles()`/`startTransfer()` as a defensive check for direct callers.
- Add machine tests: zero-footage build reaches `success` with `progress === 100` and no error, never enters `transferringFiles`, never invokes `transfer_files_with_progress`, and still writes `breadcrumbs.json` with an empty `files` array.

## Testing

- `bun run test -- src/features/build-project` — 350/350 pass (includes 2 new tests)
- `bun run eslint` — 0 errors
- `bun run prettier` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)