### PR TITLE
feat(baker): 0-camera projects, breadcrumb repair, nested project discovery (#138)

### DIFF
--- a/src-tauri/src/baker/breadcrumbs.rs
+++ b/src-tauri/src/baker/breadcrumbs.rs
@@ -226,6 +226,19 @@ pub async fn baker_update_breadcrumbs(
             continue;
         }
 
+        // A breadcrumbs file can be written for any folder with a Footage/
+        // directory or an existing breadcrumbs.json — full structural
+        // validity is NOT required, so 0-camera (podcast) and structurally
+        // imperfect projects stay repairable.
+        if !path.join("Footage").is_dir() && !exists {
+            result.failed.push(FailedUpdate {
+                path: project_path.clone(),
+                error: "No Footage folder or breadcrumbs file — nothing to describe"
+                    .to_string(),
+            });
+            continue;
+        }
+
         // Create backup if requested and file exists
         if backup_originals && exists {
             let backup_path = path.join("breadcrumbs.json.bak");
@@ -238,15 +251,7 @@ pub async fn baker_update_breadcrumbs(
             }
         }
 
-        let (is_valid, _, camera_count) = validate_project_folder(path);
-
-        if !is_valid {
-            result.failed.push(FailedUpdate {
-                path: project_path.clone(),
-                error: "Invalid project structure".to_string(),
-            });
-            continue;
-        }
+        let (_, _, camera_count) = validate_project_folder(path);
 
         let files = scan_camera_files(path);
 
@@ -430,6 +435,59 @@ pub async fn baker_update_breadcrumbs_sizes(
     }
 
     Ok(result)
+}
+
+/// Regenerate a single project's `breadcrumbs.json` from the folder contents,
+/// salvaging the user-managed link fields from the old file.
+///
+/// Unlike the batch update, repair ALWAYS backs the existing file up to
+/// `breadcrumbs.json.bak` first — a corrupt original is exactly the file the
+/// user may want to inspect later. Allowed for any folder with a `Footage/`
+/// directory or an existing breadcrumbs file.
+#[tauri::command]
+pub async fn baker_repair_breadcrumbs(
+    project_path: String,
+) -> Result<BreadcrumbsFile, String> {
+    let path = Path::new(&project_path);
+
+    if !path.exists() {
+        return Err("Project path does not exist".to_string());
+    }
+
+    let breadcrumbs_path = path.join("breadcrumbs.json");
+    let exists = breadcrumbs_path.exists();
+
+    if !path.join("Footage").is_dir() && !exists {
+        return Err(
+            "Folder has no Footage directory or breadcrumbs file to repair".to_string()
+        );
+    }
+
+    let raw_content = if exists {
+        let content = fs::read_to_string(&breadcrumbs_path)
+            .map_err(|e| format!("Failed to read existing breadcrumbs: {}", e))?;
+        fs::copy(&breadcrumbs_path, path.join("breadcrumbs.json.bak"))
+            .map_err(|e| format!("Failed to create backup: {}", e))?;
+        Some(content)
+    } else {
+        None
+    };
+
+    let (_, _, camera_count) = validate_project_folder(path);
+    let files = scan_camera_files(path);
+    let mut breadcrumbs = new_breadcrumbs_file(path, camera_count, files);
+    if let Some(content) = &raw_content {
+        salvage_links_from_raw(content, &mut breadcrumbs);
+    }
+
+    let json_content = serde_json::to_string_pretty(&breadcrumbs)
+        .map_err(|e| format!("Failed to serialize breadcrumbs: {}", e))?;
+    fs::write(&breadcrumbs_path, json_content)
+        .map_err(|e| format!("Failed to write breadcrumbs file: {}", e))?;
+
+    println!("[Baker] Repaired breadcrumbs for {}", path.display());
+
+    Ok(breadcrumbs)
 }
 
 /// Salvage the user-managed link fields (`trelloCards`, `videoLinks` and the
@@ -666,6 +724,163 @@ mod tests {
         assert!(result.successful.is_empty());
         assert_eq!(result.failed.len(), 1);
         assert!(result.failed[0].error.contains("No breadcrumbs file"));
+    }
+
+    /// Podcast project: full structure, no camera folders, one script file.
+    fn make_podcast_project(dir: &Path) {
+        for sub in ["Footage", "Graphics", "Renders", "Projects", "Scripts"] {
+            fs::create_dir_all(dir.join(sub)).unwrap();
+        }
+        fs::write(dir.join("Scripts").join("episode-01.docx"), b"script").unwrap();
+    }
+
+    // --- B3.3: batch update works for 0-camera projects ---
+
+    #[tokio::test]
+    async fn update_succeeds_for_zero_camera_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Podcast Ep 1");
+        make_podcast_project(&project);
+
+        let result = baker_update_breadcrumbs(
+            vec![project.to_string_lossy().to_string()],
+            true,
+            false,
+        )
+        .await
+        .expect("update should succeed");
+
+        assert_eq!(result.successful.len(), 1, "result was {:?}", result);
+        assert_eq!(result.created.len(), 1);
+        assert!(result.failed.is_empty(), "result was {:?}", result);
+
+        let written: BreadcrumbsFile = serde_json::from_str(
+            &fs::read_to_string(project.join("breadcrumbs.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(written.number_of_cameras, 0);
+    }
+
+    // --- B3.4: relaxed gate ---
+
+    #[tokio::test]
+    async fn update_allowed_with_only_footage_folder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Partial");
+        fs::create_dir_all(project.join("Footage").join("Camera 1")).unwrap();
+        fs::write(
+            project.join("Footage").join("Camera 1").join("clip.mp4"),
+            b"vid",
+        )
+        .unwrap();
+
+        let result = baker_update_breadcrumbs(
+            vec![project.to_string_lossy().to_string()],
+            true,
+            false,
+        )
+        .await
+        .expect("update should succeed");
+
+        assert_eq!(result.successful.len(), 1, "result was {:?}", result);
+        assert!(project.join("breadcrumbs.json").exists());
+    }
+
+    #[tokio::test]
+    async fn update_fails_without_footage_or_breadcrumbs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Random Folder");
+        fs::create_dir_all(&project).unwrap();
+
+        let result = baker_update_breadcrumbs(
+            vec![project.to_string_lossy().to_string()],
+            true,
+            false,
+        )
+        .await
+        .expect("command itself should not error");
+
+        assert!(result.successful.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert!(!project.join("breadcrumbs.json").exists());
+    }
+
+    // --- B3.2: repair command ---
+
+    #[tokio::test]
+    async fn repair_regenerates_drifted_file_and_backs_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("My Project");
+        make_valid_project(&project);
+
+        let breadcrumbs_path = project.join("breadcrumbs.json");
+        fs::write(&breadcrumbs_path, DRIFTED_BREADCRUMBS).unwrap();
+
+        let repaired = baker_repair_breadcrumbs(project.to_string_lossy().to_string())
+            .await
+            .expect("repair should succeed");
+
+        // Backup contains the original bytes.
+        let backup = fs::read_to_string(project.join("breadcrumbs.json.bak")).unwrap();
+        assert_eq!(backup, DRIFTED_BREADCRUMBS);
+
+        // The written file is now strictly parseable and retains the links.
+        let written: BreadcrumbsFile =
+            serde_json::from_str(&fs::read_to_string(&breadcrumbs_path).unwrap())
+                .expect("repaired file is valid");
+        let cards = written.trello_cards.expect("trello cards salvaged");
+        assert_eq!(cards.len(), 2);
+        let videos = written.video_links.expect("video links salvaged");
+        assert_eq!(videos.len(), 1);
+
+        assert_eq!(repaired.number_of_cameras, written.number_of_cameras);
+    }
+
+    #[tokio::test]
+    async fn repair_writes_zero_cameras_for_podcast_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Podcast Ep 2");
+        make_podcast_project(&project);
+        fs::write(project.join("breadcrumbs.json"), "{ not valid json").unwrap();
+
+        let repaired = baker_repair_breadcrumbs(project.to_string_lossy().to_string())
+            .await
+            .expect("repair should succeed");
+
+        assert_eq!(repaired.number_of_cameras, 0);
+        assert!(project.join("breadcrumbs.json.bak").exists());
+
+        let written: BreadcrumbsFile = serde_json::from_str(
+            &fs::read_to_string(project.join("breadcrumbs.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(written.number_of_cameras, 0);
+    }
+
+    #[tokio::test]
+    async fn repair_creates_breadcrumbs_when_footage_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Fresh Project");
+        make_valid_project(&project);
+
+        let repaired = baker_repair_breadcrumbs(project.to_string_lossy().to_string())
+            .await
+            .expect("repair should succeed");
+
+        assert_eq!(repaired.number_of_cameras, 1);
+        assert!(project.join("breadcrumbs.json").exists());
+        // Nothing to back up when there was no original file.
+        assert!(!project.join("breadcrumbs.json.bak").exists());
+    }
+
+    #[tokio::test]
+    async fn repair_fails_without_footage_or_breadcrumbs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Random Folder");
+        fs::create_dir_all(&project).unwrap();
+
+        let result = baker_repair_breadcrumbs(project.to_string_lossy().to_string()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/baker/scanning.rs
+++ b/src-tauri/src/baker/scanning.rs
@@ -172,6 +172,35 @@ pub fn has_invalid_breadcrumbs_file(path: &Path) -> bool {
     }
 }
 
+/// True if `dir` contains at least one non-hidden file, searching recursively.
+fn dir_contains_visible_file(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_file() {
+            return true;
+        }
+        if path.is_dir() && dir_contains_visible_file(&path) {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if any of the five standard project folders contains a real file.
+/// A `breadcrumbs.json` at the project root deliberately does not count —
+/// a metadata-only husk is not a project.
+fn has_content_in_standard_folders(path: &Path) -> bool {
+    STANDARD_PROJECT_FOLDERS
+        .iter()
+        .any(|folder| dir_contains_visible_file(&path.join(folder)))
+}
+
 pub fn validate_project_folder(path: &Path) -> (bool, Vec<String>, i32) {
     let mut errors = Vec::new();
     let mut camera_count = 0;
@@ -181,9 +210,7 @@ pub fn validate_project_folder(path: &Path) -> (bool, Vec<String>, i32) {
         return (false, errors, 0);
     }
 
-    let required_folders = vec!["Footage", "Graphics", "Renders", "Projects", "Scripts"];
-
-    for folder in &required_folders {
+    for folder in STANDARD_PROJECT_FOLDERS {
         let subfolder = path.join(folder);
         if !subfolder.exists() || !subfolder.is_dir() {
             errors.push(format!("Missing required subfolder: {}", folder));
@@ -203,8 +230,14 @@ pub fn validate_project_folder(path: &Path) -> (bool, Vec<String>, i32) {
         }
     }
 
-    if camera_count == 0 {
-        errors.push("No Camera folders found in Footage directory".to_string());
+    // Zero camera folders is a legitimate project (podcast/audio-only) as
+    // long as there is some real content; an empty scaffold is not one yet.
+    // With at least one Camera folder the project is valid even when empty
+    // (a freshly scaffolded shoot awaiting footage).
+    if camera_count == 0 && !has_content_in_standard_folders(path) {
+        errors.push(
+            "No Camera folders and no content found in project folders".to_string(),
+        );
     }
 
     (errors.is_empty(), errors, camera_count)
@@ -256,6 +289,188 @@ pub fn scan_directory_recursive(
     app_handle: &AppHandle,
     scan_id: &str,
 ) -> Result<ScanResult, String> {
+    // The core is AppHandle-free (and therefore unit-testable); this wrapper
+    // injects the scan id into every payload and forwards it to the frontend.
+    let mut emit = |event: &str, mut payload: serde_json::Value| {
+        if let Some(map) = payload.as_object_mut() {
+            map.insert("scanId".to_string(), serde_json::Value::from(scan_id));
+        }
+        let _ = app_handle.emit(event, payload);
+    };
+
+    Ok(scan_directory_core(root_path, options, &mut emit))
+}
+
+/// Classify a folder and, if it is a project (valid structure, or it carries a
+/// breadcrumbs.json — parseable or not), record it in the result and emit a
+/// discovery event. Returns whether the folder was recorded as a project.
+fn classify_and_record(
+    path: &Path,
+    name: &str,
+    result: &mut ScanResult,
+    emit: &mut dyn FnMut(&str, serde_json::Value),
+) -> bool {
+    let (is_valid, validation_errors, camera_count) = validate_project_folder(path);
+    let has_breadcrumbs = has_breadcrumbs_file(path);
+    let invalid_breadcrumbs = has_invalid_breadcrumbs_file(path);
+
+    println!(
+        "[Baker] Folder: {} | Valid: {} | HasBreadcrumbs: {} | InvalidBreadcrumbs: {} | CameraCount: {}",
+        path.display(),
+        is_valid,
+        has_breadcrumbs,
+        invalid_breadcrumbs,
+        camera_count
+    );
+
+    if !(is_valid || has_breadcrumbs || invalid_breadcrumbs) {
+        return false;
+    }
+
+    if is_valid {
+        result.valid_projects += 1;
+    }
+
+    let stale_breadcrumbs = if has_breadcrumbs {
+        check_breadcrumbs_stale(path).unwrap_or(false)
+    } else {
+        false
+    };
+
+    let folder_size = match calculate_folder_size(path) {
+        Ok(size) => {
+            result.total_folder_size += size;
+            Some(size)
+        }
+        Err(e) => {
+            result.errors.push(ScanError {
+                path: path.to_string_lossy().to_string(),
+                r#type: "filesystem".to_string(),
+                message: format!("Failed to calculate folder size: {}", e),
+                timestamp: get_current_timestamp(),
+            });
+            None
+        }
+    };
+
+    result.projects.push(ProjectFolder {
+        path: path.to_string_lossy().to_string(),
+        name: name.to_string(),
+        is_valid,
+        has_breadcrumbs,
+        stale_breadcrumbs,
+        last_scanned: get_current_timestamp(),
+        camera_count,
+        validation_errors: validation_errors.clone(),
+        invalid_breadcrumbs,
+        folder_size_bytes: folder_size,
+    });
+
+    emit(
+        "baker_scan_discovery",
+        serde_json::json!({
+            "projectPath": path.to_string_lossy(),
+            "isValid": is_valid,
+            "hasBreadcrumbs": has_breadcrumbs,
+            "invalidBreadcrumbs": invalid_breadcrumbs,
+            "errors": validation_errors
+        }),
+    );
+
+    true
+}
+
+struct VisitContext {
+    max_depth: i32,
+    include_hidden: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn visit_directory(
+    dir: &Path,
+    depth: i32,
+    skip_standard_children: bool,
+    ctx: &VisitContext,
+    result: &mut ScanResult,
+    folders_scanned: &mut i32,
+    last_progress_update: &mut Instant,
+    emit: &mut dyn FnMut(&str, serde_json::Value),
+) -> Result<(), Box<dyn std::error::Error>> {
+    if depth > ctx.max_depth {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(dir)?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+
+        if !ctx.include_hidden && name_str.starts_with('.') {
+            continue;
+        }
+
+        // Never look for projects inside a project's own structure folders.
+        if skip_standard_children
+            && STANDARD_PROJECT_FOLDERS.iter().any(|f| *f == name_str)
+        {
+            continue;
+        }
+
+        if should_skip_directory(&path) {
+            continue;
+        }
+
+        *folders_scanned += 1;
+        result.total_folders = *folders_scanned;
+
+        if last_progress_update.elapsed() >= PROGRESS_UPDATE_INTERVAL {
+            let progress = ScanProgressEvent {
+                scan_id: String::new(), // injected by the emitter wrapper
+                folders_scanned: *folders_scanned,
+                total_folders: *folders_scanned,
+                current_path: path.to_string_lossy().to_string(),
+                projects_found: result.valid_projects,
+            };
+            emit(
+                "baker_scan_progress",
+                serde_json::to_value(progress).unwrap_or_default(),
+            );
+            *last_progress_update = Instant::now();
+        }
+
+        let is_project = classify_and_record(&path, &name_str, result, emit);
+
+        // Projects may contain nested projects outside their standard
+        // folders; plain folders are always traversed — a container may hold
+        // projects alongside stray Footage/Graphics directories.
+        visit_directory(
+            &path,
+            depth + 1,
+            is_project,
+            ctx,
+            result,
+            folders_scanned,
+            last_progress_update,
+            emit,
+        )?;
+    }
+
+    Ok(())
+}
+
+pub fn scan_directory_core(
+    root_path: &Path,
+    options: &ScanOptions,
+    emit: &mut dyn FnMut(&str, serde_json::Value),
+) -> ScanResult {
     let mut result = ScanResult {
         start_time: get_current_timestamp(),
         end_time: None,
@@ -272,242 +487,222 @@ pub fn scan_directory_recursive(
     let mut folders_scanned = 0;
     let mut last_progress_update = Instant::now();
 
-    struct VisitContext<'a> {
-        max_depth: i32,
-        include_hidden: bool,
-        app_handle: &'a AppHandle,
-        scan_id: &'a str,
-    }
-
-    fn visit_directory(
-        dir: &Path,
-        depth: i32,
-        ctx: &VisitContext,
-        result: &mut ScanResult,
-        folders_scanned: &mut i32,
-        last_progress_update: &mut Instant,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        if depth > ctx.max_depth {
-            return Ok(());
-        }
-
-        let entries = fs::read_dir(dir)?;
-
-        for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_dir() {
-                let file_name = entry.file_name();
-                let name_str = file_name.to_string_lossy();
-
-                if !ctx.include_hidden && name_str.starts_with('.') {
-                    continue;
-                }
-
-                if should_skip_directory(&path) {
-                    continue;
-                }
-
-                *folders_scanned += 1;
-                result.total_folders = *folders_scanned;
-
-                if last_progress_update.elapsed() >= PROGRESS_UPDATE_INTERVAL {
-                    let progress_event = ScanProgressEvent {
-                        scan_id: ctx.scan_id.to_string(),
-                        folders_scanned: *folders_scanned,
-                        total_folders: *folders_scanned,
-                        current_path: path.to_string_lossy().to_string(),
-                        projects_found: result.valid_projects,
-                    };
-
-                    let _ = ctx.app_handle.emit("baker_scan_progress", progress_event);
-                    *last_progress_update = Instant::now();
-                }
-
-                let (is_valid, validation_errors, camera_count) = validate_project_folder(&path);
-                let has_breadcrumbs = has_breadcrumbs_file(&path);
-                let invalid_breadcrumbs = has_invalid_breadcrumbs_file(&path);
-
-                println!("[Baker] Sub-folder: {} | Valid: {} | HasBreadcrumbs: {} | InvalidBreadcrumbs: {} | CameraCount: {}",
-                    path.display(), is_valid, has_breadcrumbs, invalid_breadcrumbs, camera_count);
-
-                if is_valid || has_breadcrumbs || invalid_breadcrumbs {
-                    if is_valid {
-                        result.valid_projects += 1;
-                    }
-
-                    let stale_breadcrumbs = if has_breadcrumbs {
-                        check_breadcrumbs_stale(&path).unwrap_or(false)
-                    } else {
-                        false
-                    };
-
-                    let folder_size = match calculate_folder_size(&path) {
-                        Ok(size) => {
-                            result.total_folder_size += size;
-                            Some(size)
-                        }
-                        Err(e) => {
-                            result.errors.push(ScanError {
-                                path: path.to_string_lossy().to_string(),
-                                r#type: "filesystem".to_string(),
-                                message: format!("Failed to calculate folder size: {}", e),
-                                timestamp: get_current_timestamp(),
-                            });
-                            None
-                        }
-                    };
-
-                    let project_folder = ProjectFolder {
-                        path: path.to_string_lossy().to_string(),
-                        name: file_name.to_string_lossy().to_string(),
-                        is_valid,
-                        has_breadcrumbs,
-                        stale_breadcrumbs,
-                        last_scanned: get_current_timestamp(),
-                        camera_count,
-                        validation_errors: validation_errors.clone(),
-                        invalid_breadcrumbs,
-                        folder_size_bytes: folder_size,
-                    };
-
-                    result.projects.push(project_folder);
-                } else if !validation_errors.is_empty() {
-                    let has_footage_or_graphics =
-                        path.join("Footage").exists() || path.join("Graphics").exists();
-
-                    if !has_footage_or_graphics {
-                        visit_directory(
-                            &path,
-                            depth + 1,
-                            ctx,
-                            result,
-                            folders_scanned,
-                            last_progress_update,
-                        )?;
-                    }
-                }
-
-                if is_valid || has_breadcrumbs || invalid_breadcrumbs {
-                    let discovery_event = serde_json::json!({
-                        "scanId": ctx.scan_id,
-                        "projectPath": path.to_string_lossy(),
-                        "isValid": is_valid,
-                        "hasBreadcrumbs": has_breadcrumbs,
-                        "invalidBreadcrumbs": invalid_breadcrumbs,
-                        "errors": validation_errors
-                    });
-
-                    let _ = ctx.app_handle.emit("baker_scan_discovery", discovery_event);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    // First check the root directory itself
-    let (is_valid, validation_errors, camera_count) = validate_project_folder(root_path);
-    let has_breadcrumbs = has_breadcrumbs_file(root_path);
-    let invalid_breadcrumbs = has_invalid_breadcrumbs_file(root_path);
-
+    // The root directory itself may be a project.
     println!("[Baker] ===== ROOT FOLDER ANALYSIS =====");
-    println!("[Baker] Path: {}", root_path.display());
-    println!("[Baker] Valid BuildProject: {}", is_valid);
-    println!("[Baker] Has breadcrumbs.json: {}", has_breadcrumbs);
-    println!("[Baker] Invalid breadcrumbs.json: {}", invalid_breadcrumbs);
-    println!("[Baker] Camera count: {}", camera_count);
-    if !validation_errors.is_empty() {
-        println!("[Baker] Validation errors: {:?}", validation_errors);
-    }
+    let root_name = root_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let root_is_project = classify_and_record(root_path, &root_name, &mut result, emit);
     println!("[Baker] ================================");
-
-    if is_valid || has_breadcrumbs || invalid_breadcrumbs {
-        if is_valid {
-            result.valid_projects += 1;
-        }
-
-        let stale_breadcrumbs = if has_breadcrumbs {
-            check_breadcrumbs_stale(root_path).unwrap_or(false)
-        } else {
-            false
-        };
-
-        let root_folder_size = match calculate_folder_size(root_path) {
-            Ok(size) => {
-                result.total_folder_size += size;
-                Some(size)
-            }
-            Err(e) => {
-                result.errors.push(ScanError {
-                    path: root_path.to_string_lossy().to_string(),
-                    r#type: "filesystem".to_string(),
-                    message: format!("Failed to calculate folder size: {}", e),
-                    timestamp: get_current_timestamp(),
-                });
-                None
-            }
-        };
-
-        let project_folder = ProjectFolder {
-            path: root_path.to_string_lossy().to_string(),
-            name: root_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-            is_valid,
-            has_breadcrumbs,
-            stale_breadcrumbs,
-            last_scanned: get_current_timestamp(),
-            camera_count,
-            validation_errors: validation_errors.clone(),
-            invalid_breadcrumbs,
-            folder_size_bytes: root_folder_size,
-        };
-
-        result.projects.push(project_folder);
-
-        let discovery_event = serde_json::json!({
-            "scanId": scan_id,
-            "projectPath": root_path.to_string_lossy(),
-            "isValid": is_valid,
-            "hasBreadcrumbs": has_breadcrumbs,
-            "invalidBreadcrumbs": invalid_breadcrumbs,
-            "errors": validation_errors
-        });
-        let _ = app_handle.emit("baker_scan_discovery", discovery_event);
-    }
 
     let ctx = VisitContext {
         max_depth: options.max_depth,
         include_hidden: options.include_hidden,
-        app_handle,
-        scan_id,
     };
 
-    match visit_directory(
+    if let Err(e) = visit_directory(
         root_path,
         0,
+        root_is_project,
         &ctx,
         &mut result,
         &mut folders_scanned,
         &mut last_progress_update,
+        emit,
     ) {
-        Ok(_) => {
-            result.end_time = Some(get_current_timestamp());
-            Ok(result)
+        result.errors.push(ScanError {
+            path: root_path.to_string_lossy().to_string(),
+            r#type: "filesystem".to_string(),
+            message: e.to_string(),
+            timestamp: get_current_timestamp(),
+        });
+    }
+
+    result.end_time = Some(get_current_timestamp());
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_structure(dir: &Path) {
+        for sub in STANDARD_PROJECT_FOLDERS {
+            fs::create_dir_all(dir.join(sub)).unwrap();
         }
-        Err(e) => {
-            result.errors.push(ScanError {
-                path: root_path.to_string_lossy().to_string(),
-                r#type: "filesystem".to_string(),
-                message: e.to_string(),
-                timestamp: get_current_timestamp(),
-            });
-            result.end_time = Some(get_current_timestamp());
-            Ok(result)
-        }
+    }
+
+    /// Video project: full structure plus an (empty) Camera 1 folder.
+    fn make_video_project(dir: &Path) {
+        make_structure(dir);
+        fs::create_dir_all(dir.join("Footage").join("Camera 1")).unwrap();
+    }
+
+    /// Podcast project: full structure, no camera folders, one script file.
+    fn make_podcast_project(dir: &Path) {
+        make_structure(dir);
+        fs::write(dir.join("Scripts").join("episode-01.docx"), b"script").unwrap();
+    }
+
+    fn scan(root: &Path, max_depth: i32) -> ScanResult {
+        let options = ScanOptions {
+            max_depth,
+            include_hidden: false,
+            create_missing: false,
+            backup_originals: false,
+        };
+        scan_directory_core(root, &options, &mut |_, _| {})
+    }
+
+    fn project_names(result: &ScanResult) -> Vec<&str> {
+        result.projects.iter().map(|p| p.name.as_str()).collect()
+    }
+
+    // --- B1: validity ---
+
+    #[test]
+    fn b1_1_empty_camera_folder_project_is_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Show A");
+        make_video_project(&project);
+
+        let (is_valid, errors, camera_count) = validate_project_folder(&project);
+        assert!(is_valid, "errors: {:?}", errors);
+        assert_eq!(camera_count, 1);
+    }
+
+    #[test]
+    fn b1_2_zero_cameras_with_content_is_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Podcast Ep 1");
+        make_podcast_project(&project);
+
+        let (is_valid, errors, camera_count) = validate_project_folder(&project);
+        assert!(is_valid, "errors: {:?}", errors);
+        assert!(errors.is_empty());
+        assert_eq!(camera_count, 0);
+    }
+
+    #[test]
+    fn b1_2_deeply_nested_content_counts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Podcast Ep 2");
+        make_structure(&project);
+        fs::create_dir_all(project.join("Footage").join("Audio")).unwrap();
+        fs::write(project.join("Footage").join("Audio").join("ep.wav"), b"pcm").unwrap();
+
+        let (is_valid, errors, camera_count) = validate_project_folder(&project);
+        assert!(is_valid, "errors: {:?}", errors);
+        assert_eq!(camera_count, 0);
+    }
+
+    #[test]
+    fn b1_3_zero_cameras_without_content_is_invalid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Empty Scaffold");
+        make_structure(&project);
+
+        let (is_valid, errors, camera_count) = validate_project_folder(&project);
+        assert!(!is_valid);
+        assert_eq!(camera_count, 0);
+        assert!(
+            errors.iter().any(|e| e.to_lowercase().contains("content")),
+            "expected a no-content error, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn b1_3_hidden_files_do_not_count_as_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Hidden Only");
+        make_structure(&project);
+        fs::write(project.join("Footage").join(".DS_Store"), b"junk").unwrap();
+
+        let (is_valid, _, _) = validate_project_folder(&project);
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn b1_3_root_breadcrumbs_does_not_count_as_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("Metadata Husk");
+        make_structure(&project);
+        fs::write(project.join("breadcrumbs.json"), b"{}").unwrap();
+
+        let (is_valid, _, _) = validate_project_folder(&project);
+        assert!(!is_valid);
+    }
+
+    #[test]
+    fn b1_4_missing_required_folder_is_invalid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("No Renders");
+        make_podcast_project(&project);
+        fs::remove_dir(project.join("Renders")).unwrap();
+
+        let (is_valid, errors, _) = validate_project_folder(&project);
+        assert!(!is_valid);
+        assert!(errors.iter().any(|e| e.contains("Renders")));
+    }
+
+    // --- B4: traversal ---
+
+    #[test]
+    fn b4_1_container_with_stray_footage_is_traversed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let container = tmp.path().join("Season 1");
+        fs::create_dir_all(container.join("Footage")).unwrap(); // stray
+        make_video_project(&container.join("Episode 1"));
+        make_podcast_project(&container.join("Episode 2"));
+
+        let result = scan(tmp.path(), 3);
+        let names = project_names(&result);
+        assert!(names.contains(&"Episode 1"), "found: {:?}", names);
+        assert!(names.contains(&"Episode 2"), "found: {:?}", names);
+        assert!(!names.contains(&"Season 1"), "found: {:?}", names);
+    }
+
+    #[test]
+    fn b4_2_nested_project_inside_project_is_discovered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outer = tmp.path().join("Show A");
+        make_video_project(&outer);
+        make_video_project(&outer.join("Extras").join("Bonus Film"));
+
+        let result = scan(tmp.path(), 4);
+        let names = project_names(&result);
+        assert!(names.contains(&"Show A"), "found: {:?}", names);
+        assert!(names.contains(&"Bonus Film"), "found: {:?}", names);
+    }
+
+    #[test]
+    fn b4_3_standard_folders_are_not_searched_for_projects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outer = tmp.path().join("Show B");
+        make_video_project(&outer);
+        // A full project planted inside Footage/ must NOT be discovered.
+        make_video_project(&outer.join("Footage").join("Sneaky"));
+
+        let result = scan(tmp.path(), 5);
+        let names = project_names(&result);
+        assert!(names.contains(&"Show B"), "found: {:?}", names);
+        assert!(!names.contains(&"Sneaky"), "found: {:?}", names);
+    }
+
+    #[test]
+    fn b4_4_max_depth_is_respected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let deep = tmp.path().join("a").join("b").join("c").join("Deep Show");
+        make_video_project(&deep);
+
+        let shallow = scan(tmp.path(), 2);
+        assert!(!project_names(&shallow).contains(&"Deep Show"));
+
+        let full = scan(tmp.path(), 3);
+        assert!(project_names(&full).contains(&"Deep Show"));
     }
 }

--- a/src-tauri/src/baker/types.rs
+++ b/src-tauri/src/baker/types.rs
@@ -26,6 +26,12 @@ pub const SKIP_PATTERNS: &[&str] = &[
 // Stale breadcrumbs detection constants
 pub const STALE_SIZE_THRESHOLD_BYTES: u64 = 1024;
 
+/// The five sub-folders every BuildProject-compatible project must have.
+/// Also the folders the scanner never descends into when looking for
+/// nested projects inside a project.
+pub const STANDARD_PROJECT_FOLDERS: [&str; 5] =
+    ["Footage", "Graphics", "Renders", "Projects", "Scripts"];
+
 // Data structures matching TypeScript interfaces
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectFolder {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
             baker_read_breadcrumbs,
             baker_update_breadcrumbs,
             baker_update_breadcrumbs_sizes,
+            baker_repair_breadcrumbs,
             baker_scan_current_files,
             get_folder_size,
             baker_read_raw_breadcrumbs,

--- a/src/features/Baker/BakerPage.tsx
+++ b/src/features/Baker/BakerPage.tsx
@@ -18,6 +18,7 @@ import { FolderSelector } from './components/FolderSelector'
 import { PreviewProgress } from './components/PreviewProgress'
 import { ProjectDetailPanel } from './components/ProjectDetailPanel'
 import { ProjectListPanel } from './components/ProjectListPanel'
+import { RepairBreadcrumbsDialog } from './components/RepairBreadcrumbsDialog'
 import { ScanResults } from './components/ScanResults'
 import { StorageView } from './components/StorageView'
 import { useBakerPreferences } from './hooks/useBakerPreferences'
@@ -25,6 +26,7 @@ import { useBakerScan } from './hooks/useBakerScan'
 import { useBreadcrumbsManager } from './hooks/useBreadcrumbsManager'
 import { useBreadcrumbsPreview } from './hooks/useBreadcrumbsPreview'
 import { useLiveBreadcrumbsReader } from './hooks/useLiveBreadcrumbsReader'
+import { useRepairBreadcrumbs } from './hooks/useRepairBreadcrumbs'
 import { Button } from '@shared/ui/button'
 import ErrorBoundary from '@shared/ui/layout/ErrorBoundary'
 
@@ -43,6 +45,7 @@ const BakerPageContent: React.FC = () => {
   const [selectedProject, setSelectedProject] = useState<string | null>(null)
   const [showBatchConfirmation, setShowBatchConfirmation] = useState(false)
   const [viewMode, setViewMode] = useState<'projects' | 'storage'>('projects')
+  const [repairTarget, setRepairTarget] = useState<string | null>(null)
 
   // Custom hooks - all business logic moved to hooks
   const {
@@ -52,7 +55,8 @@ const BakerPageContent: React.FC = () => {
     scanStartTime,
     startScan,
     cancelScan,
-    clearResults
+    clearResults,
+    refreshProject
   } = useBakerScan()
   const {
     updateBreadcrumbs,
@@ -61,6 +65,7 @@ const BakerPageContent: React.FC = () => {
     clearResults: clearUpdateResults
   } = useBreadcrumbsManager()
   const { preferences, updatePreferences, resetToDefaults } = useBakerPreferences()
+  const { repairBreadcrumbs, isRepairing } = useRepairBreadcrumbs()
   const {
     breadcrumbs,
     isLoading: isLoadingBreadcrumbs,
@@ -200,6 +205,34 @@ const BakerPageContent: React.FC = () => {
     [readLiveBreadcrumbs]
   )
 
+  const handleRepairRequest = useCallback((projectPath: string) => {
+    setRepairTarget(projectPath)
+  }, [])
+
+  const handleConfirmRepair = useCallback(async () => {
+    if (!repairTarget) return
+
+    try {
+      await repairBreadcrumbs(repairTarget)
+      toast.success('Breadcrumbs repaired — backup saved as breadcrumbs.json.bak')
+      await refreshProject(repairTarget)
+      if (selectedProject === repairTarget) {
+        await readLiveBreadcrumbs(repairTarget)
+      }
+    } catch (repairError) {
+      logger.error('Failed to repair breadcrumbs:', repairError)
+      toast.error(`Failed to repair breadcrumbs: ${repairError}`)
+    } finally {
+      setRepairTarget(null)
+    }
+  }, [
+    repairTarget,
+    repairBreadcrumbs,
+    refreshProject,
+    selectedProject,
+    readLiveBreadcrumbs
+  ])
+
   const handleGeneratePreview = useCallback(async () => {
     if (selectedProject && selectedProjectData) {
       await generatePreview(selectedProject, selectedProjectData)
@@ -338,6 +371,7 @@ const BakerPageContent: React.FC = () => {
                   selectedProject={selectedProject}
                   onProjectSelection={handleProjectSelection}
                   onProjectClick={handleProjectClick}
+                  onRepairProject={handleRepairRequest}
                 />
               </div>
 
@@ -351,6 +385,7 @@ const BakerPageContent: React.FC = () => {
                   preview={selectedProject ? getPreview(selectedProject) : null}
                   isGeneratingPreview={isGenerating}
                   onGeneratePreview={handleGeneratePreview}
+                  onRepairProject={handleRepairRequest}
                   trelloApiKey={apiKey}
                   trelloApiToken={token}
                 />
@@ -391,6 +426,19 @@ const BakerPageContent: React.FC = () => {
           .filter((preview): preview is NonNullable<typeof preview> => preview !== null)}
         isLoading={isUpdating}
         invalidBreadcrumbsPaths={invalidBreadcrumbsPaths}
+      />
+
+      {/* Repair Breadcrumbs Confirmation Dialog */}
+      <RepairBreadcrumbsDialog
+        open={repairTarget !== null}
+        projectName={
+          scanResult?.projects.find((p) => p.path === repairTarget)?.name ?? null
+        }
+        isRepairing={isRepairing}
+        onOpenChange={(open) => {
+          if (!open) setRepairTarget(null)
+        }}
+        onConfirm={handleConfirmRepair}
       />
     </div>
   )

--- a/src/features/Baker/__contracts__/baker.contract.test.ts
+++ b/src/features/Baker/__contracts__/baker.contract.test.ts
@@ -24,6 +24,8 @@ vi.mock('../api', () => ({
   bakerUpdateBreadcrumbsSizes: vi
     .fn()
     .mockResolvedValue({ successful: [], failed: [], created: [], updated: [] }),
+  bakerRepairBreadcrumbs: vi.fn().mockResolvedValue({}),
+  bakerValidateFolder: vi.fn().mockResolvedValue({}),
   bakerGetVideoLinks: vi.fn().mockResolvedValue([]),
   bakerAssociateVideoLink: vi.fn().mockResolvedValue({}),
   bakerRemoveVideoLink: vi.fn().mockResolvedValue({}),
@@ -207,7 +209,7 @@ describe('Baker Barrel Exports - Shape', () => {
 
 describe('Baker api.ts Exports - Shape', () => {
   const expectedApiExports = [
-    // Tauri Commands (14)
+    // Tauri Commands (16)
     'bakerStartScan',
     'bakerCancelScan',
     'bakerGetScanStatus',
@@ -216,6 +218,8 @@ describe('Baker api.ts Exports - Shape', () => {
     'bakerScanCurrentFiles',
     'bakerUpdateBreadcrumbs',
     'bakerUpdateBreadcrumbsSizes',
+    'bakerRepairBreadcrumbs',
+    'bakerValidateFolder',
     'bakerGetVideoLinks',
     'bakerAssociateVideoLink',
     'bakerRemoveVideoLink',
@@ -242,13 +246,13 @@ describe('Baker api.ts Exports - Shape', () => {
     'addTrelloCardComment'
   ].sort()
 
-  it('exports exactly 27 I/O wrapper functions', () => {
+  it('exports exactly 29 I/O wrapper functions', () => {
     const exportNames = Object.keys(bakerApi).sort()
     expect(exportNames).toEqual(expectedApiExports)
   })
 
-  it('exports exactly 27 members', () => {
-    expect(Object.keys(bakerApi)).toHaveLength(27)
+  it('exports exactly 29 members', () => {
+    expect(Object.keys(bakerApi)).toHaveLength(29)
   })
 
   for (const name of expectedApiExports) {
@@ -667,5 +671,58 @@ describe('useBakerScan - Behavior', () => {
     // Should still only have called bakerStartScan once
     expect(mockStartScan).toHaveBeenCalledTimes(1)
     expect(result.current.isScanning).toBe(true)
+  })
+
+  it('refreshProject: re-validates one project and patches it into scanResult', async () => {
+    let capturedCompleteCallback: ((event: Event<unknown>) => void) | null = null
+    const mockListenComplete = vi.mocked(bakerApi.listenScanComplete)
+    mockListenComplete.mockImplementation(async (cb) => {
+      capturedCompleteCallback = cb as unknown as (event: Event<unknown>) => void
+      return () => {}
+    })
+
+    const staleProject = {
+      path: '/v/Broken',
+      name: 'Broken',
+      isValid: false,
+      hasBreadcrumbs: false,
+      staleBreadcrumbs: false,
+      invalidBreadcrumbs: true,
+      lastScanned: '2026-07-01T00:00:00Z',
+      cameraCount: 0,
+      validationErrors: []
+    }
+    const repairedProject = {
+      ...staleProject,
+      isValid: true,
+      hasBreadcrumbs: true,
+      invalidBreadcrumbs: false
+    }
+
+    vi.mocked(bakerApi.bakerStartScan).mockResolvedValue('scan-refresh')
+    vi.mocked(bakerApi.bakerValidateFolder).mockResolvedValue(repairedProject)
+
+    const { result } = renderHook(() => useBakerScan())
+
+    await act(async () => {
+      await result.current.startScan('/v', defaultOptions)
+    })
+    await act(async () => {
+      capturedCompleteCallback!({
+        event: 'baker_scan_complete',
+        id: 5,
+        payload: {
+          scanId: 'scan-refresh',
+          result: { ...mockScanResult, projects: [staleProject] }
+        }
+      })
+    })
+
+    await act(async () => {
+      await result.current.refreshProject('/v/Broken')
+    })
+
+    expect(bakerApi.bakerValidateFolder).toHaveBeenCalledWith('/v/Broken')
+    expect(result.current.scanResult?.projects[0]).toEqual(repairedProject)
   })
 })

--- a/src/features/Baker/api.ts
+++ b/src/features/Baker/api.ts
@@ -18,6 +18,7 @@ import type {
   BatchUpdateResult,
   BreadcrumbsFile,
   FileInfo,
+  ProjectFolder,
   ScanCompleteEvent,
   ScanErrorEvent,
   ScanOptions,
@@ -126,6 +127,16 @@ export async function bakerUpdateBreadcrumbsSizes(
   return invoke<BatchUpdateResult>('baker_update_breadcrumbs_sizes', {
     projectPaths
   })
+}
+
+export async function bakerRepairBreadcrumbs(
+  projectPath: string
+): Promise<BreadcrumbsFile> {
+  return invoke<BreadcrumbsFile>('baker_repair_breadcrumbs', { projectPath })
+}
+
+export async function bakerValidateFolder(folderPath: string): Promise<ProjectFolder> {
+  return invoke<ProjectFolder>('baker_validate_folder', { folderPath })
 }
 
 export async function getFolderSize(folderPath: string): Promise<number> {

--- a/src/features/Baker/components/ProjectDetailPanel.tsx
+++ b/src/features/Baker/components/ProjectDetailPanel.tsx
@@ -26,7 +26,8 @@ import {
   User,
   UserCheck,
   UserPlus,
-  Video
+  Video,
+  Wrench
 } from 'lucide-react'
 import { toast } from 'sonner'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -64,6 +65,7 @@ interface ProjectDetailPanelProps {
   preview: BreadcrumbsPreview | null
   isGeneratingPreview: boolean
   onGeneratePreview: () => void | Promise<void>
+  onRepairProject?: (projectPath: string) => void
   trelloApiKey?: string
   trelloApiToken?: string
 }
@@ -77,6 +79,7 @@ export const ProjectDetailPanel: React.FC<ProjectDetailPanelProps> = ({
   preview,
   isGeneratingPreview,
   onGeneratePreview,
+  onRepairProject,
   trelloApiKey,
   trelloApiToken
 }) => {
@@ -111,6 +114,7 @@ export const ProjectDetailPanel: React.FC<ProjectDetailPanelProps> = ({
       preview={preview}
       isGeneratingPreview={isGeneratingPreview}
       onGeneratePreview={onGeneratePreview}
+      onRepairProject={onRepairProject}
       trelloApiKey={trelloApiKey}
       trelloApiToken={trelloApiToken}
     />
@@ -125,6 +129,7 @@ interface ProjectDetailContentProps {
   preview: BreadcrumbsPreview | null
   isGeneratingPreview: boolean
   onGeneratePreview: () => void | Promise<void>
+  onRepairProject?: (projectPath: string) => void
   trelloApiKey?: string
   trelloApiToken?: string
 }
@@ -137,6 +142,7 @@ const ProjectDetailContent: React.FC<ProjectDetailContentProps> = ({
   preview,
   isGeneratingPreview,
   onGeneratePreview,
+  onRepairProject,
   trelloApiKey,
   trelloApiToken
 }) => {
@@ -175,6 +181,7 @@ const ProjectDetailContent: React.FC<ProjectDetailContentProps> = ({
                 preview={preview}
                 isGeneratingPreview={isGeneratingPreview}
                 onGeneratePreview={onGeneratePreview}
+                onRepairProject={onRepairProject}
               />
               <OverviewStats breadcrumbs={breadcrumbs} />
               <LinkedResources
@@ -209,6 +216,7 @@ const ProjectDetailContent: React.FC<ProjectDetailContentProps> = ({
             preview={preview}
             isGeneratingPreview={isGeneratingPreview}
             onGeneratePreview={onGeneratePreview}
+            onRepairProject={onRepairProject}
           />
           {breadcrumbsError ? (
             <div className="text-destructive flex items-center gap-2 text-sm">
@@ -275,7 +283,9 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
           <BreadcrumbsStatusPill project={project} />
           {cameraCount !== undefined && (
             <HeaderPill tone="muted">
-              {cameraCount} camera{cameraCount !== 1 ? 's' : ''}
+              {cameraCount === 0
+                ? 'No cameras'
+                : `${cameraCount} camera${cameraCount !== 1 ? 's' : ''}`}
             </HeaderPill>
           )}
         </div>
@@ -331,6 +341,7 @@ interface BreadcrumbsCalloutProps {
   preview: BreadcrumbsPreview | null
   isGeneratingPreview: boolean
   onGeneratePreview: () => void | Promise<void>
+  onRepairProject?: (projectPath: string) => void
 }
 
 function calloutHeadline(project: ProjectFolder): string {
@@ -369,7 +380,8 @@ const BreadcrumbsCallout: React.FC<BreadcrumbsCalloutProps> = ({
   project,
   preview,
   isGeneratingPreview,
-  onGeneratePreview
+  onGeneratePreview,
+  onRepairProject
 }) => {
   if (!project) return null
 
@@ -411,6 +423,17 @@ const BreadcrumbsCallout: React.FC<BreadcrumbsCalloutProps> = ({
           </p>
           <p className="text-muted-foreground text-xs">{subline}</p>
         </div>
+        {project.invalidBreadcrumbs && onRepairProject && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onRepairProject(project.path)}
+            className="border-destructive/30 text-destructive hover:bg-destructive/10 flex-shrink-0 gap-1.5"
+          >
+            <Wrench className="h-3.5 w-3.5" />
+            Repair breadcrumbs
+          </Button>
+        )}
         {!preview && (
           <Button
             variant="outline"

--- a/src/features/Baker/components/ProjectListPanel.test.tsx
+++ b/src/features/Baker/components/ProjectListPanel.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Project List Panel Tests
+ *
+ * B2.1 — 0-camera projects show a "No cameras" pill instead of "0 cams".
+ * B3.1 — projects with unparseable breadcrumbs expose a Repair action.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ProjectFolder } from '../types'
+import { ProjectListPanel } from './ProjectListPanel'
+
+const project = (overrides: Partial<ProjectFolder> = {}): ProjectFolder => ({
+  path: '/Volumes/Media/Show A',
+  name: 'Show A',
+  isValid: true,
+  hasBreadcrumbs: true,
+  staleBreadcrumbs: false,
+  invalidBreadcrumbs: false,
+  lastScanned: '2026-07-01T00:00:00Z',
+  cameraCount: 2,
+  validationErrors: [],
+  folderSizeBytes: 2048,
+  ...overrides
+})
+
+const renderPanel = (
+  projects: ProjectFolder[],
+  onRepairProject: (path: string) => void = vi.fn()
+) =>
+  render(
+    <ProjectListPanel
+      projects={projects}
+      selectedProjects={[]}
+      selectedProject={null}
+      onProjectSelection={vi.fn()}
+      onProjectClick={vi.fn()}
+      onRepairProject={onRepairProject}
+    />
+  )
+
+describe('ProjectListPanel camera pill (B2.1)', () => {
+  it('shows a "No cameras" pill for 0-camera projects', () => {
+    renderPanel([project({ cameraCount: 0 })])
+
+    expect(screen.getByText('No cameras')).toBeInTheDocument()
+    expect(screen.queryByText(/0 cams/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the camera count pill for projects with cameras', () => {
+    renderPanel([project({ cameraCount: 2 })])
+
+    expect(screen.getByText('2 cams')).toBeInTheDocument()
+    expect(screen.queryByText('No cameras')).not.toBeInTheDocument()
+  })
+})
+
+describe('ProjectListPanel repair action (B3.1)', () => {
+  it('shows a Repair button only for projects with unparseable breadcrumbs', () => {
+    renderPanel([
+      project({ invalidBreadcrumbs: true, path: '/v/Broken', name: 'Broken' }),
+      project({ path: '/v/Fine', name: 'Fine' })
+    ])
+
+    expect(screen.getAllByRole('button', { name: 'Repair' })).toHaveLength(1)
+  })
+
+  it('invokes onRepairProject with the project path without selecting the row', () => {
+    const onRepair = vi.fn()
+    const onClick = vi.fn()
+    render(
+      <ProjectListPanel
+        projects={[project({ invalidBreadcrumbs: true, path: '/v/Broken' })]}
+        selectedProjects={[]}
+        selectedProject={null}
+        onProjectSelection={vi.fn()}
+        onProjectClick={onClick}
+        onRepairProject={onRepair}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Repair' }))
+
+    expect(onRepair).toHaveBeenCalledWith('/v/Broken')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/Baker/components/ProjectListPanel.tsx
+++ b/src/features/Baker/components/ProjectListPanel.tsx
@@ -80,11 +80,13 @@ const StatusPill: React.FC<StatusPillProps> = ({ tone, dot = true, children }) =
 interface ProjectStatusPillsProps {
   project: ProjectFolder
   shouldReduceMotion: boolean
+  onRepairProject?: (projectPath: string) => void
 }
 
 const ProjectStatusPills: React.FC<ProjectStatusPillsProps> = ({
   project,
-  shouldReduceMotion
+  shouldReduceMotion,
+  onRepairProject
 }) => {
   const pulseStale = !shouldReduceMotion && project.staleBreadcrumbs
 
@@ -96,6 +98,19 @@ const ProjectStatusPills: React.FC<ProjectStatusPillsProps> = ({
 
       {project.invalidBreadcrumbs && (
         <StatusPill tone="destructive">Invalid BC</StatusPill>
+      )}
+
+      {project.invalidBreadcrumbs && onRepairProject && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onRepairProject(project.path)
+          }}
+          className="border-destructive/30 text-destructive hover:bg-destructive/10 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors"
+        >
+          Repair
+        </button>
       )}
 
       {project.hasBreadcrumbs && !project.invalidBreadcrumbs && (
@@ -125,7 +140,9 @@ const ProjectStatusPills: React.FC<ProjectStatusPillsProps> = ({
       )}
 
       <StatusPill tone="muted" dot={false}>
-        {project.cameraCount} cam{project.cameraCount !== 1 ? 's' : ''}
+        {project.cameraCount === 0
+          ? 'No cameras'
+          : `${project.cameraCount} cam${project.cameraCount !== 1 ? 's' : ''}`}
       </StatusPill>
 
       {typeof project.folderSizeBytes === 'number' ? (
@@ -147,6 +164,7 @@ interface ProjectListPanelProps {
   selectedProject: string | null
   onProjectSelection: (projectPath: string, isSelected: boolean) => void
   onProjectClick: (projectPath: string) => void
+  onRepairProject?: (projectPath: string) => void
 }
 
 const ProjectListPanelComponent: React.FC<ProjectListPanelProps> = ({
@@ -154,7 +172,8 @@ const ProjectListPanelComponent: React.FC<ProjectListPanelProps> = ({
   selectedProjects,
   selectedProject,
   onProjectSelection,
-  onProjectClick
+  onProjectClick,
+  onRepairProject
 }) => {
   const shouldReduceMotion = useReducedMotion()
   const parentRef = React.useRef<HTMLDivElement>(null)
@@ -258,7 +277,11 @@ const ProjectListPanelComponent: React.FC<ProjectListPanelProps> = ({
           </p>
           <p className="text-muted-foreground truncate text-xs">{project.path}</p>
 
-          <ProjectStatusPills project={project} shouldReduceMotion={shouldReduceMotion} />
+          <ProjectStatusPills
+            project={project}
+            shouldReduceMotion={shouldReduceMotion}
+            onRepairProject={onRepairProject}
+          />
         </div>
       </div>
     )

--- a/src/features/Baker/components/RepairBreadcrumbsDialog.test.tsx
+++ b/src/features/Baker/components/RepairBreadcrumbsDialog.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Repair Breadcrumbs Dialog Tests
+ *
+ * B3.1/B3.2 — repairing an unparseable breadcrumbs file is confirmed via an
+ * AlertDialog that explains a backup is always written first.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { RepairBreadcrumbsDialog } from './RepairBreadcrumbsDialog'
+
+const renderDialog = (
+  overrides: Partial<React.ComponentProps<typeof RepairBreadcrumbsDialog>> = {}
+) => {
+  const props = {
+    open: true,
+    projectName: 'Podcast Ep 1',
+    isRepairing: false,
+    onOpenChange: vi.fn(),
+    onConfirm: vi.fn(),
+    ...overrides
+  }
+  render(<RepairBreadcrumbsDialog {...props} />)
+  return props
+}
+
+describe('RepairBreadcrumbsDialog', () => {
+  it('names the project and mentions the backup', () => {
+    renderDialog()
+
+    expect(screen.getByText(/Podcast Ep 1/)).toBeInTheDocument()
+    expect(screen.getByText(/backup/i)).toBeInTheDocument()
+  })
+
+  it('confirms the repair', () => {
+    const props = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: /repair/i }))
+
+    expect(props.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('can be cancelled without repairing', () => {
+    const props = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(props.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('disables the confirm button while repairing', () => {
+    renderDialog({ isRepairing: true })
+
+    expect(screen.getByRole('button', { name: /repairing/i })).toBeDisabled()
+  })
+})

--- a/src/features/Baker/components/RepairBreadcrumbsDialog.tsx
+++ b/src/features/Baker/components/RepairBreadcrumbsDialog.tsx
@@ -1,0 +1,69 @@
+/**
+ * Repair Breadcrumbs Dialog
+ *
+ * Confirmation dialog shown before regenerating an unparseable breadcrumbs.json
+ * from the folder contents. The repair always writes breadcrumbs.json.bak
+ * first and salvages linked Trello cards / video links where possible.
+ */
+
+import { Wrench } from 'lucide-react'
+import React from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@shared/ui/alert-dialog'
+
+interface RepairBreadcrumbsDialogProps {
+  open: boolean
+  projectName: string | null
+  isRepairing: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+export const RepairBreadcrumbsDialog: React.FC<RepairBreadcrumbsDialogProps> = ({
+  open,
+  projectName,
+  isRepairing,
+  onOpenChange,
+  onConfirm
+}) => (
+  <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle className="flex items-center gap-2">
+          <Wrench className="h-4 w-4" />
+          Repair breadcrumbs
+        </AlertDialogTitle>
+        <AlertDialogDescription>
+          The breadcrumbs file for{' '}
+          <span className="text-foreground font-medium">
+            {projectName ?? 'this project'}
+          </span>{' '}
+          is unparseable and will be rebuilt from the folder contents. Linked Trello cards
+          and video links are preserved where possible, and the current file is saved as a
+          backup (breadcrumbs.json.bak) first.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel disabled={isRepairing}>Cancel</AlertDialogCancel>
+        <AlertDialogAction
+          disabled={isRepairing}
+          onClick={(e) => {
+            e.preventDefault()
+            onConfirm()
+          }}
+        >
+          {isRepairing ? 'Repairing…' : 'Repair'}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+)

--- a/src/features/Baker/hooks/useBakerScan.ts
+++ b/src/features/Baker/hooks/useBakerScan.ts
@@ -11,6 +11,7 @@ import {
   bakerCancelScan,
   bakerGetScanStatus,
   bakerStartScan,
+  bakerValidateFolder,
   listenScanComplete,
   listenScanError,
   listenScanProgress
@@ -188,6 +189,20 @@ export function useBakerScan(): UseBakerScanResult {
     setScanStartTime(null)
   }, [isScanning])
 
+  // Re-validate a single project (e.g. after a breadcrumbs repair) and patch
+  // it into the current results without requiring a full rescan.
+  const refreshProject = useCallback(async (projectPath: string) => {
+    const updated = await bakerValidateFolder(projectPath)
+    setScanResult((prev) =>
+      prev
+        ? {
+            ...prev,
+            projects: prev.projects.map((p) => (p.path === projectPath ? updated : p))
+          }
+        : prev
+    )
+  }, [])
+
   // Clean up polling on unmount
   useEffect(() => {
     return () => stopPolling()
@@ -200,6 +215,7 @@ export function useBakerScan(): UseBakerScanResult {
     scanStartTime,
     startScan,
     cancelScan,
-    clearResults
+    clearResults,
+    refreshProject
   }
 }

--- a/src/features/Baker/hooks/useLiveBreadcrumbsReader.test.ts
+++ b/src/features/Baker/hooks/useLiveBreadcrumbsReader.test.ts
@@ -1,0 +1,81 @@
+/**
+ * useLiveBreadcrumbsReader Tests
+ *
+ * B2.2 — a legitimate numberOfCameras of 0 (podcast/audio-only project) must
+ * round-trip through the live reader without being clamped up to 1.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BreadcrumbsFile, FileInfo } from '../types'
+
+vi.mock('../api', () => ({
+  bakerReadBreadcrumbs: vi.fn(),
+  bakerReadRawBreadcrumbs: vi.fn(),
+  bakerScanCurrentFiles: vi.fn()
+}))
+
+import { bakerReadBreadcrumbs, bakerScanCurrentFiles } from '../api'
+import { useLiveBreadcrumbsReader } from './useLiveBreadcrumbsReader'
+
+const breadcrumbs = (overrides: Partial<BreadcrumbsFile> = {}): BreadcrumbsFile => ({
+  projectTitle: 'Podcast Ep 1',
+  numberOfCameras: 0,
+  files: [],
+  parentFolder: '/Volumes/Media',
+  createdBy: 'Baker',
+  creationDateTime: '2026-07-01T00:00:00Z',
+  ...overrides
+})
+
+const file = (camera: number, name: string): FileInfo => ({
+  camera,
+  name,
+  path: `Footage/Camera ${camera}/${name}`
+})
+
+describe('useLiveBreadcrumbsReader camera count (B2.2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves numberOfCameras 0 when no camera files exist on disk', async () => {
+    vi.mocked(bakerReadBreadcrumbs).mockResolvedValue(breadcrumbs({ numberOfCameras: 0 }))
+    vi.mocked(bakerScanCurrentFiles).mockResolvedValue([])
+
+    const { result } = renderHook(() => useLiveBreadcrumbsReader())
+    await act(async () => {
+      await result.current.readLiveBreadcrumbs('/Volumes/Media/Podcast Ep 1')
+    })
+
+    expect(result.current.breadcrumbs?.numberOfCameras).toBe(0)
+  })
+
+  it('preserves the recorded camera count when camera folders are empty', async () => {
+    vi.mocked(bakerReadBreadcrumbs).mockResolvedValue(breadcrumbs({ numberOfCameras: 2 }))
+    vi.mocked(bakerScanCurrentFiles).mockResolvedValue([])
+
+    const { result } = renderHook(() => useLiveBreadcrumbsReader())
+    await act(async () => {
+      await result.current.readLiveBreadcrumbs('/Volumes/Media/Show A')
+    })
+
+    expect(result.current.breadcrumbs?.numberOfCameras).toBe(2)
+  })
+
+  it('derives the camera count from live files when files exist', async () => {
+    vi.mocked(bakerReadBreadcrumbs).mockResolvedValue(breadcrumbs({ numberOfCameras: 1 }))
+    vi.mocked(bakerScanCurrentFiles).mockResolvedValue([
+      file(1, 'a.mp4'),
+      file(3, 'c.mp4')
+    ])
+
+    const { result } = renderHook(() => useLiveBreadcrumbsReader())
+    await act(async () => {
+      await result.current.readLiveBreadcrumbs('/Volumes/Media/Show B')
+    })
+
+    expect(result.current.breadcrumbs?.numberOfCameras).toBe(3)
+  })
+})

--- a/src/features/Baker/hooks/useLiveBreadcrumbsReader.ts
+++ b/src/features/Baker/hooks/useLiveBreadcrumbsReader.ts
@@ -18,6 +18,14 @@ import { logger } from '@shared/utils'
 // Constants
 const RAW_CONTENT_PREVIEW_LIMIT = 200
 
+/**
+ * Camera count as observed on disk. 0 is a legitimate value (podcast/audio-only
+ * projects) and must never be clamped up — when no files exist the fallback
+ * (usually the recorded numberOfCameras) is used instead.
+ */
+const liveCameraCount = (files: FileInfo[], fallback: number): number =>
+  files.length > 0 ? Math.max(...files.map((f) => f.camera)) : fallback
+
 interface UseLiveBreadcrumbsReaderResult {
   breadcrumbs: BreadcrumbsFile | null
   isLoading: boolean
@@ -68,7 +76,10 @@ export function useLiveBreadcrumbsReader(): UseLiveBreadcrumbsReaderResult {
         const liveBreadcrumbs: BreadcrumbsFile = {
           ...existingBreadcrumbs,
           files: actualFiles,
-          numberOfCameras: Math.max(1, Math.max(...actualFiles.map((f) => f.camera), 0))
+          numberOfCameras: liveCameraCount(
+            actualFiles,
+            existingBreadcrumbs.numberOfCameras
+          )
         }
         setBreadcrumbs(liveBreadcrumbs)
       } else if (actualFiles.length > 0) {
@@ -76,7 +87,7 @@ export function useLiveBreadcrumbsReader(): UseLiveBreadcrumbsReaderResult {
         const projectName = projectPath.split('/').pop() || 'Unknown Project'
         const liveBreadcrumbs: BreadcrumbsFile = {
           projectTitle: projectName,
-          numberOfCameras: Math.max(1, Math.max(...actualFiles.map((f) => f.camera), 0)),
+          numberOfCameras: liveCameraCount(actualFiles, 0),
           files: actualFiles,
           parentFolder: projectPath.split('/').slice(0, -1).join('/'),
           createdBy: 'Unknown',
@@ -104,10 +115,7 @@ export function useLiveBreadcrumbsReader(): UseLiveBreadcrumbsReaderResult {
           const projectName = projectPath.split('/').pop() || 'Unknown Project'
           const fallbackBreadcrumbs: BreadcrumbsFile = {
             projectTitle: projectName,
-            numberOfCameras: Math.max(
-              1,
-              Math.max(...actualFiles.map((f) => f.camera), 0)
-            ),
+            numberOfCameras: liveCameraCount(actualFiles, 0),
             files: actualFiles,
             parentFolder: projectPath.split('/').slice(0, -1).join('/'),
             createdBy: 'Baker (recovered from file system)',

--- a/src/features/Baker/hooks/useRepairBreadcrumbs.ts
+++ b/src/features/Baker/hooks/useRepairBreadcrumbs.ts
@@ -1,0 +1,31 @@
+/**
+ * useRepairBreadcrumbs Hook
+ *
+ * Regenerates a project's unparseable breadcrumbs.json from the folder
+ * contents (always backing the original up to breadcrumbs.json.bak first).
+ */
+
+import { useCallback, useState } from 'react'
+
+import { bakerRepairBreadcrumbs } from '../api'
+import type { BreadcrumbsFile } from '../types'
+
+interface UseRepairBreadcrumbsResult {
+  repairBreadcrumbs: (projectPath: string) => Promise<BreadcrumbsFile>
+  isRepairing: boolean
+}
+
+export function useRepairBreadcrumbs(): UseRepairBreadcrumbsResult {
+  const [isRepairing, setIsRepairing] = useState(false)
+
+  const repairBreadcrumbs = useCallback(async (projectPath: string) => {
+    setIsRepairing(true)
+    try {
+      return await bakerRepairBreadcrumbs(projectPath)
+    } finally {
+      setIsRepairing(false)
+    }
+  }, [])
+
+  return { repairBreadcrumbs, isRepairing }
+}

--- a/src/features/Baker/types.ts
+++ b/src/features/Baker/types.ts
@@ -154,6 +154,7 @@ export interface UseBakerScanResult {
   // Actions
   startScan: (rootPath: string, options: ScanOptions) => Promise<void>
   cancelScan: () => void
+  refreshProject: (projectPath: string) => Promise<void>
 
   // Cleanup
   clearResults: () => void

--- a/src/features/BuildProject/hooks/useCameraAutoRemap.test.tsx
+++ b/src/features/BuildProject/hooks/useCameraAutoRemap.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * useCameraAutoRemap Tests
+ *
+ * B5.3 (issue #138) — with 0 cameras there is no valid camera to remap to, so
+ * the hook must leave file assignments untouched instead of clamping them to 1.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { FootageFile } from '../types'
+import { useCameraAutoRemap } from './useCameraAutoRemap'
+
+const footage = (camera: number, name: string): FootageFile => ({
+  file: { path: `/media/${name}`, name },
+  camera
+})
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe('useCameraAutoRemap', () => {
+  it('remaps out-of-range cameras to 1 when at least one camera exists', async () => {
+    const setFiles = vi.fn()
+    const files = [footage(3, 'a.mp4')]
+
+    renderHook(() => useCameraAutoRemap(files, 1, setFiles), { wrapper })
+
+    await waitFor(() => {
+      expect(setFiles).toHaveBeenCalledWith([{ ...files[0], camera: 1 }])
+    })
+  })
+
+  it('leaves files untouched when numCameras is 0 (B5.3)', async () => {
+    const setFiles = vi.fn()
+    const files = [footage(2, 'a.mp4'), footage(1, 'b.mp4')]
+
+    renderHook(() => useCameraAutoRemap(files, 0, setFiles), { wrapper })
+
+    // Give the query a beat to settle, then assert nothing was remapped.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(setFiles).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/BuildProject/hooks/useCameraAutoRemap.ts
+++ b/src/features/BuildProject/hooks/useCameraAutoRemap.ts
@@ -21,7 +21,10 @@ export function useCameraAutoRemap(
     ...createQueryOptions(
       queryKeys.camera.autoRemap(`${filesHash}-${numCameras}`),
       async () => {
-        if (files.length === 0) return files
+        // With 0 cameras (podcast/audio-only project) there is no valid
+        // camera to remap to — leave assignments alone and let validation
+        // report the conflict instead.
+        if (files.length === 0 || numCameras === 0) return files
 
         const hasInvalidCameras = files.some(
           (file) => file.camera > numCameras || file.camera < 1

--- a/src/features/build-project/__tests__/validation.test.ts
+++ b/src/features/build-project/__tests__/validation.test.ts
@@ -332,6 +332,62 @@ describe('Validation Stage', () => {
       })
     })
 
+    describe('zero-camera (podcast) projects — issue #138 B5.2', () => {
+      it('should pass with 0 cameras and no files', async () => {
+        vi.mocked(exists).mockResolvedValueOnce(true)
+
+        const input: ValidationInput = {
+          files: [],
+          projectName: 'Podcast Ep 1',
+          outputPath: '/valid/path',
+          numCameras: 0
+        }
+
+        const result = await validateInputs(input)
+
+        expect(result.ok).toBe(true)
+        if (result.ok) {
+          expect(result.data.isValid).toBe(true)
+        }
+      })
+
+      it('should fail with 0 cameras and footage files present', async () => {
+        vi.mocked(exists).mockResolvedValueOnce(true)
+
+        const input: ValidationInput = {
+          files: [{ file: { path: '/path/to/video.mp4', name: 'video.mp4' }, camera: 1 }],
+          projectName: 'Podcast Ep 1',
+          outputPath: '/valid/path',
+          numCameras: 0
+        }
+
+        const result = await validateInputs(input)
+
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.message.toLowerCase()).toContain('camera')
+        }
+      })
+
+      it('should still fail with 1+ cameras and no files', async () => {
+        vi.mocked(exists).mockResolvedValueOnce(true)
+
+        const input: ValidationInput = {
+          files: [],
+          projectName: 'Video Project',
+          outputPath: '/valid/path',
+          numCameras: 2
+        }
+
+        const result = await validateInputs(input)
+
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+          expect(result.error.message).toContain('At least one file')
+        }
+      })
+    })
+
     describe('output path validation', () => {
       it('should fail when output path is empty', async () => {
         const input: ValidationInput = {

--- a/src/features/build-project/stages/validation.ts
+++ b/src/features/build-project/stages/validation.ts
@@ -126,9 +126,18 @@ const MAX_PROJECT_NAME_LENGTH = 200
 // =============================================================================
 
 /**
- * Validates that the files array is not empty
+ * Validates that the files array is not empty.
+ *
+ * A 0-camera (podcast/audio-only) project is scaffolded without footage, so
+ * an empty file list is only an error when the project has cameras.
  */
-function validateFilesNotEmpty(files: FileWithCamera[]): ValidationError | null {
+function validateFilesNotEmpty(
+  files: FileWithCamera[],
+  numCameras: number
+): ValidationError | null {
+  if (numCameras === 0) {
+    return null
+  }
   if (!files || files.length === 0) {
     return {
       field: 'files',
@@ -242,8 +251,18 @@ function validateCameraAssignments(
   files: FileWithCamera[],
   numCameras: number
 ): ValidationError | null {
-  if (!files || files.length === 0 || numCameras < 1) {
-    return null // Skip if no files or invalid numCameras
+  if (!files || files.length === 0) {
+    return null // Skip if no files
+  }
+
+  // A 0-camera (podcast/audio-only) project has nowhere to put footage.
+  if (numCameras === 0) {
+    return {
+      field: 'cameraAssignments',
+      message:
+        'Footage files are assigned but the project has no cameras. Remove the footage files or set at least 1 camera.',
+      context: { numCameras, fileCount: files.length }
+    }
   }
 
   const invalidAssignments: Array<{ fileName: string; camera: number }> = []
@@ -295,7 +314,7 @@ export async function validateInputs(
 
   try {
     // Run synchronous validations first
-    const filesError = validateFilesNotEmpty(input.files)
+    const filesError = validateFilesNotEmpty(input.files, input.numCameras)
     if (filesError) {
       errors.push(filesError)
     }
@@ -328,11 +347,10 @@ export async function validateInputs(
     // Compute the project folder path
     const projectFolder = `${input.outputPath}/${input.projectName.trim()}`
 
-    // Check for potential warnings (non-blocking)
+    // Check for potential warnings (non-blocking). Only reachable for
+    // 0-camera projects — with cameras, an empty file list fails validation.
     if (input.files.length === 0) {
-      warnings.push(
-        'No files selected. Project will be created with empty camera folders.'
-      )
+      warnings.push('No files selected. Project will be created without camera folders.')
     }
 
     // Return success with validation data

--- a/src/shared/constants/__contracts__/constants.contract.test.ts
+++ b/src/shared/constants/__contracts__/constants.contract.test.ts
@@ -189,11 +189,10 @@ describe('@shared/constants barrel contract', () => {
 
   describe('behavior: project constants have correct values', () => {
     test('PROJECT_LIMITS has camera constraints', () => {
-      expect(PROJECT_LIMITS.MIN_CAMERAS).toBe(1)
+      // 0 cameras is a legitimate project (podcast/audio-only) — see issue #138
+      expect(PROJECT_LIMITS.MIN_CAMERAS).toBe(0)
       expect(PROJECT_LIMITS.MAX_CAMERAS).toBeGreaterThan(PROJECT_LIMITS.MIN_CAMERAS)
-      expect(PROJECT_LIMITS.DEFAULT_CAMERAS).toBeGreaterThanOrEqual(
-        PROJECT_LIMITS.MIN_CAMERAS
-      )
+      expect(PROJECT_LIMITS.DEFAULT_CAMERAS).toBeGreaterThanOrEqual(1)
       expect(PROJECT_LIMITS.DEFAULT_CAMERAS).toBeLessThanOrEqual(
         PROJECT_LIMITS.MAX_CAMERAS
       )

--- a/src/shared/constants/project.ts
+++ b/src/shared/constants/project.ts
@@ -3,7 +3,8 @@
  */
 
 export const PROJECT_LIMITS = {
-  MIN_CAMERAS: 1,
+  // 0 cameras is a legitimate project (podcast/audio-only) — see issue #138
+  MIN_CAMERAS: 0,
   MAX_CAMERAS: 10,
   DEFAULT_CAMERAS: 2
 } as const


### PR DESCRIPTION
Closes #138.

## What

Baker was marking every 0-camera project invalid (podcast/audio-only work), refusing to repair unparseable breadcrumbs on "invalid" projects, and never discovering projects inside container folders or nested inside other projects. This PR implements the design agreed in #138:

### Validity (B1)
- 0 `Camera N` folders is **valid** when the five standard folders exist and ≥1 non-hidden file lives under them. `breadcrumbs.json` at the root doesn't count as content, so a metadata-only husk stays invalid (but remains repairable).
- ≥1 Camera folder keeps today's behaviour — freshly scaffolded shoots with empty camera folders are unaffected.

### 0-camera recognition (B2)
- "No cameras" pill in Baker's project list and detail panels.
- `useLiveBreadcrumbsReader` no longer clamps `numberOfCameras` up to 1; a recorded 0 round-trips faithfully.

### Repair (B3)
- New `baker_repair_breadcrumbs` command + Repair action (list row and detail callout) behind an AlertDialog confirmation.
- Repair **always** writes `breadcrumbs.json.bak` first and salvages `trelloCards`/`videoLinks`/`trelloCardUrl` from the corrupt file.
- Batch update gate relaxed: any folder with `Footage/` or an existing `breadcrumbs.json` can be updated/repaired (previously required fully valid structure).
- After a repair, the single project is re-validated and patched into the results — no full rescan needed.

### Scanner recursion (B4)
- Extracted an AppHandle-free `scan_directory_core` so traversal is unit-testable.
- Always recurses into non-project folders (containers with stray `Footage`/`Graphics` dirs no longer hide their children).
- Descends into projects to find nested projects, skipping the five standard sub-folders.

### Cross-feature audit (B5)
- `MIN_CAMERAS` lowered to 0 (input accepts 0; `DEFAULT_CAMERAS` stays 2).
- BuildProject validation: empty file list allowed **only** at 0 cameras (podcast scaffold); footage files with 0 cameras is now a clear validation error (previously silently skipped).
- `useCameraAutoRemap` no longer clamps every file to camera 1 when cameras is 0.
- Trello/Upload audited — no camera-count gating found, no changes needed.

## Testing (TDD)

Behaviours were specced in #138 first, tests written and confirmed red, then implemented:
- 23 Rust baker tests (validation, repair, gate, traversal) — all passing (`cargo test`: 103/103).
- New Vitest suites: `useLiveBreadcrumbsReader`, `ProjectListPanel`, `RepairBreadcrumbsDialog`, `useCameraAutoRemap`, plus updated contract tests (Baker api 29 exports, `MIN_CAMERAS === 0`) and build-project validation cases — 852 affected tests passing; full suite green apart from a stale local worktree artefact not present in CI.
- `bunx tsc --noEmit` clean (pre-existing jest-types warning only), `eslint` 0 errors, `prettier` applied.

## Notes for review
- No version bump (bumped on master per release flow).
- `total_folder_size` can now double-count a nested project's bytes (they're inside the parent too) — surfaced for awareness; happy to dedupe if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
