### PR TITLE
feat: custom Sprout video title at upload + optional Trello card rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Bucket project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-07-21
+
+### Added
+
+- Sprout Video uploads now accept a custom video title, prefilled from the filename
+  and editable before upload, in both Baker's Add Video dialog (Upload File tab) and
+  the standalone Upload → Sprout page — filenames often don't match the final video
+  name
+- When updating Trello cards after an upload, an optional checkbox renames the
+  card(s) to match the Sprout video title with a duration suffix, e.g.
+  "My Video (1:30mins)" (or "(1:02:05hrs)" for videos over an hour); shown only when
+  the name would actually change and only applied if the card update succeeds
+- Local MP4/MOV duration probe (new `get_video_duration` Tauri command) used as a
+  fallback for the duration suffix while Sprout is still processing the upload
+
+---
+
 ## [0.16.2] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.16.2"
+version = "0.17.0"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod premiere;
 pub mod rag;
 pub mod sprout_upload;
 pub mod system;
+pub mod video_meta;
 
 pub use ai_provider::*;
 pub use auth::*;
@@ -15,6 +16,7 @@ pub use premiere::*;
 pub use rag::*;
 pub use sprout_upload::*;
 pub use system::*;
+pub use video_meta::*;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/commands/sprout_upload.rs
+++ b/src-tauri/src/commands/sprout_upload.rs
@@ -45,9 +45,10 @@ pub fn upload_video(
     file_path: String,
     api_key: String,
     folder_id: Option<String>,
+    title: Option<String>,
 ) {
     tauri::async_runtime::spawn(async move {
-        match upload_video_task(app_handle, file_path, api_key, folder_id).await {
+        match upload_video_task(app_handle, file_path, api_key, folder_id, title).await {
             Ok(_) => println!("Upload successful"),
             Err(err) => println!("Upload failed: {}", err),
         }
@@ -107,6 +108,7 @@ async fn upload_video_task(
     file_path: String,
     api_key: String,
     folder_id: Option<String>,
+    title: Option<String>,
 ) -> Result<(), String> {
     // Open the file
     let file = File::open(&file_path).map_err(|e| e.to_string())?;
@@ -168,6 +170,13 @@ async fn upload_video_task(
     // If a folder_id was provided, add it as a text field.
     if let Some(fid) = folder_id {
         form = form.text("folder_id", fid);
+    }
+    // If a title was provided, send it so Sprout doesn't derive one from the filename.
+    if let Some(t) = title {
+        let trimmed = t.trim().to_string();
+        if !trimmed.is_empty() {
+            form = form.text("title", trimmed);
+        }
     }
 
     println!("Starting upload to SproutVideo...");

--- a/src-tauri/src/commands/video_meta.rs
+++ b/src-tauri/src/commands/video_meta.rs
@@ -1,0 +1,187 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use tauri::command;
+
+/// Reads the duration (in seconds) of a local MP4/MOV file by parsing the
+/// `moov/mvhd` box directly, avoiding any external media dependencies.
+/// Used as a fallback when Sprout Video has not finished processing an
+/// upload and cannot report a duration yet.
+#[command]
+pub fn get_video_duration(file_path: String) -> Result<f64, String> {
+    let mut file = File::open(&file_path).map_err(|e| e.to_string())?;
+    let file_size = file.metadata().map_err(|e| e.to_string())?.len();
+    read_mvhd_duration(&mut file, file_size)
+}
+
+struct BoxHeader {
+    box_type: [u8; 4],
+    payload_start: u64,
+    payload_end: u64,
+}
+
+/// Reads one ISO BMFF box header at `offset`, returning None when fewer than
+/// 8 bytes remain before `end`.
+fn read_box_header<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    end: u64,
+) -> Result<Option<BoxHeader>, String> {
+    if offset + 8 > end {
+        return Ok(None);
+    }
+    reader
+        .seek(SeekFrom::Start(offset))
+        .map_err(|e| e.to_string())?;
+    let mut header = [0u8; 8];
+    reader.read_exact(&mut header).map_err(|e| e.to_string())?;
+
+    let size32 = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as u64;
+    let mut box_type = [0u8; 4];
+    box_type.copy_from_slice(&header[4..8]);
+
+    // size == 1 means a 64-bit "largesize" follows; size == 0 means the box
+    // extends to the end of the enclosing container.
+    let (size, header_len) = match size32 {
+        1 => {
+            let mut large = [0u8; 8];
+            reader.read_exact(&mut large).map_err(|e| e.to_string())?;
+            (u64::from_be_bytes(large), 16u64)
+        }
+        0 => (end - offset, 8u64),
+        n => (n, 8u64),
+    };
+
+    if size < header_len || offset + size > end {
+        return Err("Malformed box header".to_string());
+    }
+
+    Ok(Some(BoxHeader {
+        box_type,
+        payload_start: offset + header_len,
+        payload_end: offset + size,
+    }))
+}
+
+fn find_box<R: Read + Seek>(
+    reader: &mut R,
+    mut offset: u64,
+    end: u64,
+    name: &[u8; 4],
+) -> Result<BoxHeader, String> {
+    while let Some(header) = read_box_header(reader, offset, end)? {
+        offset = header.payload_end;
+        if &header.box_type == name {
+            return Ok(header);
+        }
+    }
+    Err(format!(
+        "'{}' box not found",
+        String::from_utf8_lossy(name)
+    ))
+}
+
+fn read_mvhd_duration<R: Read + Seek>(reader: &mut R, file_size: u64) -> Result<f64, String> {
+    let moov = find_box(reader, 0, file_size, b"moov")?;
+    let mvhd = find_box(reader, moov.payload_start, moov.payload_end, b"mvhd")?;
+
+    let payload_len = (mvhd.payload_end - mvhd.payload_start) as usize;
+    let mut payload = vec![0u8; payload_len];
+    reader
+        .seek(SeekFrom::Start(mvhd.payload_start))
+        .map_err(|e| e.to_string())?;
+    reader.read_exact(&mut payload).map_err(|e| e.to_string())?;
+
+    // mvhd layout after version(1)+flags(3):
+    //   v0: creation u32, modification u32, timescale u32, duration u32
+    //   v1: creation u64, modification u64, timescale u32, duration u64
+    let version = *payload.first().ok_or("Empty mvhd box")?;
+    let (timescale, duration) = match version {
+        1 => {
+            if payload.len() < 32 {
+                return Err("mvhd box too short".to_string());
+            }
+            (
+                u32::from_be_bytes(payload[20..24].try_into().unwrap()),
+                u64::from_be_bytes(payload[24..32].try_into().unwrap()),
+            )
+        }
+        _ => {
+            if payload.len() < 20 {
+                return Err("mvhd box too short".to_string());
+            }
+            (
+                u32::from_be_bytes(payload[12..16].try_into().unwrap()),
+                u32::from_be_bytes(payload[16..20].try_into().unwrap()) as u64,
+            )
+        }
+    };
+
+    if timescale == 0 || duration == 0 {
+        return Err("Video duration not available in file metadata".to_string());
+    }
+
+    Ok(duration as f64 / timescale as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn boxed(name: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&((payload.len() as u32) + 8).to_be_bytes());
+        out.extend_from_slice(name);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn mvhd_v0(timescale: u32, duration: u32) -> Vec<u8> {
+        let mut payload = vec![0u8; 20];
+        payload[12..16].copy_from_slice(&timescale.to_be_bytes());
+        payload[16..20].copy_from_slice(&duration.to_be_bytes());
+        boxed(b"mvhd", &payload)
+    }
+
+    fn mvhd_v1(timescale: u32, duration: u64) -> Vec<u8> {
+        let mut payload = vec![0u8; 32];
+        payload[0] = 1;
+        payload[20..24].copy_from_slice(&timescale.to_be_bytes());
+        payload[24..32].copy_from_slice(&duration.to_be_bytes());
+        boxed(b"mvhd", &payload)
+    }
+
+    #[test]
+    fn reads_version_0_duration() {
+        // ftyp precedes moov, as in real files
+        let mut data = boxed(b"ftyp", &[0u8; 8]);
+        data.extend(boxed(b"moov", &mvhd_v0(600, 54_000))); // 90 seconds
+        let len = data.len() as u64;
+        let result = read_mvhd_duration(&mut Cursor::new(data), len).unwrap();
+        assert!((result - 90.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn reads_version_1_duration() {
+        let mut data = boxed(b"mdat", &[0u8; 16]);
+        data.extend(boxed(b"moov", &mvhd_v1(1000, 3_725_000))); // 3725 seconds
+        let len = data.len() as u64;
+        let result = read_mvhd_duration(&mut Cursor::new(data), len).unwrap();
+        assert!((result - 3725.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn errors_when_moov_missing() {
+        let data = boxed(b"mdat", &[0u8; 16]);
+        let len = data.len() as u64;
+        assert!(read_mvhd_duration(&mut Cursor::new(data), len).is_err());
+    }
+
+    #[test]
+    fn errors_on_zero_duration() {
+        let mut data = Vec::new();
+        data.extend(boxed(b"moov", &mvhd_v0(600, 0)));
+        let len = data.len() as u64;
+        assert!(read_mvhd_duration(&mut Cursor::new(data), len).is_err());
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,6 +74,8 @@ fn main() {
             fetch_trello_boards,
             // Feature 004 Phase 2: Sprout Video URL auto-fetch
             fetch_sprout_video_details,
+            // Sprout title + Trello rename: local duration fallback probe
+            get_video_duration,
             // Feature 006: AI-Powered Autocue Script Formatter
             parse_docx_file,
             generate_docx_file,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/Baker/components/AddVideoDialog.tsx
+++ b/src/features/Baker/components/AddVideoDialog.tsx
@@ -115,7 +115,7 @@ export function AddVideoDialog({
 
           {/* Upload File Tab */}
           <TabsContent value="upload" className="space-y-4 py-4">
-            <UploadContent uploadMode={uploadMode} urlMode={urlMode} />
+            <UploadContent uploadMode={uploadMode} urlMode={urlMode} form={form} />
           </TabsContent>
         </Tabs>
 
@@ -269,10 +269,12 @@ function UrlEntryContent({
 // Sub-component for upload content
 function UploadContent({
   uploadMode,
-  urlMode
+  urlMode,
+  form
 }: {
   uploadMode: UploadModeState
   urlMode: UrlModeState
+  form: FormState
 }) {
   return (
     <div className="space-y-4">
@@ -299,6 +301,23 @@ function UploadContent({
           </p>
         )}
       </div>
+
+      {uploadMode.selectedFile && (
+        <div className="space-y-2">
+          <Label htmlFor="upload-video-title">Video Title</Label>
+          <Input
+            id="upload-video-title"
+            placeholder="Video title on Sprout Video"
+            value={form.formData.title}
+            onChange={(e) => form.onFormFieldChange('title', e.target.value)}
+            maxLength={200}
+            disabled={uploadMode.uploading || uploadMode.uploadSuccess}
+          />
+          <p className="text-muted-foreground text-xs">
+            Used as the video title on Sprout Video. Leave blank to use the filename.
+          </p>
+        </div>
+      )}
 
       {!urlMode.hasApiKey && (
         <Alert>

--- a/src/features/Baker/components/VideoLinksManager.test.tsx
+++ b/src/features/Baker/components/VideoLinksManager.test.tsx
@@ -201,6 +201,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       selectedFile: null,
       uploading: false,
       response: null,
+      localDuration: null,
       selectFile: mockSelectFile,
       uploadFile: mockUploadFile,
       resetUploadState: mockResetUploadState
@@ -336,6 +337,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -438,6 +440,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -486,6 +489,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -581,6 +585,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1107,6 +1112,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1139,6 +1145,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1168,6 +1175,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1198,6 +1206,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1231,6 +1240,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1258,6 +1268,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState
@@ -1371,6 +1382,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         selectedFile: '/test/video.mp4',
         uploading: false,
         response: null,
+        localDuration: null,
         selectFile: mockSelectFile,
         uploadFile: mockUploadFile,
         resetUploadState: mockResetUploadState

--- a/src/features/Baker/components/VideoLinksManager.tsx
+++ b/src/features/Baker/components/VideoLinksManager.tsx
@@ -55,6 +55,9 @@ export function VideoLinksManager({ projectPath }: VideoLinksManagerProps) {
     setIsTrelloDialogOpen,
     addMode,
 
+    // Trello card rename proposal
+    renameProposal,
+
     // Loading states
     isUpdating,
     isFetchingVideo,
@@ -192,6 +195,7 @@ export function VideoLinksManager({ projectPath }: VideoLinksManagerProps) {
         trelloCards={trelloCards}
         onUpdate={handleTrelloCardUpdate}
         onAddTrelloCard={handleAddTrelloCard}
+        proposedCardName={renameProposal}
       />
 
       {/* Remove video link confirmation dialog */}

--- a/src/features/Trello/components/TrelloCardUpdateDialog.test.tsx
+++ b/src/features/Trello/components/TrelloCardUpdateDialog.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for TrelloCardUpdateDialog — card selection and the optional
+ * rename-to-video-title checkbox
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { TrelloCard } from '@shared/types'
+
+import { TrelloCardUpdateDialog } from './TrelloCardUpdateDialog'
+
+const cards: TrelloCard[] = [
+  {
+    url: 'https://trello.com/c/abc123/my-card',
+    cardId: 'abc123',
+    title: 'Old Card Name',
+    boardName: 'Production'
+  }
+]
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  trelloCards: cards,
+  onAddTrelloCard: vi.fn()
+}
+
+describe('TrelloCardUpdateDialog', () => {
+  it('hides the rename option when no proposed name is given', () => {
+    render(<TrelloCardUpdateDialog {...baseProps} onUpdate={vi.fn()} />)
+
+    expect(screen.queryByText(/rename card/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the rename option with the proposed name, unticked by default', () => {
+    render(
+      <TrelloCardUpdateDialog
+        {...baseProps}
+        onUpdate={vi.fn()}
+        proposedCardName="My Video (1:30mins)"
+      />
+    )
+
+    expect(screen.getByText(/rename card/i)).toBeInTheDocument()
+    expect(screen.getByText('My Video (1:30mins)')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /rename card/i })).not.toBeChecked()
+  })
+
+  it('passes renameToVideoTitle: false when the checkbox is left unticked', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TrelloCardUpdateDialog
+        {...baseProps}
+        onUpdate={onUpdate}
+        proposedCardName="My Video (1:30mins)"
+      />
+    )
+
+    // Select the card via its checkbox (first in the list)
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[0])
+    fireEvent.click(screen.getByRole('button', { name: /update 1 card/i }))
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith([0], { renameToVideoTitle: false })
+    )
+  })
+
+  it('passes renameToVideoTitle: true when the checkbox is ticked', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TrelloCardUpdateDialog
+        {...baseProps}
+        onUpdate={onUpdate}
+        proposedCardName="My Video (1:30mins)"
+      />
+    )
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[0]) // select the card
+    fireEvent.click(screen.getByRole('checkbox', { name: /rename card/i }))
+    fireEvent.click(screen.getByRole('button', { name: /update 1 card/i }))
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith([0], { renameToVideoTitle: true })
+    )
+  })
+})

--- a/src/features/Trello/components/TrelloCardUpdateDialog.tsx
+++ b/src/features/Trello/components/TrelloCardUpdateDialog.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { Alert, AlertDescription } from '@shared/ui/alert'
 import { Button } from '@shared/ui/button'
 import { Checkbox } from '@shared/ui/checkbox'
+import { Label } from '@shared/ui/label'
 import {
   Dialog,
   DialogContent,
@@ -23,8 +24,13 @@ interface TrelloCardUpdateDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   trelloCards: TrelloCard[]
-  onUpdate: (selectedCardIndexes: number[]) => Promise<void>
+  onUpdate: (
+    selectedCardIndexes: number[],
+    options?: { renameToVideoTitle?: boolean }
+  ) => Promise<void>
   onAddTrelloCard: () => void
+  /** Proposed new card name (video title + duration suffix); null hides the rename option */
+  proposedCardName?: string | null
 }
 
 export function TrelloCardUpdateDialog({
@@ -32,9 +38,11 @@ export function TrelloCardUpdateDialog({
   onOpenChange,
   trelloCards,
   onUpdate,
-  onAddTrelloCard
+  onAddTrelloCard,
+  proposedCardName = null
 }: TrelloCardUpdateDialogProps) {
   const [selectedIndexes, setSelectedIndexes] = useState<number[]>([])
+  const [renameCards, setRenameCards] = useState(false)
   const [updating, setUpdating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -51,7 +59,7 @@ export function TrelloCardUpdateDialog({
     setError(null)
 
     try {
-      await onUpdate(selectedIndexes)
+      await onUpdate(selectedIndexes, { renameToVideoTitle: renameCards })
       onOpenChange(false)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update Trello cards')
@@ -63,6 +71,7 @@ export function TrelloCardUpdateDialog({
   const handleDialogChange = (open: boolean) => {
     if (!open) {
       setSelectedIndexes([])
+      setRenameCards(false)
       setError(null)
     }
     onOpenChange(open)
@@ -133,6 +142,26 @@ export function TrelloCardUpdateDialog({
             </div>
           ))}
         </div>
+
+        {/* Optional rename, separate from the card update itself */}
+        {proposedCardName && (
+          <div className="border-border flex items-start space-x-3 rounded-lg border border-dashed p-3">
+            <Checkbox
+              id="rename-trello-cards"
+              checked={renameCards}
+              onCheckedChange={(checked) => setRenameCards(checked === true)}
+              disabled={updating}
+            />
+            <div className="flex-1">
+              <Label htmlFor="rename-trello-cards" className="cursor-pointer">
+                Rename card(s) to match the video title
+              </Label>
+              <p className="text-muted-foreground mt-1 text-sm">
+                New name: <span className="font-medium">{proposedCardName}</span>
+              </p>
+            </div>
+          </div>
+        )}
 
         {error && (
           <Alert variant="destructive">

--- a/src/features/Trello/hooks/useVideoLinksManager.ts
+++ b/src/features/Trello/hooks/useVideoLinksManager.ts
@@ -4,7 +4,12 @@
  * Extracted to reduce component complexity (DEBT-002)
  */
 
-import { validateVideoLink, logger } from '@shared/utils'
+import {
+  fileNameToTitle,
+  formatDurationSuffix,
+  logger,
+  validateVideoLink
+} from '@shared/utils'
 import { useState } from 'react'
 
 import type { BreadcrumbsFile, VideoLink } from '@features/Baker'
@@ -23,7 +28,7 @@ import {
   useUploadEvents
 } from '@features/Upload'
 
-import { bakerReadBreadcrumbs, fetchTrelloCardById } from '../api'
+import { bakerReadBreadcrumbs, fetchTrelloCardById, updateTrelloCard } from '../api'
 
 interface UseVideoLinksManagerProps {
   projectPath: string
@@ -60,8 +65,15 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
   const { apiKey } = useSproutVideoApiKey()
   const { apiKey: trelloApiKey, apiToken: trelloToken } = useTrelloApiKeys()
   const { fetchVideoDetailsAsync, isFetching: isFetchingVideo } = useSproutVideoApi()
-  const { selectedFile, uploading, response, selectFile, uploadFile, resetUploadState } =
-    useFileUpload()
+  const {
+    selectedFile,
+    uploading,
+    response,
+    localDuration,
+    selectFile,
+    uploadFile,
+    resetUploadState
+  } = useFileUpload()
   const { progress, message } = useUploadEvents()
 
   // UI state
@@ -175,17 +187,83 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     }
   }
 
+  // Prefill the title from the chosen filename; the user can edit it before upload
+  const handleSelectUploadFile = async () => {
+    const file = await selectFile()
+    if (file) {
+      setFormData((prev) => ({ ...prev, title: fileNameToTitle(file) }))
+    }
+  }
+
   const handleUploadAndAdd = async () => {
     if (!selectedFile || !apiKey) return
 
     try {
-      await uploadFile(apiKey)
+      await uploadFile(apiKey, formData.title)
     } catch (error) {
       logger.error('Upload failed:', error)
     }
   }
 
-  const handleTrelloCardUpdate = async (selectedCardIndexes: number[]) => {
+  // Title of the video as uploaded to Sprout (only meaningful after an upload)
+  const uploadedVideoTitle = response
+    ? response.title?.trim() || formData.title.trim()
+    : ''
+
+  // Best duration known right now: Sprout's if processed, else the local file probe
+  const knownDuration =
+    response && response.duration > 0 ? response.duration : localDuration
+
+  const proposedCardName = uploadedVideoTitle
+    ? knownDuration && knownDuration > 0
+      ? `${uploadedVideoTitle} (${formatDurationSuffix(knownDuration)})`
+      : uploadedVideoTitle
+    : null
+
+  // Only offer a rename when at least one linked card would actually change
+  const renameProposal =
+    proposedCardName && trelloCards?.some((card) => card.title !== proposedCardName)
+      ? proposedCardName
+      : null
+
+  /**
+   * Resolves the final card name for a rename: prefers Sprout's processed
+   * duration (re-fetched once if the upload response predated processing),
+   * falls back to the local file probe, and omits the suffix if neither is
+   * available.
+   */
+  const resolveRenameCardName = async (): Promise<string | null> => {
+    if (!uploadedVideoTitle) return null
+
+    let duration = response && response.duration > 0 ? response.duration : null
+
+    if (!duration && response?.id && apiKey) {
+      try {
+        const details = await fetchVideoDetailsAsync({
+          videoUrl: `https://sproutvideo.com/videos/${response.id}`,
+          apiKey
+        })
+        if (details.duration > 0) {
+          duration = details.duration
+        }
+      } catch (error) {
+        logger.warn('Could not re-fetch Sprout video duration:', error)
+      }
+    }
+
+    if (!duration && localDuration && localDuration > 0) {
+      duration = localDuration
+    }
+
+    return duration
+      ? `${uploadedVideoTitle} (${formatDurationSuffix(duration)})`
+      : uploadedVideoTitle
+  }
+
+  const handleTrelloCardUpdate = async (
+    selectedCardIndexes: number[],
+    options?: { renameToVideoTitle?: boolean }
+  ) => {
     if (!trelloApiKey || !trelloToken) {
       throw new Error('Trello API credentials not configured')
     }
@@ -193,6 +271,8 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     const breadcrumbsData = (await bakerReadBreadcrumbs(projectPath)) as BreadcrumbsFile
 
     const breadcrumbsBlock = generateBreadcrumbsBlock(breadcrumbsData)
+
+    const newCardName = options?.renameToVideoTitle ? await resolveRenameCardName() : null
 
     const updatePromises = selectedCardIndexes.map(async (index) => {
       const card = trelloCards[index]
@@ -205,6 +285,16 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
         trelloToken,
         { autoReplace: true, silentErrors: false }
       )
+
+      // Rename only after the card update itself succeeded
+      if (newCardName && card.title !== newCardName) {
+        await updateTrelloCard(
+          card.cardId,
+          { name: newCardName },
+          trelloApiKey,
+          trelloToken
+        )
+      }
     })
 
     await Promise.all(updatePromises)
@@ -272,6 +362,9 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     setIsTrelloDialogOpen,
     addMode,
 
+    // Trello card rename proposal (null when no rename applies)
+    renameProposal,
+
     // Loading states
     isUpdating,
     isFetchingVideo,
@@ -290,7 +383,7 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     handleAddTrelloCard,
     handleDialogOpenChange,
     handleTabChange,
-    selectFile,
+    selectFile: handleSelectUploadFile,
 
     // AlertDialog state for video removal
     pendingRemoveVideoIndex,

--- a/src/features/Upload/__contracts__/upload.contract.test.ts
+++ b/src/features/Upload/__contracts__/upload.contract.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from 'vitest'
 // Mock the api layer (single mock point for all Upload I/O)
 vi.mock('../api', () => ({
   uploadVideo: vi.fn().mockResolvedValue(undefined),
+  getVideoDuration: vi.fn().mockResolvedValue(90),
   getFolders: vi.fn().mockResolvedValue({ folders: [] }),
   fetchSproutVideoDetails: vi.fn().mockResolvedValue({}),
   openFolder: vi.fn().mockResolvedValue(undefined),

--- a/src/features/Upload/api.ts
+++ b/src/features/Upload/api.ts
@@ -22,9 +22,15 @@ import type {
 export async function uploadVideo(
   filePath: string,
   apiKey: string,
-  folderId: string | null
+  folderId: string | null,
+  title?: string | null
 ): Promise<void> {
-  return invoke('upload_video', { filePath, apiKey, folderId })
+  return invoke('upload_video', { filePath, apiKey, folderId, title: title ?? null })
+}
+
+/** Probe a local MP4/MOV file for its duration in seconds (mvhd metadata) */
+export async function getVideoDuration(filePath: string): Promise<number> {
+  return invoke<number>('get_video_duration', { filePath })
 }
 
 export async function getFolders(

--- a/src/features/Upload/components/UploadSprout.test.tsx
+++ b/src/features/Upload/components/UploadSprout.test.tsx
@@ -288,7 +288,7 @@ describe('UploadSprout Page', () => {
       const uploadButton = screen.getByRole('button', { name: /Upload Video/i })
       fireEvent.click(uploadButton)
 
-      expect(mockUploadFile).toHaveBeenCalledWith('test-api-key')
+      expect(mockUploadFile).toHaveBeenCalledWith('test-api-key', '')
     })
   })
 

--- a/src/features/Upload/components/UploadSprout.tsx
+++ b/src/features/Upload/components/UploadSprout.tsx
@@ -6,10 +6,13 @@
  */
 
 import { Button } from '@shared/ui/button'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
 import { Progress } from '@shared/ui/progress'
 import ErrorBoundary from '@shared/ui/layout/ErrorBoundary'
 import { useSproutVideoApiKey } from '@shared/hooks'
 import { useBreadcrumb } from '@shared/hooks'
+import { fileNameToTitle } from '@shared/utils'
 import { useFileUpload } from '../hooks/useFileUpload'
 import { useImageRefresh } from '../hooks/useImageRefresh'
 import { useUploadEvents } from '../hooks/useUploadEvents'
@@ -17,7 +20,7 @@ import EmbedCodeInput from '@shared/ui/EmbedCodeInput'
 import ExternalLink from '@shared/ui/ExternalLink'
 import FormattedDate from '@shared/ui/FormattedDate'
 import { AlertTriangle, RefreshCw, Sprout } from 'lucide-react'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 
 const UploadSproutContent: React.FC = () => {
   // Custom hooks
@@ -27,6 +30,7 @@ const UploadSproutContent: React.FC = () => {
   const { selectedFile, response, selectFile, uploadFile } = useFileUpload()
   const { thumbnailLoaded, refreshTimestamp, setThumbnailLoaded } =
     useImageRefresh(response)
+  const [title, setTitle] = useState('')
 
   // Page label - shadcn breadcrumb component (memoized to prevent infinite re-renders)
   const breadcrumbItems = useMemo(
@@ -38,13 +42,21 @@ const UploadSproutContent: React.FC = () => {
   )
   useBreadcrumb(breadcrumbItems)
 
+  // Prefill the title from the chosen filename; the user can edit it freely
+  const handleSelectFile = async () => {
+    const file = await selectFile()
+    if (file) {
+      setTitle(fileNameToTitle(file))
+    }
+  }
+
   // Handle upload with API key
   const handleUpload = () => {
     // Reset progress and message before starting upload
     setProgress(0)
     setMessage(null)
     setUploading(true)
-    uploadFile(apiKey)
+    uploadFile(apiKey, title)
   }
 
   return (
@@ -75,7 +87,7 @@ const UploadSproutContent: React.FC = () => {
               <h2 className="text-foreground text-sm font-semibold">Select Video</h2>
             </div>
             <div className="p-4">
-              <Button onClick={selectFile} className="w-full">
+              <Button onClick={handleSelectFile} className="w-full">
                 Select Video File
               </Button>
               {selectedFile && (
@@ -85,6 +97,22 @@ const UploadSproutContent: React.FC = () => {
                     {selectedFile.split('/').pop()}
                   </span>
                 </p>
+              )}
+              {selectedFile && (
+                <div className="mt-3 space-y-2">
+                  <Label htmlFor="sprout-video-title">Video Title</Label>
+                  <Input
+                    id="sprout-video-title"
+                    placeholder="Video title on Sprout Video"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    maxLength={200}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    Used as the video title on Sprout Video. Leave blank to use the
+                    filename.
+                  </p>
+                </div>
               )}
             </div>
           </div>

--- a/src/features/Upload/hooks/useFileUpload.ts
+++ b/src/features/Upload/hooks/useFileUpload.ts
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { logger } from '@shared/utils'
 
 import {
+  getVideoDuration,
   listenUploadComplete,
   listenUploadError,
   openFileDialog,
@@ -16,8 +17,9 @@ interface UseFileUploadReturn {
   selectedFile: string | null
   uploading: boolean
   response: SproutUploadResponse | null
-  selectFile: () => Promise<void>
-  uploadFile: (apiKey: string | null) => Promise<void>
+  localDuration: number | null
+  selectFile: () => Promise<string | null>
+  uploadFile: (apiKey: string | null, title?: string) => Promise<void>
   resetUploadState: () => void
 }
 
@@ -25,16 +27,28 @@ export const useFileUpload = (): UseFileUploadReturn => {
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
   const [response, setResponse] = useState<SproutUploadResponse | null>(null)
+  const [localDuration, setLocalDuration] = useState<number | null>(null)
   const [selectedFolder] = useState<string | null>(null)
 
-  const selectFile = async () => {
+  const selectFile = async (): Promise<string | null> => {
     const file = await openFileDialog({
       multiple: false,
       filters: [{ name: 'Videos', extensions: ['mp4', 'mov', 'avi'] }]
     })
     if (typeof file === 'string') {
       setSelectedFile(file)
+      // Probe the local file for duration as a fallback for when Sprout
+      // hasn't finished processing at Trello-update time. Non-fatal.
+      setLocalDuration(null)
+      getVideoDuration(file)
+        .then((duration) => setLocalDuration(duration))
+        .catch((error) => {
+          logger.warn('Could not read local video duration:', error)
+          setLocalDuration(null)
+        })
+      return file
     }
+    return null
   }
 
   const resetUploadState = () => {
@@ -42,7 +56,7 @@ export const useFileUpload = (): UseFileUploadReturn => {
     setResponse(null)
   }
 
-  const uploadFile = async (apiKey: string | null) => {
+  const uploadFile = async (apiKey: string | null, title?: string) => {
     // Validate file selection and API key
     if (!selectedFile) {
       toast.error('Please select a video file.')
@@ -108,10 +122,12 @@ export const useFileUpload = (): UseFileUploadReturn => {
         })
 
         // Invoke the Rust backend command to start the upload
-        uploadVideo(selectedFile, apiKey, selectedFolder).catch(async (error) => {
-          await cleanup()
-          reject(error)
-        })
+        uploadVideo(selectedFile, apiKey, selectedFolder, title?.trim() || null).catch(
+          async (error) => {
+            await cleanup()
+            reject(error)
+          }
+        )
       })
 
       // Update the state with the final response from the backend upload
@@ -149,6 +165,7 @@ export const useFileUpload = (): UseFileUploadReturn => {
     selectedFile,
     uploading,
     response,
+    localDuration,
     selectFile,
     uploadFile,
     resetUploadState

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -51,6 +51,12 @@ export { isUpdateAvailable } from './versionUtils'
 /** Merge Tailwind CSS classes with conflict resolution via clsx + twMerge */
 export { cn } from './cn'
 
+// Video utilities
+/** Format a duration in seconds as a name suffix -- "1:30mins" or "1:02:05hrs" */
+export { formatDurationSuffix } from './video'
+/** Derive a default video title from a file path -- basename without extension */
+export { fileNameToTitle } from './video'
+
 // Breadcrumbs utilities
 /** Format a date for breadcrumbs display with full month and year */
 export { formatBreadcrumbDate } from './breadcrumbs'

--- a/src/shared/utils/video.test.ts
+++ b/src/shared/utils/video.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for video utilities: duration suffix formatting and title derivation
+ */
+import { describe, expect, it } from 'vitest'
+
+import { fileNameToTitle, formatDurationSuffix } from './video'
+
+describe('formatDurationSuffix', () => {
+  it('formats 90 seconds as 1:30mins', () => {
+    expect(formatDurationSuffix(90)).toBe('1:30mins')
+  })
+
+  it('zero-pads seconds', () => {
+    expect(formatDurationSuffix(605)).toBe('10:05mins')
+  })
+
+  it('formats sub-minute durations', () => {
+    expect(formatDurationSuffix(42)).toBe('0:42mins')
+  })
+
+  it('rounds fractional seconds to the nearest second', () => {
+    expect(formatDurationSuffix(89.6)).toBe('1:30mins')
+    expect(formatDurationSuffix(89.4)).toBe('1:29mins')
+  })
+
+  it('switches to H:MM:SShrs at one hour', () => {
+    expect(formatDurationSuffix(3600)).toBe('1:00:00hrs')
+    expect(formatDurationSuffix(3725)).toBe('1:02:05hrs')
+  })
+
+  it('stays in minutes just under an hour', () => {
+    expect(formatDurationSuffix(3599)).toBe('59:59mins')
+  })
+
+  it('handles zero and invalid input gracefully', () => {
+    expect(formatDurationSuffix(0)).toBe('0:00mins')
+    expect(formatDurationSuffix(NaN)).toBe('0:00mins')
+    expect(formatDurationSuffix(-5)).toBe('0:00mins')
+  })
+})
+
+describe('fileNameToTitle', () => {
+  it('strips the directory and extension', () => {
+    expect(fileNameToTitle('/renders/WM101_final_v3.mp4')).toBe('WM101_final_v3')
+  })
+
+  it('handles Windows-style paths', () => {
+    expect(fileNameToTitle('C:\\Renders\\My Video.mov')).toBe('My Video')
+  })
+
+  it('keeps names without an extension intact', () => {
+    expect(fileNameToTitle('/renders/raw_footage')).toBe('raw_footage')
+  })
+
+  it('only strips the last extension', () => {
+    expect(fileNameToTitle('/renders/lecture.v2.final.mp4')).toBe('lecture.v2.final')
+  })
+
+  it('does not treat a leading dot as an extension', () => {
+    expect(fileNameToTitle('.hidden')).toBe('.hidden')
+  })
+})

--- a/src/shared/utils/video.ts
+++ b/src/shared/utils/video.ts
@@ -1,0 +1,36 @@
+/**
+ * Video Utilities
+ *
+ * Helpers for deriving video titles and formatting durations,
+ * shared between the Upload and Trello features.
+ */
+
+/**
+ * Formats a duration in seconds as a compact suffix for card/video names.
+ * Under an hour: "M:SSmins" (e.g. 90 -> "1:30mins", 605 -> "10:05mins").
+ * An hour or more: "H:MM:SShrs" (e.g. 3725 -> "1:02:05hrs").
+ * Seconds are rounded to the nearest whole second.
+ */
+export function formatDurationSuffix(seconds: number): string {
+  const total = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0
+  const secs = total % 60
+  const paddedSecs = String(secs).padStart(2, '0')
+
+  if (total < 3600) {
+    return `${Math.floor(total / 60)}:${paddedSecs}mins`
+  }
+
+  const hours = Math.floor(total / 3600)
+  const mins = String(Math.floor((total % 3600) / 60)).padStart(2, '0')
+  return `${hours}:${mins}:${paddedSecs}hrs`
+}
+
+/**
+ * Derives a default video title from a file path: the basename without
+ * its extension (e.g. "/renders/WM101_final_v3.mp4" -> "WM101_final_v3").
+ */
+export function fileNameToTitle(filePath: string): string {
+  const base = filePath.split(/[\\/]/).pop() ?? filePath
+  const dotIndex = base.lastIndexOf('.')
+  return (dotIndex > 0 ? base.slice(0, dotIndex) : base).trim()
+}

--- a/tests/integration/us06-sprout-upload.test.ts
+++ b/tests/integration/us06-sprout-upload.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../src/features/Upload/api', () => ({
   openFileDialog: vi.fn().mockResolvedValue('/videos/test-video.mp4'),
   uploadVideo: vi.fn().mockResolvedValue(undefined),
+  getVideoDuration: vi.fn().mockResolvedValue(90),
   listenUploadComplete: vi.fn().mockResolvedValue(vi.fn()),
   listenUploadError: vi.fn().mockResolvedValue(vi.fn()),
   listenUploadProgress: vi.fn().mockResolvedValue(vi.fn()),
@@ -90,6 +91,7 @@ describe('US-06 — Sprout Video: File Upload (useFileUpload)', () => {
 
     vi.mocked(api.openFileDialog).mockResolvedValue('/videos/test-video.mp4')
     vi.mocked(api.uploadVideo).mockResolvedValue(undefined)
+    vi.mocked(api.getVideoDuration).mockResolvedValue(90)
     vi.mocked(api.listenUploadComplete).mockResolvedValue(vi.fn())
     vi.mocked(api.listenUploadError).mockResolvedValue(vi.fn())
     vi.mocked(appStore.getState).mockReturnValue({
@@ -209,7 +211,8 @@ describe('US-06 — Sprout Video: File Upload (useFileUpload)', () => {
       expect(api.uploadVideo).toHaveBeenCalledWith(
         '/videos/test-video.mp4',
         'my-api-key',
-        null // selectedFolder is always null in this hook
+        null, // selectedFolder is always null in this hook
+        null // no custom title supplied
       )
     })
 

--- a/tests/unit/components/TrelloCardUpdateDialog.test.tsx
+++ b/tests/unit/components/TrelloCardUpdateDialog.test.tsx
@@ -260,7 +260,7 @@ describe('TrelloCardUpdateDialog Component', () => {
       await user.click(screen.getByRole('button', { name: /update 2 cards/i }))
 
       // Assert
-      expect(mockOnUpdate).toHaveBeenCalledWith([0, 2])
+      expect(mockOnUpdate).toHaveBeenCalledWith([0, 2], { renameToVideoTitle: false })
     })
 
     test('closes dialog after successful update', async () => {


### PR DESCRIPTION
## Summary

Filenames often don't match the final video name. This PR lets users set the Sprout Video title at upload time, and optionally sync the Trello card name to it.

- **Custom video title at upload** — Baker's Add Video dialog (Upload File tab) and the standalone Upload → Sprout page both gain a Video Title field, prefilled from the filename (minus extension) and freely editable. The title is sent to Sprout as a multipart `title` field; blank falls back to today's filename behaviour.
- **Optional Trello card rename** — when updating Trello cards after an upload, a separate opt-in checkbox (unticked, shown only when the name would actually change) renames the selected card(s) to the video title with a duration suffix, e.g. `My Video (1:30mins)`, switching to `(1:02:05hrs)` at 60+ minutes. The rename runs only after the card update itself succeeds.
- **Duration fallback chain** — Sprout's processed duration → one re-fetch of video details if the upload response predated processing → local MP4/MOV probe via a new dependency-free `get_video_duration` Tauri command (parses the `moov/mvhd` box) → bare title with no suffix.
- **Version bump** — 0.16.2 → 0.17.0 across package.json / tauri.conf.json / Cargo.toml / Cargo.lock, with a CHANGELOG entry.

## Test plan

- [x] New unit tests: `formatDurationSuffix` / `fileNameToTitle` (src/shared/utils/video.test.ts)
- [x] New component tests: rename checkbox behaviour in `TrelloCardUpdateDialog`
- [x] New Rust unit tests: mvhd parser (v0/v1 boxes, missing moov, zero duration)
- [x] Updated existing suites for the new hook/API shapes (us06 integration, upload contracts, UploadSprout, VideoLinksManager mocks)
- [x] Full local run: eslint 0 errors, prettier clean, vitest 6,770 passing, `cargo check` + bin tests green, `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)