### PR TITLE
feat(baker): set a branded poster frame on an already-linked video

### DIFF
--- a/src/features/Baker/components/AddVideoDialog.test.tsx
+++ b/src/features/Baker/components/AddVideoDialog.test.tsx
@@ -338,3 +338,51 @@ describe('AddVideoDialog - poster frame status', () => {
     expect(screen.queryByText(/setting poster frame/i)).not.toBeInTheDocument()
   })
 })
+
+// Issue #141 amendment: a blank poster frame is never sent to Sprout, in the
+// upload flow as well as the card action (B7.1-B7.3).
+describe('AddVideoDialog - poster frame text is required (B7)', () => {
+  it('b7_1_blocks_the_upload_when_the_option_is_ticked_and_the_text_is_blank', () => {
+    render(
+      <AddVideoDialog
+        {...baseProps({ posterFrame: posterFrameState({ enabled: true, text: '' }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /upload and add/i })).toBeDisabled()
+    expect(screen.getByText(/poster frame text is required/i)).toBeInTheDocument()
+  })
+
+  it('b7_3_treats_whitespace_only_text_as_blank', () => {
+    render(
+      <AddVideoDialog
+        {...baseProps({ posterFrame: posterFrameState({ enabled: true, text: '   ' }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /upload and add/i })).toBeDisabled()
+    expect(screen.getByText(/poster frame text is required/i)).toBeInTheDocument()
+  })
+
+  it('b7_1_allows_the_upload_once_there_is_real_text', () => {
+    render(
+      <AddVideoDialog
+        {...baseProps({ posterFrame: posterFrameState({ enabled: true }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /upload and add/i })).toBeEnabled()
+    expect(screen.queryByText(/poster frame text is required/i)).not.toBeInTheDocument()
+  })
+
+  it('b7_2_does_not_block_the_upload_when_the_option_is_unticked', () => {
+    render(
+      <AddVideoDialog
+        {...baseProps({ posterFrame: posterFrameState({ enabled: false, text: '' }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /upload and add/i })).toBeEnabled()
+    expect(screen.queryByText(/poster frame text is required/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/features/Baker/components/AddVideoDialog.tsx
+++ b/src/features/Baker/components/AddVideoDialog.tsx
@@ -138,6 +138,10 @@ export function AddVideoDialog({
   // work can't be torn down halfway through (B5.2).
   const posterFrameWorking = posterFrame.enabled && posterFrame.status === 'working'
   const posterFrameSettled = !posterFrame.enabled || posterFrame.status !== 'working'
+  // A background-only frame is never sent to Sprout, so a ticked option with no
+  // text holds the upload back (#141 amendment, B7.1-B7.3).
+  const posterFrameTextMissing =
+    posterFrame.enabled && posterFrame.text.trim().length === 0
 
   return (
     <Dialog open={dialog.isOpen} onOpenChange={dialog.onOpenChange}>
@@ -209,7 +213,10 @@ export function AddVideoDialog({
               <Button
                 onClick={uploadMode.onUploadAndAdd}
                 disabled={
-                  !uploadMode.selectedFile || !urlMode.hasApiKey || uploadMode.uploading
+                  !uploadMode.selectedFile ||
+                  !urlMode.hasApiKey ||
+                  uploadMode.uploading ||
+                  posterFrameTextMissing
                 }
               >
                 {uploadMode.uploading ? (
@@ -401,10 +408,14 @@ function PosterFrameContent({
               maxLength={200}
               disabled={posterFrame.status === 'working'}
             />
-            <p className="text-muted-foreground text-xs">
-              Taken from the last part of the video title. Edit it to change the thumbnail
-              only.
-            </p>
+            {posterFrame.text.trim().length === 0 ? (
+              <p className="text-warning text-xs">Poster frame text is required.</p>
+            ) : (
+              <p className="text-muted-foreground text-xs">
+                Taken from the last part of the video title. Edit it to change the
+                thumbnail only.
+              </p>
+            )}
           </div>
 
           {posterFrame.previewImageUrl && (

--- a/src/features/Baker/components/SetPosterFrameDialog.test.tsx
+++ b/src/features/Baker/components/SetPosterFrameDialog.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * Tests for SetPosterFrameDialog — the card action that sets a branded poster
+ * frame on an already-linked Sprout video.
+ * Issue #141 (B3.1-B3.3, B3.5-B3.8, B4.1-B4.5, B5.3, B5.4)
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SetPosterFrameDialog } from './SetPosterFrameDialog'
+import type {
+  SetPosterFrameDialogProps,
+  SetPosterFramePanelState
+} from './SetPosterFrameDialog'
+
+const BACKGROUNDS = ['/backgrounds/wbs-blue.jpg', '/backgrounds/wbs-red.png']
+
+function panelState(
+  overrides: Partial<SetPosterFramePanelState> = {}
+): SetPosterFramePanelState {
+  return {
+    unavailableReason: null,
+    backgrounds: BACKGROUNDS,
+    selectedBackground: BACKGROUNDS[0],
+    onBackgroundChange: vi.fn(),
+    text: 'Managing Change',
+    onTextChange: vi.fn(),
+    previewImageUrl: 'blob:preview',
+    saveCopy: false,
+    onSaveCopyChange: vi.fn(),
+    status: 'idle',
+    error: null,
+    ...overrides
+  }
+}
+
+function baseProps(
+  overrides: Partial<SetPosterFrameDialogProps> = {}
+): SetPosterFrameDialogProps {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    videoTitle: 'WBS - MSc - Managing Change',
+    posterFrame: panelState(),
+    canvasRef: React.createRef<HTMLCanvasElement>(),
+    onConfirm: vi.fn(),
+    onRetry: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('SetPosterFrameDialog - contents', () => {
+  it('b3_1_names_the_video_the_frame_will_be_set_on', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByText('WBS - MSc - Managing Change')).toBeInTheDocument()
+  })
+
+  it('b3_2_shows_the_selected_background_filename', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByText('wbs-blue.jpg')).toBeInTheDocument()
+  })
+
+  it('b3_3_shows_the_prefilled_poster_frame_text', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByLabelText(/poster frame text/i)).toHaveValue('Managing Change')
+  })
+
+  it('b3_4_reports_text_edits_back_to_the_caller', () => {
+    const onTextChange = vi.fn()
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ onTextChange }) })}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText(/poster frame text/i), {
+      target: { value: 'Change, Managed' }
+    })
+
+    expect(onTextChange).toHaveBeenCalledWith('Change, Managed')
+  })
+
+  it('b3_5_renders_the_live_preview_canvas', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByRole('img', { name: /poster frame preview/i })).toBeInTheDocument()
+  })
+
+  it('b3_6_offers_the_save_a_copy_tick_reflecting_the_remembered_choice', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ saveCopy: true }) })}
+      />
+    )
+
+    expect(
+      screen.getByRole('checkbox', { name: /save a copy .*graphics/i })
+    ).toBeChecked()
+  })
+
+  it('b3_6_reports_the_save_a_copy_tick_back_to_the_caller', () => {
+    const onSaveCopyChange = vi.fn()
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ onSaveCopyChange }) })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /save a copy .*graphics/i }))
+
+    expect(onSaveCopyChange).toHaveBeenCalledWith(true)
+  })
+
+  it('b3_7_warns_that_the_current_poster_frame_will_be_replaced', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByText(/replaces the current poster frame/i)).toBeInTheDocument()
+  })
+
+  it('b3_7_exposes_exactly_one_confirming_button_and_no_second_confirmation', () => {
+    const onConfirm = vi.fn()
+    render(<SetPosterFrameDialog {...baseProps({ onConfirm })} />)
+
+    const confirm = screen.getByRole('button', { name: /^set poster frame$/i })
+    fireEvent.click(confirm)
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    // No AlertDialog step in between
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('SetPosterFrameDialog - required text (B3.8)', () => {
+  it('b3_8_disables_the_action_and_explains_when_the_text_is_empty', () => {
+    render(
+      <SetPosterFrameDialog {...baseProps({ posterFrame: panelState({ text: '' }) })} />
+    )
+
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+    expect(screen.getByText(/poster frame text is required/i)).toBeInTheDocument()
+  })
+
+  it('b3_8_treats_whitespace_only_text_as_empty', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ text: '   ' }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+    expect(screen.getByText(/poster frame text is required/i)).toBeInTheDocument()
+  })
+
+  it('b3_8_enables_the_action_once_there_is_real_text', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeEnabled()
+    expect(screen.queryByText(/poster frame text is required/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('SetPosterFrameDialog - unavailable configuration', () => {
+  it('b4_1_explains_a_missing_background_folder_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason:
+              'No default background folder configured. Set one in Settings.'
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/Set one in Settings/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
+  it('b4_2_explains_a_folder_with_no_images_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason: 'The background folder contains no image files.',
+            backgrounds: []
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/no image files/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
+  it('b4_3_explains_a_missing_font_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason:
+              'Poster frame text requires Cabrito.otf in ~/Library/Fonts.'
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/requires Cabrito\.otf/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
+  it('b4_4_explains_a_missing_sprout_api_key_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason:
+              'Sprout Video API key not configured. Go to Settings to add it.'
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/API key not configured/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
+  it('b4_5_claims_no_reason_while_the_checks_are_still_in_flight', () => {
+    render(<SetPosterFrameDialog {...baseProps()} />)
+
+    expect(screen.queryByText(/Settings/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cabrito/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeEnabled()
+  })
+})
+
+describe('SetPosterFrameDialog - request in flight and failure', () => {
+  it('b5_3_locks_the_dialog_while_the_request_is_in_flight', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ status: 'working' }) })}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /setting poster frame/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+  })
+
+  it('b5_3_keeps_the_text_field_untouchable_while_working', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({ posterFrame: panelState({ status: 'working' }) })}
+      />
+    )
+
+    expect(screen.getByLabelText(/poster frame text/i)).toBeDisabled()
+  })
+
+  it('b5_4_reports_a_terminal_failure_with_a_retry_action', () => {
+    const onRetry = vi.fn()
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          onRetry,
+          posterFrame: panelState({
+            status: 'error',
+            error: 'Poster frame is 793 KB — Sprout Video allows up to 500 KB.'
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/793 KB/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/Baker/components/SetPosterFrameDialog.tsx
+++ b/src/features/Baker/components/SetPosterFrameDialog.tsx
@@ -1,0 +1,217 @@
+/**
+ * SetPosterFrameDialog - sets a branded poster frame on an already-linked
+ * Sprout video (Issue #141).
+ *
+ * Purely presentational: every value here is owned by useCardPosterFrame. The
+ * dialog is itself the confirmation step — it
+ * shows the exact frame that will be sent before the irreversible PUT — so no
+ * second AlertDialog sits on top of it.
+ */
+
+import { AlertCircle, Image as ImageIcon, Loader2 } from 'lucide-react'
+import type { RefObject } from 'react'
+
+import { Alert, AlertDescription } from '@shared/ui/alert'
+import { Button } from '@shared/ui/button'
+import { Checkbox } from '@shared/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@shared/ui/dialog'
+import { Input } from '@shared/ui/input'
+import { Label } from '@shared/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@shared/ui/select'
+
+/** Poster frame state the dialog renders but never owns */
+export interface SetPosterFramePanelState {
+  /** Why a poster frame cannot be built or sent; disables the action when set */
+  unavailableReason: string | null
+  backgrounds: string[]
+  selectedBackground: string | null
+  onBackgroundChange: (path: string) => void
+  text: string
+  onTextChange: (text: string) => void
+  previewImageUrl: string | null
+  saveCopy: boolean
+  onSaveCopyChange: (saveCopy: boolean) => void
+  status: 'idle' | 'working' | 'success' | 'error'
+  error: string | null
+}
+
+export interface SetPosterFrameDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Title of the video whose poster frame is being replaced */
+  videoTitle: string
+  posterFrame: SetPosterFramePanelState
+  /**
+   * Ref for the preview canvas. Kept out of the posterFrame group because a
+   * member expression used as `ref=` reads as a render-time ref access.
+   */
+  canvasRef: RefObject<HTMLCanvasElement | null>
+  onConfirm: () => void
+  onRetry: () => void
+}
+
+export function SetPosterFrameDialog({
+  open,
+  onOpenChange,
+  videoTitle,
+  posterFrame,
+  canvasRef,
+  onConfirm,
+  onRetry
+}: SetPosterFrameDialogProps) {
+  const working = posterFrame.status === 'working'
+  // A background-only frame is never sent to Sprout (B3.8)
+  const textMissing = posterFrame.text.trim().length === 0
+  const blocked = posterFrame.unavailableReason !== null || textMissing
+  const selectedName = posterFrame.selectedBackground?.split('/').pop() ?? ''
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Closing mid-request would tear down the in-flight PUT (B5.3)
+        if (!next && working) return
+        onOpenChange(next)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Set poster frame</DialogTitle>
+          <DialogDescription>
+            This replaces the current poster frame on Sprout Video.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1">
+            <Label>Video</Label>
+            <p className="text-muted-foreground text-sm">{videoTitle}</p>
+          </div>
+
+          {posterFrame.unavailableReason ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{posterFrame.unavailableReason}</AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="card-poster-frame-background">Background</Label>
+                <Select
+                  value={posterFrame.selectedBackground ?? ''}
+                  onValueChange={posterFrame.onBackgroundChange}
+                  disabled={working}
+                >
+                  <SelectTrigger id="card-poster-frame-background" className="w-full">
+                    <SelectValue placeholder="Select a background">
+                      {selectedName}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent className="max-h-[240px]">
+                    {posterFrame.backgrounds.map((file) => (
+                      <SelectItem key={file} value={file}>
+                        {file.split('/').pop()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="card-poster-frame-text">Poster frame text</Label>
+                <Input
+                  id="card-poster-frame-text"
+                  value={posterFrame.text}
+                  onChange={(event) => posterFrame.onTextChange(event.target.value)}
+                  maxLength={200}
+                  disabled={working}
+                />
+                {textMissing ? (
+                  <p className="text-warning text-xs">Poster frame text is required.</p>
+                ) : (
+                  <p className="text-muted-foreground text-xs">
+                    Taken from the last part of the video title. Edit it to change the
+                    thumbnail only.
+                  </p>
+                )}
+              </div>
+
+              {posterFrame.previewImageUrl && (
+                <div className="border-border overflow-hidden rounded border">
+                  <canvas
+                    ref={canvasRef}
+                    role="img"
+                    aria-label="Poster frame preview"
+                    className="aspect-video w-full"
+                  />
+                </div>
+              )}
+
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="card-poster-frame-save-copy"
+                  checked={posterFrame.saveCopy}
+                  onCheckedChange={(checked) =>
+                    posterFrame.onSaveCopyChange(checked === true)
+                  }
+                  disabled={working}
+                />
+                <Label htmlFor="card-poster-frame-save-copy" className="cursor-pointer">
+                  Save a copy to the project&apos;s Graphics folder
+                </Label>
+              </div>
+            </>
+          )}
+
+          {posterFrame.status === 'error' && posterFrame.error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription className="flex flex-col items-start gap-2">
+                <span>{posterFrame.error}</span>
+                <Button variant="outline" size="sm" onClick={onRetry}>
+                  Retry
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={working}
+          >
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={blocked || working}>
+            {working ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Setting poster frame...
+              </>
+            ) : (
+              <>
+                <ImageIcon className="mr-2 h-4 w-4" />
+                Set poster frame
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/Baker/components/VideoLinkCard.tsx
+++ b/src/features/Baker/components/VideoLinkCard.tsx
@@ -3,7 +3,14 @@
  * Feature: 004-embed-multiple-video
  */
 
-import { ChevronDown, ChevronUp, ExternalLink, Trash2, Video } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Image as ImageIcon,
+  Trash2,
+  Video
+} from 'lucide-react'
 import React from 'react'
 
 import { Button } from '@shared/ui/button'
@@ -18,6 +25,21 @@ interface VideoLinkCardProps {
   onMoveDown: () => void
   canMoveUp: boolean
   canMoveDown: boolean
+  /** Opens the branded poster frame dialog for this link (Issue #141) */
+  onSetPosterFrame?: () => void
+  /** Why the poster frame action is unavailable; disables it when set */
+  posterFrameDisabledReason?: string | null
+  /**
+   * Bumped after a poster frame is set. Sprout may reuse the same asset URL,
+   * so without this the browser keeps serving the superseded image.
+   */
+  thumbnailCacheKey?: number | null
+}
+
+/** Appends a cache-busting param, respecting any query string already present */
+function withCacheKey(url: string, cacheKey: number | null | undefined): string {
+  if (!cacheKey) return url
+  return `${url}${url.includes('?') ? '&' : '?'}v=${cacheKey}`
 }
 
 function VideoLinkCardComponent({
@@ -26,7 +48,10 @@ function VideoLinkCardComponent({
   onMoveUp,
   onMoveDown,
   canMoveUp,
-  canMoveDown
+  canMoveDown,
+  onSetPosterFrame,
+  posterFrameDisabledReason,
+  thumbnailCacheKey
 }: VideoLinkCardProps) {
   const formatDate = (isoDate?: string) => {
     if (!isoDate) return null
@@ -52,7 +77,7 @@ function VideoLinkCardComponent({
       <div className="bg-muted relative aspect-video w-full">
         {videoLink.thumbnailUrl ? (
           <img
-            src={videoLink.thumbnailUrl}
+            src={withCacheKey(videoLink.thumbnailUrl, thumbnailCacheKey)}
             alt={videoLink.title}
             className="h-full w-full object-cover"
           />
@@ -84,6 +109,21 @@ function VideoLinkCardComponent({
           >
             <ChevronDown className="h-3.5 w-3.5" />
           </Button>
+          {onSetPosterFrame && (
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={onSetPosterFrame}
+              disabled={!!posterFrameDisabledReason}
+              className="bg-background h-7 w-7"
+              // The reason is the tooltip, but the action keeps its own name so
+              // it stays findable (and announced) while disabled.
+              aria-label="Set poster frame"
+              title={posterFrameDisabledReason || 'Set poster frame'}
+            >
+              <ImageIcon className="h-3.5 w-3.5" />
+            </Button>
+          )}
           <Button
             variant="secondary"
             size="icon"

--- a/src/features/Baker/components/VideoLinksManager.test.tsx
+++ b/src/features/Baker/components/VideoLinksManager.test.tsx
@@ -21,8 +21,10 @@ import type { usePosterFrameForUpload } from '@features/Upload'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { SproutUploadResponse } from '@shared/types'
+import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { VideoLink } from '../types'
 import { VideoLinksManager } from './VideoLinksManager'
 
 // Mock hooks
@@ -40,6 +42,14 @@ vi.mock('../../Trello/hooks/useBreadcrumbsTrelloCards')
 vi.mock('../../Trello/api')
 vi.mock('@features/Upload')
 vi.mock('@shared/hooks/useApiKeys')
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn()
+  }
+}))
 
 // Helper function to create a complete mock SproutUploadResponse
 const createMockSproutUploadResponse = (
@@ -111,6 +121,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
   const mockUploadFile = vi.fn()
   const mockResetUploadState = vi.fn()
   const mockVideoProcessorReset = vi.fn()
+  const mockUpdateVideoLinkAsync = vi.fn()
   const mockPosterFrameRun = vi.fn()
   const mockPosterFrameRetry = vi.fn()
   const mockPosterFrameReset = vi.fn()
@@ -167,7 +178,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       removeVideoLink: mockRemoveVideoLink,
       removeVideoLinkAsync: vi.fn(),
       updateVideoLink: vi.fn(),
-      updateVideoLinkAsync: vi.fn(),
+      updateVideoLinkAsync: mockUpdateVideoLinkAsync,
       reorderVideoLinks: mockReorderVideoLinks,
       reorderVideoLinksAsync: vi.fn(),
       isUpdating: false,
@@ -250,6 +261,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
     })
 
     // Mock usePosterFrameForUpload (Issue #140)
+    mockUpdateVideoLinkAsync.mockResolvedValue(undefined)
     mockPosterFrameRun.mockResolvedValue({ ok: true, posterFrameUrl: null, error: null })
     mockPosterFrameRetry.mockResolvedValue({
       ok: true,
@@ -1564,6 +1576,317 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
         )
       )
       expect(mockPosterFrameRun).not.toHaveBeenCalled()
+    })
+  })
+
+  // ==========================================
+  // Issue #141: set a poster frame on an already-linked video
+  // ==========================================
+  describe('#141: Set poster frame card action', () => {
+    const linkWithId: VideoLink = {
+      url: 'https://sproutvideo.com/videos/abc123',
+      title: 'WBS - MSc - Managing Change',
+      sproutVideoId: 'abc123',
+      thumbnailUrl: 'https://cdn.sproutvideo.com/poster/abc123.jpg',
+      uploadDate: '2026-01-05T10:00:00Z',
+      sourceRenderFile: 'managing_change.mp4'
+    }
+
+    const linkWithoutId: VideoLink = {
+      url: 'https://videos.sproutvideo.com/embed/def456/tok',
+      title: 'WBS - MSc - Leading Teams',
+      sproutVideoId: null,
+      thumbnailUrl: 'https://cdn.sproutvideo.com/poster/def456.jpg',
+      uploadDate: null,
+      sourceRenderFile: null
+    }
+
+    const unlinkableLink: VideoLink = {
+      url: 'https://example.com/not-a-sprout-video',
+      title: 'Somewhere else entirely',
+      sproutVideoId: null,
+      thumbnailUrl: null,
+      uploadDate: null,
+      sourceRenderFile: null
+    }
+
+    const withVideoLinks = (links: VideoLink[]) => {
+      vi.mocked(useBreadcrumbsVideoLinksModule.useBreadcrumbsVideoLinks).mockReturnValue({
+        videoLinks: links,
+        isLoading: false,
+        error: null,
+        addVideoLink: mockAddVideoLink,
+        addVideoLinkAsync: vi.fn(),
+        removeVideoLink: mockRemoveVideoLink,
+        removeVideoLinkAsync: vi.fn(),
+        updateVideoLink: vi.fn(),
+        updateVideoLinkAsync: mockUpdateVideoLinkAsync,
+        reorderVideoLinks: mockReorderVideoLinks,
+        reorderVideoLinksAsync: vi.fn(),
+        isUpdating: false,
+        addError: null,
+        removeError: null,
+        updateError: null,
+        reorderError: null
+      })
+    }
+
+    /** Opens the card action dialog for the card at `index` */
+    const openPosterFrameDialog = async (index = 0) => {
+      renderWithQueryClient(<VideoLinksManager projectPath={mockProjectPath} />)
+      const actions = screen.getAllByRole('button', { name: /set poster frame/i })
+      await userEvent.click(actions[index])
+      return within(await screen.findByRole('dialog'))
+    }
+
+    it('b2_1_sends_the_frame_for_the_stored_sprout_id', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() =>
+        expect(mockPosterFrameRun).toHaveBeenCalledWith('abc123', 'test-api-key')
+      )
+    })
+
+    it('b2_2_derives_the_id_from_the_url_when_none_is_stored', async () => {
+      withVideoLinks([linkWithoutId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/def456-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() =>
+        expect(mockPosterFrameRun).toHaveBeenCalledWith('def456', 'test-api-key')
+      )
+    })
+
+    it('b2_3_disables_the_action_when_no_id_can_be_resolved', async () => {
+      withVideoLinks([unlinkableLink])
+
+      renderWithQueryClient(<VideoLinksManager projectPath={mockProjectPath} />)
+
+      const action = screen.getByRole('button', { name: /set poster frame/i })
+      expect(action).toBeDisabled()
+      expect(action.getAttribute('title')).toMatch(/no sprout video id/i)
+    })
+
+    it('b4_4_explains_a_missing_sprout_api_key_in_the_dialog', async () => {
+      withVideoLinks([linkWithId])
+      vi.mocked(useApiKeysModule.useSproutVideoApiKey).mockReturnValue({
+        apiKey: '',
+        isLoading: false,
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+
+      expect(dialog.getByText(/API key not configured/i)).toBeInTheDocument()
+      expect(dialog.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+    })
+
+    it('b6_1_writes_the_refreshed_thumbnail_back_to_the_right_link', async () => {
+      withVideoLinks([linkWithoutId, linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog(1)
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() =>
+        expect(mockUpdateVideoLinkAsync).toHaveBeenCalledWith({
+          videoIndex: 1,
+          updatedLink: expect.objectContaining({
+            url: linkWithId.url,
+            thumbnailUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg'
+          })
+        })
+      )
+    })
+
+    it('b6_2_persists_a_derived_sprout_id_in_the_same_write', async () => {
+      withVideoLinks([linkWithoutId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/def456-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() =>
+        expect(mockUpdateVideoLinkAsync).toHaveBeenCalledWith({
+          videoIndex: 0,
+          updatedLink: expect.objectContaining({ sproutVideoId: 'def456' })
+        })
+      )
+    })
+
+    it('b6_3_cache_busts_the_card_thumbnail_after_a_successful_set', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: linkWithId.thumbnailUrl,
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() =>
+        expect(screen.getByAltText(linkWithId.title).getAttribute('src')).toMatch(
+          /[?&]v=\d+/
+        )
+      )
+    })
+
+    it('b6_7_closes_the_dialog_and_reports_success', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() => expect(toast.success).toHaveBeenCalled())
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    })
+
+    it('b6_4_still_reports_success_when_the_breadcrumbs_write_back_fails', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg',
+        error: null
+      })
+      mockUpdateVideoLinkAsync.mockRejectedValue(
+        new Error('breadcrumbs.json is read-only')
+      )
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() => expect(toast.warning).toHaveBeenCalled())
+      expect(toast.error).not.toHaveBeenCalled()
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    })
+
+    it('b6_4_still_reports_success_when_sprout_details_could_not_be_re_read', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: null,
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() => expect(toast.warning).toHaveBeenCalled())
+      expect(toast.error).not.toHaveBeenCalled()
+    })
+
+    it('b6_6_opens_no_trello_dialog_after_a_successful_set', async () => {
+      const trelloCards = [
+        { cardId: 'card-1', title: 'Managing Change', url: 'https://trello.com/c/card-1' }
+      ]
+      vi.mocked(
+        useBreadcrumbsTrelloCardsHookModule.useBreadcrumbsTrelloCards
+      ).mockReturnValue({
+        trelloCards,
+        isLoading: false,
+        error: null,
+        addTrelloCard: vi.fn(),
+        addTrelloCardAsync: vi.fn(),
+        removeTrelloCard: vi.fn(),
+        removeTrelloCardAsync: vi.fn(),
+        fetchCardDetails: vi.fn(),
+        fetchCardDetailsAsync: vi.fn(),
+        isUpdating: false,
+        isFetchingDetails: false,
+        addError: null,
+        removeError: null,
+        fetchError: null,
+        fetchedCardData: undefined
+      } as unknown as ReturnType<
+        typeof useBreadcrumbsTrelloCardsHookModule.useBreadcrumbsTrelloCards
+      >)
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: true,
+        posterFrameUrl: 'https://cdn.sproutvideo.com/poster/abc123-branded.jpg',
+        error: null
+      })
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() => expect(toast.success).toHaveBeenCalled())
+      expect(screen.queryByText(/update trello card/i)).not.toBeInTheDocument()
+    })
+
+    it('b5_4_keeps_the_dialog_open_with_the_error_on_a_terminal_failure', async () => {
+      withVideoLinks([linkWithId])
+      mockPosterFrameRun.mockResolvedValue({
+        ok: false,
+        posterFrameUrl: null,
+        error: 'Poster frame is 793 KB — Sprout Video allows up to 500 KB.'
+      })
+      vi.mocked(usePosterFrameForUploadModule.usePosterFrameForUpload).mockReturnValue(
+        posterFrameHookReturn({
+          status: 'error',
+          error: 'Poster frame is 793 KB — Sprout Video allows up to 500 KB.'
+        })
+      )
+
+      const dialog = await openPosterFrameDialog()
+      await userEvent.click(dialog.getByRole('button', { name: /^set poster frame$/i }))
+
+      await waitFor(() => expect(mockPosterFrameRun).toHaveBeenCalled())
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(dialog.getByText(/793 KB/)).toBeInTheDocument()
+      expect(mockUpdateVideoLinkAsync).not.toHaveBeenCalled()
+    })
+
+    it('b3_4_re_derives_the_text_when_the_dialog_is_reopened_for_another_link', async () => {
+      withVideoLinks([linkWithId, linkWithoutId])
+
+      renderWithQueryClient(<VideoLinksManager projectPath={mockProjectPath} />)
+      const actions = screen.getAllByRole('button', { name: /set poster frame/i })
+
+      await userEvent.click(actions[0])
+      await screen.findByRole('dialog')
+      await userEvent.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i })
+      )
+      await userEvent.click(actions[1])
+      await screen.findByRole('dialog')
+
+      // The hook derives text from the title it is given, so switching links must
+      // re-seed it (reset clears any text the user typed for the previous link).
+      expect(mockPosterFrameReset).toHaveBeenCalled()
+      expect(
+        vi
+          .mocked(usePosterFrameForUploadModule.usePosterFrameForUpload)
+          .mock.calls.some(([options]) => options?.videoTitle === linkWithoutId.title)
+      ).toBe(true)
     })
   })
 })

--- a/src/features/Baker/components/VideoLinksManager.test.tsx
+++ b/src/features/Baker/components/VideoLinksManager.test.tsx
@@ -1869,14 +1869,19 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       withVideoLinks([linkWithId, linkWithoutId])
 
       renderWithQueryClient(<VideoLinksManager projectPath={mockProjectPath} />)
-      const actions = screen.getAllByRole('button', { name: /set poster frame/i })
 
-      await userEvent.click(actions[0])
+      await userEvent.click(
+        screen.getAllByRole('button', { name: /set poster frame/i })[0]
+      )
       await screen.findByRole('dialog')
       await userEvent.click(
         within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i })
       )
-      await userEvent.click(actions[1])
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+      await userEvent.click(
+        screen.getAllByRole('button', { name: /^set poster frame$/i })[1]
+      )
       await screen.findByRole('dialog')
 
       // The hook derives text from the title it is given, so switching links must

--- a/src/features/Baker/components/VideoLinksManager.tsx
+++ b/src/features/Baker/components/VideoLinksManager.tsx
@@ -22,6 +22,7 @@ import {
 import { TrelloCardUpdateDialog } from '@features/Trello'
 import { VideoLinkCard } from './VideoLinkCard'
 import { AddVideoDialog } from './AddVideoDialog'
+import { SetPosterFrameDialog } from './SetPosterFrameDialog'
 
 interface VideoLinksManagerProps {
   projectPath: string
@@ -60,6 +61,18 @@ export function VideoLinksManager({ projectPath }: VideoLinksManagerProps) {
 
     // Branded poster frame (Issue #140)
     posterFrame,
+
+    // Poster frame for an already-linked video (Issue #141)
+    cardPosterFrame,
+    posterFrameTarget,
+    posterFrameTargetIndex,
+    cardPosterFrameUnavailableReason,
+    thumbnailCacheKeys,
+    posterFrameDisabledReason,
+    requestSetPosterFrame,
+    confirmSetPosterFrame,
+    retrySetPosterFrame,
+    handlePosterFrameDialogOpenChange,
 
     // Loading states
     isUpdating,
@@ -196,6 +209,9 @@ export function VideoLinksManager({ projectPath }: VideoLinksManagerProps) {
               onMoveDown={() => handleMoveDown(index)}
               canMoveUp={index > 0}
               canMoveDown={index < videoLinks.length - 1}
+              onSetPosterFrame={() => requestSetPosterFrame(index)}
+              posterFrameDisabledReason={posterFrameDisabledReason(link)}
+              thumbnailCacheKey={thumbnailCacheKeys[link.url] ?? null}
             />
           ))}
         </div>
@@ -208,6 +224,29 @@ export function VideoLinksManager({ projectPath }: VideoLinksManagerProps) {
           <span className="text-muted-foreground ml-2 text-sm">Updating...</span>
         </div>
       )}
+
+      {/* Set poster frame on an already-linked video (Issue #141) */}
+      <SetPosterFrameDialog
+        open={posterFrameTargetIndex !== null}
+        onOpenChange={handlePosterFrameDialogOpenChange}
+        videoTitle={posterFrameTarget?.title ?? ''}
+        posterFrame={{
+          unavailableReason: cardPosterFrameUnavailableReason,
+          backgrounds: cardPosterFrame.backgrounds,
+          selectedBackground: cardPosterFrame.selectedBackground,
+          onBackgroundChange: cardPosterFrame.setSelectedBackground,
+          text: cardPosterFrame.text,
+          onTextChange: cardPosterFrame.setText,
+          previewImageUrl: cardPosterFrame.previewImageUrl,
+          saveCopy: cardPosterFrame.saveCopy,
+          onSaveCopyChange: cardPosterFrame.setSaveCopy,
+          status: cardPosterFrame.status,
+          error: cardPosterFrame.error
+        }}
+        canvasRef={cardPosterFrame.canvasRef}
+        onConfirm={() => void confirmSetPosterFrame()}
+        onRetry={retrySetPosterFrame}
+      />
 
       {/* Trello Card Update Dialog */}
       <TrelloCardUpdateDialog

--- a/src/features/Trello/hooks/useCardPosterFrame.ts
+++ b/src/features/Trello/hooks/useCardPosterFrame.ts
@@ -1,0 +1,162 @@
+/**
+ * useCardPosterFrame (Issue #141)
+ *
+ * Sets a branded poster frame on a video that is already linked to a project,
+ * driven from the video card's overlay action rather than an upload. Owns the
+ * dialog target, the id resolution for links that never stored a Sprout id, the
+ * breadcrumbs write-back, and the per-link cache key that makes a replaced
+ * frame actually visible.
+ *
+ * One instance per VideoLinksManager, not per card: its inputs are React
+ * Query-backed and shared, but its poster frame text follows the *targeted*
+ * link's title, which is why it can't share the upload flow's instance.
+ */
+
+import { logger, sproutVideoIdFromUrl } from '@shared/utils'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import type { VideoLink } from '@features/Baker'
+import { usePosterFrameForUpload } from '@features/Upload'
+
+const NO_SPROUT_ID_REASON = 'No Sprout video ID could be determined from this link.'
+const NO_API_KEY_REASON = 'Sprout Video API key not configured. Go to Settings to add it.'
+
+/**
+ * The Sprout id a poster frame can be set against: the stored one, or one
+ * derived from the link's own URL for links added before the id was captured
+ * (B2.1-B2.2).
+ */
+function resolveSproutVideoId(videoLink: VideoLink): string | null {
+  return videoLink.sproutVideoId?.trim() || sproutVideoIdFromUrl(videoLink.url)
+}
+
+interface UseCardPosterFrameOptions {
+  /** Project the links belong to — destination for the optional Graphics copy */
+  projectPath: string
+  videoLinks: VideoLink[]
+  /** Sprout Video API key, absent when it hasn't been configured */
+  apiKey: string | null | undefined
+  updateVideoLinkAsync: (variables: {
+    videoIndex: number
+    updatedLink: VideoLink
+  }) => Promise<unknown>
+}
+
+export function useCardPosterFrame({
+  projectPath,
+  videoLinks,
+  apiKey,
+  updateVideoLinkAsync
+}: UseCardPosterFrameOptions) {
+  const [targetIndex, setTargetIndex] = useState<number | null>(null)
+  const [thumbnailCacheKeys, setThumbnailCacheKeys] = useState<Record<string, number>>({})
+
+  const target = targetIndex !== null ? videoLinks[targetIndex] : undefined
+
+  const posterFrame = usePosterFrameForUpload({
+    projectPath,
+    videoTitle: target?.title ?? ''
+  })
+
+  /**
+   * Opens the dialog for one link. The hook is reset first so text typed for a
+   * previously targeted link doesn't carry over — it re-derives from this
+   * link's title instead (B3.4).
+   */
+  const request = (index: number) => {
+    posterFrame.reset()
+    setTargetIndex(index)
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    // Closing mid-request would tear down the in-flight PUT (B5.3)
+    if (!open && posterFrame.status === 'working') return
+    if (!open) setTargetIndex(null)
+  }
+
+  /** Records the refreshed thumbnail, reporting whether the write stuck */
+  const writeBack = async (
+    index: number,
+    link: VideoLink,
+    videoId: string,
+    posterFrameUrl: string | null
+  ): Promise<boolean> => {
+    const updatedLink: VideoLink = {
+      ...link,
+      thumbnailUrl: posterFrameUrl ?? link.thumbnailUrl,
+      // One write, two fixes: a derived id is worth keeping (B6.2)
+      sproutVideoId: link.sproutVideoId?.trim() || videoId
+    }
+
+    const changed =
+      updatedLink.thumbnailUrl !== link.thumbnailUrl ||
+      updatedLink.sproutVideoId !== link.sproutVideoId
+
+    if (!changed) return posterFrameUrl !== null
+
+    try {
+      await updateVideoLinkAsync({ videoIndex: index, updatedLink })
+      return posterFrameUrl !== null
+    } catch (error) {
+      logger.warn('Could not write the refreshed poster frame to breadcrumbs:', error)
+      return false
+    }
+  }
+
+  /**
+   * Replaces the poster frame on Sprout for the targeted link. Sprout is the
+   * irreversible step, so once it accepts the frame the outcome is a success
+   * even if the follow-up bookkeeping fails — the warning names what went
+   * unrefreshed rather than offering a retry that would re-send an accepted
+   * frame (B6.4).
+   */
+  const confirm = async () => {
+    const index = targetIndex
+    if (index === null) return
+
+    const link = videoLinks[index]
+    if (!link) return
+
+    const videoId = resolveSproutVideoId(link)
+    if (!videoId || !apiKey) return
+
+    const result = await posterFrame.run(videoId, apiKey)
+
+    // A terminal failure leaves the dialog open with its error and retry (B5.4)
+    if (!result.ok) return
+
+    setTargetIndex(null)
+
+    const refreshed = await writeBack(index, link, videoId, result.posterFrameUrl)
+
+    setThumbnailCacheKeys((current) => ({ ...current, [link.url]: Date.now() }))
+
+    if (refreshed) {
+      toast.success('Poster frame set on Sprout Video.')
+    } else {
+      toast.warning(
+        'Poster frame set on Sprout Video, but the stored thumbnail could not be refreshed.'
+      )
+    }
+  }
+
+  /** Why the card action is unavailable for a link, or null when it is usable */
+  const disabledReason = (videoLink: VideoLink): string | null =>
+    resolveSproutVideoId(videoLink) ? null : NO_SPROUT_ID_REASON
+
+  return {
+    posterFrame,
+    target,
+    targetIndex,
+    // The hook's own reason first, then anything else that would stop the request
+    unavailableReason:
+      posterFrame.unavailableReason ?? (apiKey ? null : NO_API_KEY_REASON),
+    thumbnailCacheKeys,
+    disabledReason,
+    request,
+    confirm,
+    retry: () => void confirm(),
+    handleOpenChange
+  }
+}

--- a/src/features/Trello/hooks/useVideoLinksManager.ts
+++ b/src/features/Trello/hooks/useVideoLinksManager.ts
@@ -20,6 +20,7 @@ import {
   updateTrelloCardWithBreadcrumbs
 } from '@features/Baker'
 import { useBreadcrumbsTrelloCards } from './useBreadcrumbsTrelloCards'
+import { useCardPosterFrame } from './useCardPosterFrame'
 import { useBreadcrumbsVideoLinks } from '@features/Baker'
 import {
   useFileUpload,
@@ -58,6 +59,7 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     addVideoLink,
     removeVideoLink,
     reorderVideoLinks,
+    updateVideoLinkAsync,
     isUpdating,
     addError
   } = useBreadcrumbsVideoLinks({ projectPath })
@@ -89,6 +91,15 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
   const posterFrame = usePosterFrameForUpload({
     projectPath,
     videoTitle: formData.title
+  })
+
+  // Poster frame for an already-linked video, driven from the card action
+  // (Issue #141)
+  const cardPosterFrame = useCardPosterFrame({
+    projectPath,
+    videoLinks,
+    apiKey,
+    updateVideoLinkAsync
   })
 
   /**
@@ -401,6 +412,18 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
 
     // Branded poster frame state and handlers (Issue #140)
     posterFrame,
+
+    // Poster frame for an already-linked video, from the card action (Issue #141)
+    cardPosterFrame: cardPosterFrame.posterFrame,
+    posterFrameTarget: cardPosterFrame.target,
+    posterFrameTargetIndex: cardPosterFrame.targetIndex,
+    cardPosterFrameUnavailableReason: cardPosterFrame.unavailableReason,
+    thumbnailCacheKeys: cardPosterFrame.thumbnailCacheKeys,
+    posterFrameDisabledReason: cardPosterFrame.disabledReason,
+    requestSetPosterFrame: cardPosterFrame.request,
+    confirmSetPosterFrame: cardPosterFrame.confirm,
+    retrySetPosterFrame: cardPosterFrame.retry,
+    handlePosterFrameDialogOpenChange: cardPosterFrame.handleOpenChange,
 
     // Loading states
     isUpdating,

--- a/src/features/Upload/internal/parseSproutVideoUrl.ts
+++ b/src/features/Upload/internal/parseSproutVideoUrl.ts
@@ -1,3 +1,5 @@
+import { sproutVideoIdFromUrl } from '@shared/utils'
+
 /**
  * Parses Sprout Video URLs to extract video ID
  * Feature: 004-embed-multiple-video
@@ -20,34 +22,8 @@
  * // Returns: null
  */
 export function parseSproutVideoUrl(url: string): string | null {
-  // Trim whitespace
-  const trimmedUrl = url.trim()
-
-  // Return null for empty strings
-  if (!trimmedUrl) {
-    return null
-  }
-
-  // Pattern 1: Public video page URL
-  // Matches: https://sproutvideo.com/videos/{VIDEO_ID}
-  // Also matches http:// (non-secure)
-  const publicMatch = trimmedUrl.match(
-    /(?:https?:\/\/)?sproutvideo\.com\/videos\/([a-zA-Z0-9]+)/
-  )
-  if (publicMatch && publicMatch[1]) {
-    return publicMatch[1]
-  }
-
-  // Pattern 2: Embed URL
-  // Matches: https://videos.sproutvideo.com/embed/{VIDEO_ID}/...
-  // Video ID may be followed by token, query params, or nothing
-  const embedMatch = trimmedUrl.match(
-    /(?:https?:\/\/)?videos\.sproutvideo\.com\/embed\/([a-zA-Z0-9]+)/
-  )
-  if (embedMatch && embedMatch[1]) {
-    return embedMatch[1]
-  }
-
-  // No valid pattern matched
-  return null
+  // The parsing itself lives in @shared/utils because Baker needs it too
+  // (issue #141), and this module is deliberately not exported from the
+  // Upload barrel. Kept as a wrapper so existing callers stay put.
+  return sproutVideoIdFromUrl(url)
 }

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -58,6 +58,8 @@ export { formatDurationSuffix } from './video'
 export { fileNameToTitle } from './video'
 /** Derive branded poster frame text from a video title (last ' - ' segment) */
 export { titleToPosterFrameText } from './video'
+/** Extract a Sprout Video id from a public or embed Sprout URL */
+export { sproutVideoIdFromUrl } from './video'
 
 // Breadcrumbs utilities
 /** Format a date for breadcrumbs display with full month and year */

--- a/src/shared/utils/video.test.ts
+++ b/src/shared/utils/video.test.ts
@@ -3,7 +3,12 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { fileNameToTitle, formatDurationSuffix, titleToPosterFrameText } from './video'
+import {
+  fileNameToTitle,
+  formatDurationSuffix,
+  sproutVideoIdFromUrl,
+  titleToPosterFrameText
+} from './video'
 
 describe('formatDurationSuffix', () => {
   it('formats 90 seconds as 1:30mins', () => {
@@ -94,5 +99,41 @@ describe('titleToPosterFrameText', () => {
 
   it('trims surrounding whitespace on the derived segment', () => {
     expect(titleToPosterFrameText('WBS -   Managing Change  ')).toBe('Managing Change')
+  })
+})
+
+// Issue #141 (B2.2): a link added by URL often carries no stored sproutVideoId,
+// so the id has to come from the URL itself before a poster frame can be set.
+describe('sproutVideoIdFromUrl', () => {
+  it('b2_2_extracts_the_id_from_a_public_video_url', () => {
+    expect(sproutVideoIdFromUrl('https://sproutvideo.com/videos/abc123')).toBe('abc123')
+  })
+
+  it('b2_2_extracts_the_id_from_an_embed_url', () => {
+    expect(
+      sproutVideoIdFromUrl('https://videos.sproutvideo.com/embed/def456/sometoken')
+    ).toBe('def456')
+  })
+
+  it('b2_2_accepts_urls_without_a_protocol', () => {
+    expect(sproutVideoIdFromUrl('sproutvideo.com/videos/abc123')).toBe('abc123')
+  })
+
+  it('b2_2_trims_surrounding_whitespace', () => {
+    expect(sproutVideoIdFromUrl('  https://sproutvideo.com/videos/abc123  ')).toBe(
+      'abc123'
+    )
+  })
+
+  it('b2_3_returns_null_for_a_non_sprout_url', () => {
+    expect(sproutVideoIdFromUrl('https://youtube.com/watch?v=abc123')).toBeNull()
+  })
+
+  it('b2_3_returns_null_for_an_empty_url', () => {
+    expect(sproutVideoIdFromUrl('   ')).toBeNull()
+  })
+
+  it('b2_3_returns_null_when_no_id_follows_the_videos_segment', () => {
+    expect(sproutVideoIdFromUrl('https://sproutvideo.com/')).toBeNull()
   })
 })

--- a/src/shared/utils/video.ts
+++ b/src/shared/utils/video.ts
@@ -26,6 +26,38 @@ export function formatDurationSuffix(seconds: number): string {
 }
 
 /**
+ * Extracts a Sprout Video id from either URL form the app stores:
+ * the public page (`sproutvideo.com/videos/{id}`) or the embed
+ * (`videos.sproutvideo.com/embed/{id}/...`). The protocol is optional.
+ *
+ * Lives here rather than inside a feature because both Upload (resolving a
+ * pasted URL) and Baker (setting a poster frame on a link that never stored
+ * its id) need it.
+ *
+ * @returns the id, or null when the URL is empty or not a Sprout URL
+ */
+export function sproutVideoIdFromUrl(url: string): string | null {
+  const trimmedUrl = url.trim()
+  if (!trimmedUrl) return null
+
+  const publicMatch = trimmedUrl.match(
+    /(?:https?:\/\/)?sproutvideo\.com\/videos\/([a-zA-Z0-9]+)/
+  )
+  if (publicMatch && publicMatch[1]) {
+    return publicMatch[1]
+  }
+
+  const embedMatch = trimmedUrl.match(
+    /(?:https?:\/\/)?videos\.sproutvideo\.com\/embed\/([a-zA-Z0-9]+)/
+  )
+  if (embedMatch && embedMatch[1]) {
+    return embedMatch[1]
+  }
+
+  return null
+}
+
+/**
  * Derives a default video title from a file path: the basename without
  * its extension (e.g. "/renders/WM101_final_v3.mp4" -> "WM101_final_v3").
  */

--- a/tests/unit/components/VideoLinkCard.test.tsx
+++ b/tests/unit/components/VideoLinkCard.test.tsx
@@ -66,6 +66,7 @@ describe('VideoLinkCard Component', () => {
   let mockOnRemove: ReturnType<typeof vi.fn>
   let mockOnMoveUp: ReturnType<typeof vi.fn>
   let mockOnMoveDown: ReturnType<typeof vi.fn>
+  let mockOnSetPosterFrame: ReturnType<typeof vi.fn>
 
   // Mock data
   const baseVideoLink: VideoLink = {
@@ -82,6 +83,7 @@ describe('VideoLinkCard Component', () => {
     mockOnRemove = vi.fn()
     mockOnMoveUp = vi.fn()
     mockOnMoveDown = vi.fn()
+    mockOnSetPosterFrame = vi.fn()
   })
 
   // =================================================================
@@ -341,6 +343,139 @@ describe('VideoLinkCard Component', () => {
 
       // Assert: Component should render without errors
       expect(screen.getByText('Project Alpha - Final Edit')).toBeInTheDocument()
+    })
+  })
+
+  // =================================================================
+  // Issue #141: Set poster frame action (B1.1-B1.4, B2.3)
+  // =================================================================
+
+  describe('Poster frame action (#141)', () => {
+    test('b1_1_offers_a_set_poster_frame_action_alongside_the_other_overlay_actions', () => {
+      render(
+        <VideoLinkCard
+          videoLink={baseVideoLink}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      const action = screen.getByRole('button', { name: /set poster frame/i })
+      expect(action).toBeInTheDocument()
+      expect(action).toBeEnabled()
+      // Sits with move up/down/remove rather than in the card body
+      expect(screen.getByRole('button', { name: /move up/i }).parentElement).toBe(
+        action.parentElement
+      )
+    })
+
+    test('b1_2_invokes_the_callback_and_renders_no_dialog_of_its_own', async () => {
+      const user = userEvent.setup()
+      render(
+        <VideoLinkCard
+          videoLink={baseVideoLink}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /set poster frame/i }))
+
+      expect(mockOnSetPosterFrame).toHaveBeenCalledTimes(1)
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    test('b2_3_disables_the_action_and_explains_when_no_sprout_id_can_be_resolved', () => {
+      render(
+        <VideoLinkCard
+          videoLink={{
+            ...baseVideoLink,
+            sproutVideoId: null,
+            url: 'https://example.com/x'
+          }}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          posterFrameDisabledReason="No Sprout video ID could be determined from this link."
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      const action = screen.getByRole('button', { name: /set poster frame/i })
+      expect(action).toBeDisabled()
+      expect(action.getAttribute('title')).toContain('No Sprout video ID')
+    })
+
+    test('b1_4_renders_the_stored_thumbnail_verbatim_when_nothing_was_refreshed', () => {
+      render(
+        <VideoLinkCard
+          videoLink={baseVideoLink}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      expect(screen.getByAltText('Project Alpha - Final Edit')).toHaveAttribute(
+        'src',
+        'https://sproutvideo.com/thumbnails/abc123.jpg'
+      )
+    })
+
+    test('b1_3_cache_busts_a_refreshed_thumbnail_with_a_question_mark', () => {
+      render(
+        <VideoLinkCard
+          videoLink={baseVideoLink}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          thumbnailCacheKey={1717171717}
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      expect(screen.getByAltText('Project Alpha - Final Edit')).toHaveAttribute(
+        'src',
+        'https://sproutvideo.com/thumbnails/abc123.jpg?v=1717171717'
+      )
+    })
+
+    test('b1_3_cache_busts_a_url_that_already_has_a_query_string_with_an_ampersand', () => {
+      render(
+        <VideoLinkCard
+          videoLink={{
+            ...baseVideoLink,
+            thumbnailUrl: 'https://sproutvideo.com/thumbnails/abc123.jpg?size=large'
+          }}
+          onRemove={mockOnRemove}
+          onMoveUp={mockOnMoveUp}
+          onMoveDown={mockOnMoveDown}
+          onSetPosterFrame={mockOnSetPosterFrame}
+          thumbnailCacheKey={1717171717}
+          canMoveUp={true}
+          canMoveDown={true}
+        />
+      )
+
+      expect(screen.getByAltText('Project Alpha - Final Edit')).toHaveAttribute(
+        'src',
+        'https://sproutvideo.com/thumbnails/abc123.jpg?size=large&v=1717171717'
+      )
     })
   })
 


### PR DESCRIPTION
Adds a `Set poster frame` action to each card in Baker's Video Links panel, so videos
added by URL — or uploaded before #140 existed — can get a branded thumbnail without
opening Sprout's web UI.

Design was agreed on the issue before any code:
[design](https://github.com/twentynineteen/bucket/issues/141#issuecomment-5204976964) ·
[amendments](https://github.com/twentynineteen/bucket/issues/141#issuecomment-5205006995).

## B1 — Card action

`VideoLinkCard` gains a fourth overlay icon beside move up / move down / remove. The
card stays presentational — it invokes `onSetPosterFrame` and renders no dialog of its
own, so it keeps its `React.memo` benefit and needs no project context. The action keeps
its own `aria-label` while disabled so the `title` can carry the reason instead of
replacing the name.

## B2 — Resolving the target video

Prefers the stored `sproutVideoId`, falls back to deriving one from the link's own URL,
and disables the action with an explanation only when neither resolves. The parse logic
moved **down** to `@shared/utils/video.ts` as `sproutVideoIdFromUrl` rather than up into
the Upload barrel — `upload.contract.test.ts:232` deliberately forbids exporting
`parseSproutVideoUrl`, which now delegates to the shared function. No logic duplicated,
no contract touched.

## B3/B4 — Dialog

`SetPosterFrameDialog`: video title, background select, poster-frame text prefilled by
the last-`' - '`-segment rule, live 16:9 preview, `Save a copy to the project's Graphics
folder` tick (sharing #140's remembered preference), and an explicit line that the
current poster frame will be replaced. The dialog **is** the confirmation — you cannot
reach the button without seeing a preview of what will be sent — so no second
`AlertDialog` sits on top of it.

Unavailable configuration explains itself inside the dialog with the confirming button
disabled, reusing #140's strings verbatim plus a missing-API-key case. A multi-sentence
"here's how to fix it" doesn't fit in a hover tooltip on a 28px icon that is itself only
visible on hover.

## B5/B6 — Request and aftermath

`useCardPosterFrame` reuses #140's `usePosterFrameForUpload` for the canvas export, the
2s/5s/10s transient retry ladder, the terminal 413 message and the optional Graphics
copy. On success it writes the refreshed `thumbnailUrl` back to breadcrumbs and persists
a derived `sproutVideoId` in the same write.

Sprout may hand back the *same* asset URL after a replacement — breadcrumbs wouldn't
change, the browser would serve the cached old image, and a successful set would look
like it did nothing. So each link carries a session cache key (`?v=<ts>`, joined with
`&` when the URL already has a query string) while breadcrumbs keeps Sprout's URL
verbatim, so no timestamps leak into `breadcrumbs.json` or Trello breadcrumb blocks.

A failed details re-read or breadcrumbs write is reported as **success with a warning**:
the irreversible step already worked, and a Retry that re-sends an accepted frame would
be misleading. Linked Trello cards are deliberately untouched (out of scope, per issue).

## B7 — No blank poster frames (#140 amendment)

Blank text was previously sendable in the upload flow — nothing gated it. Now ticking
`Create branded poster frame` with blank (or whitespace-only) text holds `Upload and
Add` back with the same hint the card dialog uses.

## Testing evidence

Red first, committed on its own (`cb34990`): 27 failing tests plus
`SetPosterFrameDialog.test.tsx` unable to load (19 tests) because the component didn't
exist. Checking out that commit and running the suite reproduces the red state.

| Layer | Tests | Behaviours |
|---|---|---|
| `shared/utils/video.test.ts` | 7 | B2.2, B2.3 |
| `VideoLinkCard.test.tsx` | 6 | B1.1–B1.4, B2.3 |
| `SetPosterFrameDialog.test.tsx` (new) | 19 | B3, B4, B5.3, B5.4 |
| `VideoLinksManager.test.tsx` | 13 | B2, B5.1, B5.4, B6 |
| `AddVideoDialog.test.tsx` | 4 | B7 |

- Full suite: **4658 passed, 289 files, 0 failed**
- ESLint: **0 errors, 17 warnings — identical count to master.** `useVideoLinksManager`
  was already over the complexity limit at 16; wiring the card action inline took it to
  21, so the logic lives in its own hook and the function is back at 16.
- Prettier clean; `vite build` succeeds.
- No Rust changes — the backend command from #140 is reused as-is.

## Notes for review

- **B6.5** (a failed Graphics copy must not fail the set) has no new test: the card
  action calls the same `run`, and #140 already covers it at
  `usePosterFrameForUpload.test.ts:448`.
- **Two hook instances.** `useVideoLinksManager` now mounts `usePosterFrameForUpload`
  twice — once for the upload tab, once for the card action — because their text follows
  different titles. Both inputs are React Query-backed (`useBackgroundFolder` keyed on
  folder path, font check `staleTime: Infinity`), so nothing is fetched twice. Happy to
  collapse them behind one instance with a switchable title source if you'd rather.
- **Cache keys are keyed by link URL**, not index, so they survive a reorder. They're
  session-only: after a restart the card falls back to the stored URL, which by then
  points at the branded frame anyway.
- **`Date.now()` in the hook** is the cache key's only source. It never reaches
  breadcrumbs.
- **The dialog closes on success** and reports via a Sonner toast rather than sitting
  open with a success line the way #140's mid-flow upload dialog does. That wasn't in
  the original issue text — it's recorded as B6.7 in the amendment comment.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
