### PR TITLE
chore: bump version to 0.18.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the Bucket project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-06
+
+### Added
+
+- Baker: branded poster frames at upload time — ticking "Create branded poster frame" in
+  the Upload File tab builds the thumbnail from a background image plus the video title
+  and sets it on Sprout Video as the custom poster frame, instead of leaving Sprout's
+  auto-generated still in place. Includes a live 16:9 preview, an optional copy into the
+  project's Graphics folder, and a retry ladder for transient Sprout failures (#140)
+- Baker: "Set poster frame" action on each video card, so videos added by URL or uploaded
+  before the feature existed can be given a branded thumbnail without opening Sprout's
+  web UI. Targets the stored Sprout id, or one derived from the link's own URL, and
+  refreshes the stored `thumbnailUrl` in breadcrumbs afterwards (#141)
+- Baker: support for 0-camera (podcast/audio-only) projects — validation accepts zero
+  Camera folders when the five standard folders exist and hold at least one file, and the
+  list and detail panels show a "No cameras" pill (#138)
+- Baker: Repair action that regenerates an unparseable `breadcrumbs.json`, backing the
+  original up to `breadcrumbs.json.bak` and salvaging linked Trello cards and video
+  links (#138)
+- Baker: nested project discovery — scans now recurse into container folders and into
+  projects themselves to find projects nested inside others (#138)
+
+### Fixed
+
+- The UI no longer renders a blank page when opened in a plain browser (e.g. `bun run
+  dev` without Tauri): Tauri window calls are guarded so an unavailable native API
+  degrades instead of crashing the app at startup (#144)
+- Baker: a blank poster frame can no longer be sent to Sprout — with the poster frame
+  option ticked, an empty text field holds the action back rather than uploading a
+  background-only image (#141)
+
+---
+
 ## [0.17.1] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.17.1"
+version = "0.18.0"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Prepares the 0.18.0 release. No functional changes — version bump and changelog only.

## Why 0.18.0

Four merges have landed on `master` since 0.17.1, three of them features, so this is a
minor bump:

| PR | Issue | Change |
|---|---|---|
| #139 | #138 | Baker: 0-camera (podcast) projects, breadcrumb repair, nested project discovery |
| #143 | #140 | Baker: branded poster frame during upload |
| #146 | #141 | Baker: set a poster frame on an already-linked video |
| #145 | #144 | fix: render the UI in a plain browser instead of a blank page |

## Version locations updated

- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (the `Bucket` package entry)
- `src-tauri/tauri.conf.json`

Verified with `cargo metadata --no-deps`, which resolves the manifest and lockfile
cleanly at `Bucket@0.18.0`.

## What happens after this merges

Merging this pushes a `package.json` version change to `master`, which triggers
`auto-release-pr.yml` and opens the `master → release` PR automatically. Merging **that**
one pushes to `release` and fires `publish.yml`.

⚠️ **Merge the release PR with a merge commit, not a squash.** Squash-merging it is what
causes the recurring version-file conflicts between `master` and `release`.

The published release will be an unsigned draft — notarise locally with
`./scripts/notarize-local.sh`, staple, `gh release upload --clobber`, then un-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)