### PR TITLE
fix: render the UI in a plain browser instead of a blank page

### DIFF
--- a/src/shared/hooks/useSystemTheme.test.ts
+++ b/src/shared/hooks/useSystemTheme.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for useSystemTheme's behaviour with and without the Tauri bridge.
+ * Issue #144 (B3.1-B3.3)
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauriMock = vi.fn()
+const getCurrentWindowMock = vi.fn()
+const themeMock = vi.fn()
+const onThemeChangedMock = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock()
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => getCurrentWindowMock()
+}))
+
+import { useSystemTheme } from './useSystemTheme'
+
+beforeEach(() => {
+  isTauriMock.mockReset()
+  getCurrentWindowMock.mockReset()
+  themeMock.mockReset().mockResolvedValue('dark')
+  onThemeChangedMock.mockReset().mockResolvedValue(() => {})
+  getCurrentWindowMock.mockReturnValue({
+    theme: () => themeMock(),
+    onThemeChanged: (cb: (event: { payload: string }) => void) => onThemeChangedMock(cb)
+  })
+})
+
+describe('useSystemTheme outside the Tauri webview', () => {
+  it('b3_1_does_not_throw_and_reports_no_theme', () => {
+    isTauriMock.mockReturnValue(false)
+
+    const { result } = renderHook(() => useSystemTheme())
+
+    expect(result.current).toBeNull()
+  })
+
+  it('b3_2_never_asks_for_the_current_window', () => {
+    isTauriMock.mockReturnValue(false)
+
+    renderHook(() => useSystemTheme())
+
+    expect(getCurrentWindowMock).not.toHaveBeenCalled()
+    expect(onThemeChangedMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSystemTheme inside the Tauri webview', () => {
+  it('b3_3_reads_the_window_theme', async () => {
+    isTauriMock.mockReturnValue(true)
+
+    const { result } = renderHook(() => useSystemTheme())
+
+    await waitFor(() => expect(result.current).toBe('dark'))
+    expect(themeMock).toHaveBeenCalled()
+  })
+
+  it('b3_3_subscribes_to_theme_changes', async () => {
+    isTauriMock.mockReturnValue(true)
+
+    renderHook(() => useSystemTheme())
+
+    await waitFor(() => expect(onThemeChangedMock).toHaveBeenCalled())
+  })
+})

--- a/src/shared/hooks/useSystemTheme.ts
+++ b/src/shared/hooks/useSystemTheme.ts
@@ -2,6 +2,8 @@
 import { useEffect, useState } from 'react'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 
+import { isTauriRuntime } from '@shared/utils'
+
 export type SystemTheme = 'light' | 'dark' | null
 
 /**
@@ -26,6 +28,10 @@ export function useSystemTheme() {
   const [theme, setTheme] = useState<SystemTheme>(null)
 
   useEffect(() => {
+    // Outside the desktop app there is no native theme to read, and
+    // getCurrentWindow() would throw and unmount the subtree (Issue #144)
+    if (!isTauriRuntime()) return
+
     const window = getCurrentWindow()
 
     // Get initial theme

--- a/src/shared/hooks/useWindowState.test.ts
+++ b/src/shared/hooks/useWindowState.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for useWindowState's behaviour with and without the Tauri bridge.
+ * Issue #144 (B2.1-B2.3)
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauriMock = vi.fn()
+const getCurrentWindowMock = vi.fn()
+const onResizedMock = vi.fn()
+const onMovedMock = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock()
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => getCurrentWindowMock(),
+  LogicalPosition: class {
+    constructor(
+      public x: number,
+      public y: number
+    ) {}
+  },
+  LogicalSize: class {
+    constructor(
+      public width: number,
+      public height: number
+    ) {}
+  }
+}))
+
+import { useWindowState } from './useWindowState'
+
+beforeEach(() => {
+  localStorage.clear()
+  isTauriMock.mockReset()
+  getCurrentWindowMock.mockReset()
+  onResizedMock.mockReset().mockResolvedValue(() => {})
+  onMovedMock.mockReset().mockResolvedValue(() => {})
+  getCurrentWindowMock.mockReturnValue({
+    setPosition: vi.fn().mockResolvedValue(undefined),
+    setSize: vi.fn().mockResolvedValue(undefined),
+    outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+    outerSize: vi.fn().mockResolvedValue({ width: 800, height: 600 }),
+    onResized: (cb: () => void) => onResizedMock(cb),
+    onMoved: (cb: () => void) => onMovedMock(cb)
+  })
+})
+
+describe('useWindowState outside the Tauri webview', () => {
+  it('b2_1_does_not_throw_when_there_is_no_bridge', () => {
+    isTauriMock.mockReturnValue(false)
+
+    expect(() => renderHook(() => useWindowState())).not.toThrow()
+  })
+
+  it('b2_2_never_asks_for_the_current_window', () => {
+    isTauriMock.mockReturnValue(false)
+
+    renderHook(() => useWindowState())
+
+    expect(getCurrentWindowMock).not.toHaveBeenCalled()
+  })
+
+  it('b2_2_registers_no_listeners', () => {
+    isTauriMock.mockReturnValue(false)
+
+    renderHook(() => useWindowState())
+
+    expect(onResizedMock).not.toHaveBeenCalled()
+    expect(onMovedMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('useWindowState inside the Tauri webview', () => {
+  it('b2_3_reads_the_current_window_and_registers_listeners', async () => {
+    isTauriMock.mockReturnValue(true)
+
+    renderHook(() => useWindowState())
+
+    expect(getCurrentWindowMock).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(onResizedMock).toHaveBeenCalled()
+      expect(onMovedMock).toHaveBeenCalled()
+    })
+  })
+
+  it('b2_3_restores_a_saved_window_state', async () => {
+    isTauriMock.mockReturnValue(true)
+    localStorage.setItem(
+      'bucket-window-state',
+      JSON.stringify({ x: 10, y: 20, width: 1024, height: 768 })
+    )
+
+    renderHook(() => useWindowState())
+
+    const tauriWindow = getCurrentWindowMock.mock.results[0].value
+    await waitFor(() => {
+      expect(tauriWindow.setPosition).toHaveBeenCalled()
+      expect(tauriWindow.setSize).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/shared/hooks/useWindowState.ts
+++ b/src/shared/hooks/useWindowState.ts
@@ -2,6 +2,8 @@
 import { useEffect } from 'react'
 import { getCurrentWindow, LogicalPosition, LogicalSize } from '@tauri-apps/api/window'
 
+import { isTauriRuntime } from '@shared/utils'
+
 interface WindowState {
   x: number
   y: number
@@ -58,6 +60,10 @@ function throttle<T extends (...args: unknown[]) => void>(
  */
 export function useWindowState() {
   useEffect(() => {
+    // Nothing to persist outside the desktop app, and getCurrentWindow()
+    // would throw here and unmount the whole tree (Issue #144)
+    if (!isTauriRuntime()) return
+
     const window = getCurrentWindow()
 
     // Restore saved position/size

--- a/src/shared/utils/__contracts__/utils.contract.test.ts
+++ b/src/shared/utils/__contracts__/utils.contract.test.ts
@@ -37,7 +37,9 @@ import {
   createDetailedFieldChange,
   generateProjectChangeDetail,
   generateBreadcrumbsPreview,
-  debugComparison
+  debugComparison,
+  // Runtime environment (Issue #144)
+  isTauriRuntime
 } from '@shared/utils'
 
 // Storage exports require Tauri runtime, test shape only via dynamic import
@@ -52,6 +54,12 @@ describe('@shared/utils barrel contract', () => {
 
     test('debounce export', () => {
       expect(debounce).toBeTypeOf('function')
+    })
+
+    // B1.3: hooks ask the barrel whether the Tauri bridge exists, rather than
+    // importing @tauri-apps themselves just to run the check.
+    test('runtime environment export', () => {
+      expect(isTauriRuntime).toBeTypeOf('function')
     })
 
     test('validation exports', () => {

--- a/src/shared/utils/environment.test.ts
+++ b/src/shared/utils/environment.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the Tauri runtime detection helper.
+ * Issue #144 (B1.1, B1.2, B4.1-B4.3)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauriMock = vi.fn()
+const warnMock = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock()
+}))
+
+vi.mock('./logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => warnMock(...args),
+    error: vi.fn(),
+    log: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  },
+  createNamespacedLogger: () => ({
+    warn: (...args: unknown[]) => warnMock(...args),
+    error: vi.fn(),
+    log: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+/** Fresh module each time so the once-only warning flag starts unset. */
+async function loadEnvironment() {
+  vi.resetModules()
+  return import('./environment')
+}
+
+beforeEach(() => {
+  isTauriMock.mockReset()
+  warnMock.mockReset()
+})
+
+describe('isTauriRuntime', () => {
+  it('b1_1_is_true_inside_the_tauri_webview', async () => {
+    isTauriMock.mockReturnValue(true)
+    const { isTauriRuntime } = await loadEnvironment()
+
+    expect(isTauriRuntime()).toBe(true)
+  })
+
+  it('b1_2_is_false_in_a_plain_browser', async () => {
+    isTauriMock.mockReturnValue(false)
+    const { isTauriRuntime } = await loadEnvironment()
+
+    expect(isTauriRuntime()).toBe(false)
+  })
+
+  it('b1_2_is_false_when_the_detection_call_itself_throws', async () => {
+    isTauriMock.mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'metadata')")
+    })
+    const { isTauriRuntime } = await loadEnvironment()
+
+    expect(isTauriRuntime()).toBe(false)
+  })
+})
+
+describe('missing-runtime notice', () => {
+  it('b4_1_warns_once_and_names_the_desktop_app', async () => {
+    isTauriMock.mockReturnValue(false)
+    const { isTauriRuntime } = await loadEnvironment()
+
+    isTauriRuntime()
+
+    expect(warnMock).toHaveBeenCalledTimes(1)
+    expect(String(warnMock.mock.calls[0][0])).toMatch(/dev:tauri/)
+  })
+
+  it('b4_2_does_not_warn_again_on_later_calls', async () => {
+    isTauriMock.mockReturnValue(false)
+    const { isTauriRuntime } = await loadEnvironment()
+
+    isTauriRuntime()
+    isTauriRuntime()
+    isTauriRuntime()
+
+    expect(warnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('b4_3_never_warns_inside_the_desktop_app', async () => {
+    isTauriMock.mockReturnValue(true)
+    const { isTauriRuntime } = await loadEnvironment()
+
+    isTauriRuntime()
+    isTauriRuntime()
+
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/utils/environment.ts
+++ b/src/shared/utils/environment.ts
@@ -1,0 +1,46 @@
+/**
+ * Runtime environment detection (Issue #144)
+ *
+ * Bucket is a Tauri desktop app: `@tauri-apps/api` calls only work inside the
+ * Tauri webview, where the `__TAURI_INTERNALS__` bridge is injected. Loading
+ * the Vite dev server in a plain browser has no bridge, so anything touching
+ * the window or `invoke` throws — and a throw inside a mount effect takes the
+ * whole React tree down with it.
+ *
+ * Code that runs at mount asks here first and no-ops when the bridge is
+ * absent, so `vite dev` renders the UI instead of a blank page.
+ */
+
+import { isTauri } from '@tauri-apps/api/core'
+
+import { logger } from './logger'
+
+let hasWarnedMissingRuntime = false
+
+/**
+ * Whether the app is running inside the Tauri webview, where native APIs
+ * work. Returns false in a plain browser, warning once so an oddly empty UI
+ * has a visible explanation.
+ *
+ * The warning is not gated on a dev-only env flag: a real build only ever
+ * runs inside the webview, so this branch cannot be reached in production.
+ */
+export function isTauriRuntime(): boolean {
+  let present = false
+
+  try {
+    present = isTauri()
+  } catch {
+    // A detection helper that throws is itself proof there's no bridge
+    present = false
+  }
+
+  if (!present && !hasWarnedMissingRuntime) {
+    hasWarnedMissingRuntime = true
+    logger.warn(
+      'Not running inside the Bucket desktop app — native features (window state, file access, Sprout Video uploads) are unavailable. Run `bun run dev:tauri` for the full app.'
+    )
+  }
+
+  return present
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -59,6 +59,10 @@ export { fileNameToTitle } from './video'
 /** Derive branded poster frame text from a video title (last ' - ' segment) */
 export { titleToPosterFrameText } from './video'
 
+// Runtime environment
+/** Whether the app is running inside the Tauri webview, where native APIs work */
+export { isTauriRuntime } from './environment'
+
 // Breadcrumbs utilities
 /** Format a date for breadcrumbs display with full month and year */
 export { formatBreadcrumbDate } from './breadcrumbs'

--- a/tests/unit/hooks/useWindowState.test.ts
+++ b/tests/unit/hooks/useWindowState.test.ts
@@ -8,6 +8,12 @@ import { LogicalPosition, LogicalSize } from '@tauri-apps/api/window'
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Issue #144: the hook now no-ops outside the Tauri webview, so these
+// in-Tauri behaviours need the bridge reported as present.
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => true
+}))
+
 // Mock Tauri window API
 const mockSetPosition = vi.fn()
 const mockSetSize = vi.fn()


### PR DESCRIPTION
Closes #144.

`bun run dev` + http://localhost:1422 rendered a blank dark page. `useWindowState` called `getCurrentWindow()` synchronously inside a mount effect; with no `__TAURI_INTERNALS__` bridge that throws, the exception escaped the effect, and React tore down the whole tree (`An error occurred in the <App> component` in the console). `useSystemTheme` had the identical pattern, reached via `useMacOSEffects` from the sidebar — the next crash once the first was fixed.

The desktop app is still `bun run dev:tauri`; this just makes `vite dev` usable for UI work instead of a blank page with no explanation.

## What changed, by behaviour area

### B1 — Runtime detection
`src/shared/utils/environment.ts` adds `isTauriRuntime()`, wrapping `isTauri()` from `@tauri-apps/api/core` (Tauri's own helper, so it tracks any change to how the bridge is exposed) and defending against the detection call itself throwing. Exported from `@shared/utils` so hooks don't import `@tauri-apps` just to ask the question.

### B2/B3 — The two fatal call sites
`useWindowState` and `useSystemTheme` return early when there's no bridge: no `getCurrentWindow()`, no listeners, `useSystemTheme` reports `null`. Inside the webview both behave exactly as before.

### B4 — One-time notice
First time a guarded hook finds no bridge:

> Not running inside the Bucket desktop app — native features (window state, file access, Sprout Video uploads) are unavailable. Run `bun run dev:tauri` for the full app.

Once per page load, no UI surface. Not gated behind `import.meta.env.DEV`: a real build only ever runs inside the webview, so the branch can't fire in production, and an env flag would only make it harder to test honestly.

### Deliberately unchanged
`useUsername`, `useVersionCheck`, `shared/lib/prefetch-strategies.ts`, the updater in `AppRouter.tsx:103-121`, `ExternalLink` and the build-project machine already fail safely (React Query error state, or try/catch). They still log in a browser; guarding them is churn without a behaviour change, so it's out of scope.

## Testing evidence

Red first: commit `e4e93e7` holds the failing tests alone — 4 failing (`environment.ts` didn't exist, both hooks called `getCurrentWindow` unconditionally, barrel export missing). Green in `8c68133`.

| Gate | Result |
|---|---|
| `bun run test:run` | 6890 passed, 0 failed |
| `bun run eslint` | 0 errors |
| `bun run prettier` | clean |

New tests: `environment.test.ts` (detection both ways, throwing detector, warn-once, silent inside Tauri), `useWindowState.test.ts` and `useSystemTheme.test.ts` (no-bridge → no native calls; bridge → unchanged behaviour), plus a barrel assertion in the utils contract.

**Verified in a real browser**, which is the part jsdom can't prove — reloaded http://localhost:1422 after the fix:

- Full UI renders: sidebar, Build a Project, and the Baker page.
- Console on a fresh load contains **no `[EXCEPTION]`** and no `An error occurred in the <App> component`.
- What remains is the one-time notice plus the pre-existing caught warnings: `Error loading API keys` (React Query) and `[useBuildProject] Failed to setup Tauri listeners` (already inside try/catch, doubled by StrictMode).

## Notes for review

- **`tests/unit/hooks/useWindowState.test.ts` needed one line.** That pre-existing suite mocks `@tauri-apps/api/window` but not `/core`, so real `isTauri()` returned false in jsdom and all 14 in-Tauri assertions broke. It now mocks `isTauri: () => true`, which is what those tests always meant. No assertions were changed or weakened.
- **The warning is unconditional, not dev-gated** — reasoning above. If you'd rather it were `import.meta.env.DEV`-only, that's a one-line change plus a test tweak.
- The remaining console noise in a browser is deliberate (see *Deliberately unchanged*). If you want a genuinely clean browser console, that's a follow-up covering the safe-but-noisy touchpoints.
- Locally, `vitest run` also picks up a stale git-ignored worktree at `.claude/worktrees/baker-trello-self-assign/` whose own `button.test.tsx` fails 10 Framer Motion tests — pre-existing, unrelated, invisible to CI. Worth deleting that directory.
- No version bump, per the release flow.
