### PR TITLE
fix: stop silent Sprout upload hangs and make toasts visible on every theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the Bucket project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-08-07
+
+### Fixed
+
+- Sprout upload: a failed upload no longer hangs the Add Video dialog indefinitely. The
+  response body was parsed as JSON before the HTTP status was checked, so any non-2xx
+  answer with an HTML or empty body — an nginx `413`, a `502`/`504` from a load balancer —
+  failed to deserialise and exited through a bare `println!`, bypassing the only path that
+  told the frontend anything. The status is now decided first and reported with a body
+  excerpt. Confirmed in the wild: an upload stalled at 11.61% logged "error decoding
+  response body: expected value at line 1 column 1" (#150)
+- Sprout upload: a 2xx response carrying `null`, `[]` or a bare string no longer reports
+  success. It parsed fine but held no video record, so the upload appeared to work while no
+  link was ever added (#150)
+- Toasts are now visible on every theme. They rendered with no background on 10 of the 13
+  themes, because the app's theme name was passed to sonner verbatim and sonner only
+  defines its colour variables for `light` and `dark` — leaving `background: var(--normal-bg)`
+  invalid and transparent. Over a dialog overlay on the light custom themes this reached
+  ~1.15:1 contrast, making failures look like nothing had happened. Colours are now supplied
+  inline, and severity backgrounds are tints of the popover surface rather than solid fills,
+  which a contrast audit found fell below 4.5:1 in six of the twelve themes (#151)
+- Upload status severity is carried as typed data rather than matched from message text.
+  The Add Video dialog tested for the substring "failed" and the Sprout page for "success",
+  so a failure worded "Sprout rejected the upload: HTTP 413" rendered as a neutral notice
+  (#150, #151)
+- Upload status messages are cleared when the dialog closes, the tab changes, or a new
+  upload starts, so a previous attempt's text cannot sit beneath a live progress bar (#151)
+
 ## [0.18.0] - 2026-08-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A desktop video editing workflow application that streamlines video ingest, project creation, and integrates with professional video production tools.",
   "author": "Dan Mills",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Bucket"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "argon2",
  "base64ct",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bucket"
-version = "0.18.0"
+version = "0.18.1"
 description = "An app to streamline ingesting and uploading video content"
 authors = ["Daniel Mills"]
 license = "UNLICENSED"

--- a/src-tauri/src/commands/sprout_upload.rs
+++ b/src-tauri/src/commands/sprout_upload.rs
@@ -85,14 +85,28 @@ fn body_excerpt(body: &str) -> String {
 /// frontend waiting forever. See issue #150.
 pub fn classify_response(status: reqwest::StatusCode, body: &str) -> Result<Value, String> {
     if status.is_success() {
-        serde_json::from_str(body).map_err(|e| {
+        let parsed: Value = serde_json::from_str(body).map_err(|e| {
             format!(
                 "Sprout returned HTTP {} but the response body was not valid JSON ({}): {}",
                 status,
                 e,
                 body_excerpt(body)
             )
-        })
+        })?;
+
+        // A 2xx carrying `null`, `[]` or a bare string parses fine but is not a
+        // video record. Treating it as success emits `upload_complete` with a
+        // useless payload, so the user is told the upload worked and no video
+        // link appears. Require the `id` the frontend actually reads.
+        if parsed.get("id").is_none() {
+            return Err(format!(
+                "Sprout returned HTTP {} with an unexpected JSON shape (no \"id\"): {}",
+                status,
+                body_excerpt(body)
+            ));
+        }
+
+        Ok(parsed)
     } else {
         Err(format!(
             "Sprout rejected the upload: HTTP {} — {}",

--- a/src-tauri/src/commands/sprout_upload.rs
+++ b/src-tauri/src/commands/sprout_upload.rs
@@ -55,6 +55,53 @@ pub fn upload_video(
     });
 }
 
+/// Maximum characters of a response body to quote in an error message. Enough to
+/// identify an HTML error page, short enough to stay readable in a toast.
+const BODY_EXCERPT_LIMIT: usize = 512;
+
+/// Renders a response body for an error message, truncated on a char boundary so
+/// multi-byte content cannot panic.
+fn body_excerpt(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "(empty body)".to_string();
+    }
+
+    let excerpt: String = trimmed.chars().take(BODY_EXCERPT_LIMIT).collect();
+    if trimmed.chars().count() > BODY_EXCERPT_LIMIT {
+        format!("{}… (truncated)", excerpt)
+    } else {
+        excerpt
+    }
+}
+
+/// Decides an upload's outcome from the HTTP status and the raw response body.
+///
+/// The body is parsed as JSON only on the success path. Sprout and the
+/// intermediaries in front of it return HTML or empty bodies for 413/502/504, so
+/// deserialising before checking the status throws away the status code that
+/// names the actual failure — and, because that parse failure propagated with
+/// `?`, it bypassed the only `upload_error` emitter entirely and left the
+/// frontend waiting forever. See issue #150.
+pub fn classify_response(status: reqwest::StatusCode, body: &str) -> Result<Value, String> {
+    if status.is_success() {
+        serde_json::from_str(body).map_err(|e| {
+            format!(
+                "Sprout returned HTTP {} but the response body was not valid JSON ({}): {}",
+                status,
+                e,
+                body_excerpt(body)
+            )
+        })
+    } else {
+        Err(format!(
+            "Sprout rejected the upload: HTTP {} — {}",
+            status,
+            body_excerpt(body)
+        ))
+    }
+}
+
 // Async Progress Tracking Reader using Tokio's AsyncRead API (with ReadBuf)
 pub struct ProgressReader<R> {
     inner: R,
@@ -191,18 +238,25 @@ async fn upload_video_task(
         .map_err(|e| e.to_string())?;
 
     let status = response.status();
-    // Parse the response body as JSON.
-    let response_json: Value = response.json().await.map_err(|e| e.to_string())?;
-    println!("Upload Response: {:?}", response_json);
+    println!("Upload response: HTTP {}", status);
 
-    if status.is_success() {
-        println!("Upload complete!");
-        let _ = app_handle.emit("upload_complete", response_json);
-        Ok(())
-    } else {
-        let error_message = format!("Upload failed: HTTP {} - {:?}", status, response_json);
-        let _ = app_handle.emit("upload_error", error_message.clone());
-        Err(error_message)
+    // Read the body as text first. Deciding the outcome must never depend on the
+    // body being parseable, or a non-JSON error page silently kills the upload.
+    let body_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response body (HTTP {}): {}", status, e))?;
+
+    match classify_response(status, &body_text) {
+        Ok(response_json) => {
+            println!("Upload complete!");
+            let _ = app_handle.emit("upload_complete", response_json);
+            Ok(())
+        }
+        Err(error_message) => {
+            let _ = app_handle.emit("upload_error", error_message.clone());
+            Err(error_message)
+        }
     }
 }
 

--- a/src-tauri/src/commands/tests/mod.rs
+++ b/src-tauri/src/commands/tests/mod.rs
@@ -1,1 +1,2 @@
 mod rag_validation_tests;
+mod sprout_upload_tests;

--- a/src-tauri/src/commands/tests/sprout_upload_tests.rs
+++ b/src-tauri/src/commands/tests/sprout_upload_tests.rs
@@ -1,0 +1,96 @@
+/**
+ * Sprout Upload Tests
+ * Issue #150 - Sprout upload hangs silently on large files
+ *
+ * Covers UP-02: a non-2xx response with an unparseable body must still report
+ * its HTTP status. Previously `response.json()` ran before the status check, so
+ * an HTML 413/502/504 error page failed to deserialise and exited via `?` into a
+ * bare `println!`, leaving the frontend waiting on an event that never came.
+ */
+use crate::commands::sprout_upload::classify_response;
+use reqwest::StatusCode;
+
+#[test]
+fn success_with_valid_json_returns_the_parsed_body() {
+    let body = r#"{"id":"abc123","title":"Interview part 1"}"#;
+    let result = classify_response(StatusCode::OK, body);
+
+    let value = result.expect("a 2xx with valid JSON should classify as success");
+    assert_eq!(value["id"], "abc123");
+    assert_eq!(value["title"], "Interview part 1");
+}
+
+#[test]
+fn non_2xx_with_html_body_reports_the_status_code() {
+    // The exact shape an nginx / load-balancer body-size rejection takes.
+    let body = "<html>\r\n<head><title>413 Request Entity Too Large</title></head>\r\n</html>";
+    let result = classify_response(StatusCode::PAYLOAD_TOO_LARGE, body);
+
+    let err = result.expect_err("a 413 must not be treated as success");
+    assert!(
+        err.contains("413"),
+        "error must name the HTTP status so the cause is identifiable, got: {err}"
+    );
+    assert!(
+        err.contains("Request Entity Too Large"),
+        "error must include the response body so the cause is identifiable, got: {err}"
+    );
+}
+
+#[test]
+fn non_2xx_with_empty_body_still_reports_the_status_code() {
+    let result = classify_response(StatusCode::BAD_GATEWAY, "");
+
+    let err = result.expect_err("a 502 must not be treated as success");
+    assert!(
+        err.contains("502"),
+        "error must name the HTTP status even with no body, got: {err}"
+    );
+}
+
+#[test]
+fn non_2xx_with_json_body_still_reports_the_status_code() {
+    // The one path that previously worked must keep working.
+    let result = classify_response(StatusCode::UNAUTHORIZED, r#"{"error":"bad api key"}"#);
+
+    let err = result.expect_err("a 401 must not be treated as success");
+    assert!(err.contains("401"), "got: {err}");
+    assert!(err.contains("bad api key"), "got: {err}");
+}
+
+#[test]
+fn success_with_unparseable_body_is_an_error_naming_the_status() {
+    // This is the case that produced the reported hang:
+    // "error decoding response body: expected value at line 1 column 1".
+    let result = classify_response(StatusCode::OK, "<html>not json</html>");
+
+    let err = result.expect_err("a 2xx with a non-JSON body cannot yield a video record");
+    assert!(
+        err.contains("200"),
+        "error must name the HTTP status, got: {err}"
+    );
+}
+
+#[test]
+fn oversized_bodies_are_truncated_in_the_error_message() {
+    let body = "x".repeat(5000);
+    let result = classify_response(StatusCode::INTERNAL_SERVER_ERROR, &body);
+
+    let err = result.expect_err("a 500 must not be treated as success");
+    assert!(
+        err.len() < 1024,
+        "error message must stay readable rather than embedding the whole body, got {} chars",
+        err.len()
+    );
+    assert!(err.contains("500"), "got: {err}");
+}
+
+#[test]
+fn multibyte_bodies_are_truncated_without_panicking() {
+    // Truncating on a byte boundary rather than a char boundary would panic here.
+    let body = "é".repeat(5000);
+    let result = classify_response(StatusCode::INTERNAL_SERVER_ERROR, &body);
+
+    let err = result.expect_err("a 500 must not be treated as success");
+    assert!(err.contains("500"), "got: {err}");
+}

--- a/src-tauri/src/commands/tests/sprout_upload_tests.rs
+++ b/src-tauri/src/commands/tests/sprout_upload_tests.rs
@@ -59,6 +59,21 @@ fn non_2xx_with_json_body_still_reports_the_status_code() {
 }
 
 #[test]
+fn success_with_json_that_is_not_a_video_record_is_an_error() {
+    // A caching proxy answering 200 with `null` parses fine but carries no
+    // video. Emitting upload_complete here tells the user it worked while no
+    // link is ever added.
+    for body in ["null", "[]", "\"ok\"", "3", "{}", r#"{"error":"nope"}"#] {
+        let err = classify_response(StatusCode::OK, body)
+            .expect_err("a 2xx without an id is not a video record");
+        assert!(
+            err.contains("unexpected JSON shape"),
+            "body {body} should be rejected as a non-record, got: {err}"
+        );
+    }
+}
+
+#[test]
 fn success_with_unparseable_body_is_an_error_naming_the_status() {
     // This is the case that produced the reported hang:
     // "error decoding response body: expected value at line 1 column 1".
@@ -78,11 +93,27 @@ fn oversized_bodies_are_truncated_in_the_error_message() {
 
     let err = result.expect_err("a 500 must not be treated as success");
     assert!(
-        err.len() < 1024,
-        "error message must stay readable rather than embedding the whole body, got {} chars",
-        err.len()
+        err.contains("… (truncated)"),
+        "an oversized body must be marked as truncated, got: {err}"
+    );
+    // 512 chars of body + a short prefix. Pins the limit rather than just
+    // asserting "not enormous".
+    assert!(
+        (520..640).contains(&err.chars().count()),
+        "expected ~512 chars of body plus a prefix, got {} chars",
+        err.chars().count()
     );
     assert!(err.contains("500"), "got: {err}");
+}
+
+#[test]
+fn empty_body_is_reported_as_such() {
+    let err = classify_response(StatusCode::BAD_GATEWAY, "   \n\t ")
+        .expect_err("a 502 must not be treated as success");
+    assert!(
+        err.contains("(empty body)"),
+        "a whitespace-only body should read as empty, got: {err}"
+    );
 }
 
 #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bucket",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "identifier": "com.bucket-app.dev",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/features/Baker/components/AddVideoDialog.test.tsx
+++ b/src/features/Baker/components/AddVideoDialog.test.tsx
@@ -386,3 +386,81 @@ describe('AddVideoDialog - poster frame text is required (B7)', () => {
     expect(screen.queryByText(/poster frame text is required/i)).not.toBeInTheDocument()
   })
 })
+
+// ==========================================================================
+// UPLOAD-02 — upload message severity comes from the event, not the text.
+//
+// Every message below deliberately contains neither "failed" nor "success":
+// that is the whole regression. `message.includes('failed')` renders a hard
+// failure as a neutral notice.
+// ==========================================================================
+type UploadMessage = {
+  text: string
+  severity: 'error' | 'success' | 'info'
+}
+
+/**
+ * Casts through the current `string | null` prop type. Once the message shape
+ * lands in @features/Upload this cast disappears.
+ */
+const messageProps = (message: UploadMessage) =>
+  baseProps({
+    uploadMode: {
+      ...baseProps().uploadMode,
+      uploading: false,
+      message: message as unknown as string
+    }
+  })
+
+const DESTRUCTIVE_CLASSES = ['border-red-500/50', 'text-red-600']
+
+describe('AddVideoDialog - upload message severity (UPLOAD-02)', () => {
+  it('renders an HTTP 413 rejection with the destructive alert variant', () => {
+    const text = 'Sprout rejected the upload: HTTP 413 — <html>'
+
+    expect(text.toLowerCase()).not.toContain('failed')
+    expect(text.toLowerCase()).not.toContain('success')
+
+    render(<AddVideoDialog {...messageProps({ text, severity: 'error' })} />)
+
+    const alert = screen.getByRole('alert')
+    for (const cls of DESTRUCTIVE_CLASSES) {
+      expect(alert.className).toContain(cls)
+    }
+    expect(alert).toHaveTextContent(text)
+  })
+
+  it('renders a non-JSON body rejection with the destructive alert variant', () => {
+    const text = 'Sprout returned HTTP 200 but the response body was not valid JSON (…)'
+
+    expect(text.toLowerCase()).not.toContain('failed')
+
+    render(<AddVideoDialog {...messageProps({ text, severity: 'error' })} />)
+
+    const alert = screen.getByRole('alert')
+    for (const cls of DESTRUCTIVE_CLASSES) {
+      expect(alert.className).toContain(cls)
+    }
+    expect(alert).toHaveTextContent(text)
+  })
+
+  it('does not use the destructive variant for a success message', () => {
+    const text = 'Upload complete — the video is now on Sprout'
+
+    render(<AddVideoDialog {...messageProps({ text, severity: 'success' })} />)
+
+    const alert = screen.getByRole('alert')
+    for (const cls of DESTRUCTIVE_CLASSES) {
+      expect(alert.className).not.toContain(cls)
+    }
+    expect(alert).toHaveTextContent(text)
+  })
+
+  it('never renders the message as [object Object]', () => {
+    const text = 'Sprout rejected the upload: HTTP 413 — <html>'
+
+    render(<AddVideoDialog {...messageProps({ text, severity: 'error' })} />)
+
+    expect(screen.getByRole('alert')).not.toHaveTextContent('[object Object]')
+  })
+})

--- a/src/features/Baker/components/AddVideoDialog.tsx
+++ b/src/features/Baker/components/AddVideoDialog.tsx
@@ -14,6 +14,8 @@ import {
 } from 'lucide-react'
 import type { RefObject } from 'react'
 
+import type { UploadMessage } from '@features/Upload'
+
 import { Alert, AlertDescription } from '@shared/ui/alert'
 import { Button } from '@shared/ui/button'
 import { Checkbox } from '@shared/ui/checkbox'
@@ -73,7 +75,7 @@ export interface UploadModeState {
   selectedFile: string | null
   uploading: boolean
   progress: number
-  message: string | null
+  message: UploadMessage | null
   uploadSuccess: boolean
   onSelectFile: () => void
   onUploadAndAdd: () => void
@@ -567,15 +569,10 @@ function UploadContent({
 
       {uploadMode.message && !uploadMode.uploading && (
         <Alert
-          variant={
-            typeof uploadMode.message === 'string' &&
-            uploadMode.message.includes('failed')
-              ? 'destructive'
-              : 'default'
-          }
+          variant={uploadMode.message.severity === 'error' ? 'destructive' : 'default'}
         >
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription>{String(uploadMode.message)}</AlertDescription>
+          <AlertDescription>{uploadMode.message.text}</AlertDescription>
         </Alert>
       )}
     </div>

--- a/src/features/Baker/components/VideoLinksManager.test.tsx
+++ b/src/features/Baker/components/VideoLinksManager.test.tsx
@@ -1157,7 +1157,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       vi.mocked(useUploadEventsModule.useUploadEvents).mockReturnValue({
         progress: 0,
         uploading: false,
-        message: 'Upload failed: Network error',
+        message: { text: 'Upload failed: Network error', severity: 'error' },
         setUploading: vi.fn(),
         setProgress: vi.fn(),
         setMessage: vi.fn()
@@ -1190,7 +1190,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       vi.mocked(useUploadEventsModule.useUploadEvents).mockReturnValue({
         progress: 0,
         uploading: false,
-        message: 'Upload failed: Request timeout',
+        message: { text: 'Upload failed: Request timeout', severity: 'error' },
         setUploading: vi.fn(),
         setProgress: vi.fn(),
         setMessage: vi.fn()
@@ -1251,7 +1251,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       vi.mocked(useUploadEventsModule.useUploadEvents).mockReturnValue({
         progress: 0,
         uploading: false,
-        message: 'Upload failed: Network error',
+        message: { text: 'Upload failed: Network error', severity: 'error' },
         setUploading: vi.fn(),
         setProgress: vi.fn(),
         setMessage: vi.fn()
@@ -1285,7 +1285,7 @@ describe('VideoLinksManager - Upload Toggle Enhancement', () => {
       vi.mocked(useUploadEventsModule.useUploadEvents).mockReturnValue({
         progress: 0,
         uploading: false,
-        message: 'Upload failed',
+        message: { text: 'Upload failed', severity: 'error' },
         setUploading: vi.fn(),
         setProgress: vi.fn(),
         setMessage: vi.fn()

--- a/src/features/Trello/hooks/useVideoLinksManager.test.tsx
+++ b/src/features/Trello/hooks/useVideoLinksManager.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * UPLOAD-04 / UPLOAD-05 — a stale upload message must never survive into the
+ * next visit to the Add Video dialog.
+ *
+ * `useUploadEvents` is deliberately left un-mocked so the assertions run
+ * against the real React Query cache entry under `queryKeys.upload.events()`;
+ * everything else useVideoLinksManager depends on is stubbed.
+ */
+
+import '@testing-library/jest-dom'
+
+import { queryKeys } from '@shared/lib'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import React, { type ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as apiKeysModule from '@shared/hooks'
+import * as bakerModule from '@features/Baker'
+import * as uploadModule from '@features/Upload'
+
+import * as trelloCardsModule from './useBreadcrumbsTrelloCards'
+import * as cardPosterFrameModule from './useCardPosterFrame'
+import { useVideoLinksManager } from './useVideoLinksManager'
+
+vi.mock('../api', () => ({
+  bakerReadBreadcrumbs: vi.fn().mockResolvedValue({}),
+  fetchTrelloCardById: vi.fn().mockResolvedValue({}),
+  updateTrelloCard: vi.fn().mockResolvedValue({})
+}))
+
+vi.mock('./useBreadcrumbsTrelloCards')
+vi.mock('./useCardPosterFrame')
+
+vi.mock('@shared/hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/hooks')>()),
+  useSproutVideoApiKey: vi.fn(),
+  useTrelloApiKeys: vi.fn()
+}))
+
+vi.mock('@features/Baker', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@features/Baker')>()),
+  useBreadcrumbsVideoLinks: vi.fn(),
+  generateBreadcrumbsBlock: vi.fn(() => ''),
+  updateTrelloCardWithBreadcrumbs: vi.fn()
+}))
+
+// Partial mock: useUploadEvents stays real so it keeps writing to the cache.
+vi.mock('@features/Upload', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@features/Upload')>()),
+  useFileUpload: vi.fn(),
+  usePosterFrameForUpload: vi.fn(),
+  useSproutVideoApi: vi.fn(),
+  useSproutVideoProcessor: vi.fn()
+}))
+
+const STALE_MESSAGE = {
+  text: 'Sprout rejected the upload: HTTP 413 — <html>',
+  severity: 'error' as const
+}
+
+const uploadEventsKey = queryKeys.upload.events()
+
+type UploadEventsCache = {
+  progress: number
+  uploading: boolean
+  message: unknown
+}
+
+const mockUploadFile = vi.fn().mockResolvedValue(undefined)
+
+const setupMocks = () => {
+  vi.mocked(bakerModule.useBreadcrumbsVideoLinks).mockReturnValue({
+    videoLinks: [],
+    isLoading: false,
+    error: null,
+    addVideoLink: vi.fn(),
+    addVideoLinkAsync: vi.fn(),
+    removeVideoLink: vi.fn(),
+    removeVideoLinkAsync: vi.fn(),
+    updateVideoLink: vi.fn(),
+    updateVideoLinkAsync: vi.fn(),
+    reorderVideoLinks: vi.fn(),
+    reorderVideoLinksAsync: vi.fn(),
+    isUpdating: false,
+    addError: null,
+    removeError: null,
+    updateError: null,
+    reorderError: null
+  } as unknown as ReturnType<typeof bakerModule.useBreadcrumbsVideoLinks>)
+
+  vi.mocked(trelloCardsModule.useBreadcrumbsTrelloCards).mockReturnValue({
+    trelloCards: [],
+    isLoading: false,
+    error: null,
+    addTrelloCard: vi.fn(),
+    addTrelloCardAsync: vi.fn(),
+    removeTrelloCard: vi.fn(),
+    removeTrelloCardAsync: vi.fn(),
+    fetchCardDetails: vi.fn(),
+    fetchCardDetailsAsync: vi.fn(),
+    isUpdating: false,
+    isFetchingDetails: false,
+    addError: null,
+    removeError: null,
+    fetchError: null,
+    fetchedCardData: undefined
+  } as unknown as ReturnType<typeof trelloCardsModule.useBreadcrumbsTrelloCards>)
+
+  vi.mocked(cardPosterFrameModule.useCardPosterFrame).mockReturnValue({
+    activeIndex: null,
+    open: vi.fn(),
+    close: vi.fn(),
+    status: 'idle',
+    error: null,
+    run: vi.fn(),
+    retry: vi.fn(),
+    reset: vi.fn()
+  } as unknown as ReturnType<typeof cardPosterFrameModule.useCardPosterFrame>)
+
+  vi.mocked(apiKeysModule.useSproutVideoApiKey).mockReturnValue({
+    apiKey: 'test-api-key',
+    isLoading: false,
+    error: null
+  } as unknown as ReturnType<typeof apiKeysModule.useSproutVideoApiKey>)
+
+  vi.mocked(apiKeysModule.useTrelloApiKeys).mockReturnValue({
+    apiKey: 'trello-key',
+    apiToken: 'trello-token',
+    isLoading: false,
+    error: null
+  } as unknown as ReturnType<typeof apiKeysModule.useTrelloApiKeys>)
+
+  vi.mocked(uploadModule.useFileUpload).mockReturnValue({
+    selectedFile: '/renders/WBS_intro.mp4',
+    uploading: false,
+    response: null,
+    localDuration: null,
+    selectFile: vi.fn(),
+    uploadFile: mockUploadFile,
+    resetUploadState: vi.fn()
+  } as unknown as ReturnType<typeof uploadModule.useFileUpload>)
+
+  vi.mocked(uploadModule.useSproutVideoApi).mockReturnValue({
+    fetchVideoDetails: vi.fn(),
+    fetchVideoDetailsAsync: vi.fn(),
+    isFetching: false,
+    error: null,
+    data: undefined,
+    reset: vi.fn()
+  } as unknown as ReturnType<typeof uploadModule.useSproutVideoApi>)
+
+  vi.mocked(uploadModule.useSproutVideoProcessor).mockReturnValue({
+    reset: vi.fn()
+  } as unknown as ReturnType<typeof uploadModule.useSproutVideoProcessor>)
+
+  vi.mocked(uploadModule.usePosterFrameForUpload).mockReturnValue({
+    available: true,
+    unavailableReason: null,
+    enabled: false,
+    setEnabled: vi.fn(),
+    backgrounds: [],
+    selectedBackground: null,
+    setSelectedBackground: vi.fn(),
+    text: 'Managing Change',
+    setText: vi.fn(),
+    previewImageUrl: null,
+    canvasRef: { current: null },
+    saveCopy: false,
+    setSaveCopy: vi.fn(),
+    status: 'idle',
+    error: null,
+    run: vi.fn(),
+    retry: vi.fn(),
+    reset: vi.fn()
+  } as unknown as ReturnType<typeof uploadModule.usePosterFrameForUpload>)
+}
+
+const renderManager = async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false }
+    }
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+
+  const view = renderHook(() => useVideoLinksManager({ projectPath: '/project' }), {
+    wrapper
+  })
+
+  // Let the upload-events query settle before seeding the cache.
+  await waitFor(() => {
+    expect(queryClient.getQueryData(uploadEventsKey)).toBeDefined()
+  })
+
+  return { ...view, queryClient }
+}
+
+const seedStaleMessage = async (queryClient: QueryClient) => {
+  act(() => {
+    queryClient.setQueryData(uploadEventsKey, {
+      progress: 100,
+      uploading: false,
+      message: STALE_MESSAGE
+    })
+  })
+
+  await waitFor(() => {
+    expect(
+      (queryClient.getQueryData(uploadEventsKey) as UploadEventsCache).message
+    ).toEqual(STALE_MESSAGE)
+  })
+}
+
+const cachedMessage = (queryClient: QueryClient) =>
+  (queryClient.getQueryData(uploadEventsKey) as UploadEventsCache | undefined)?.message
+
+beforeEach(() => {
+  mockUploadFile.mockClear()
+  mockUploadFile.mockResolvedValue(undefined)
+  setupMocks()
+})
+
+describe('UPLOAD-04: closing the dialog clears the previous upload message', () => {
+  it('nulls the cached message when the dialog closes', async () => {
+    const { result, queryClient } = await renderManager()
+    await seedStaleMessage(queryClient)
+
+    await act(async () => {
+      result.current.handleDialogOpenChange(false)
+    })
+
+    await waitFor(() => {
+      expect(cachedMessage(queryClient)).toBeNull()
+    })
+  })
+
+  it('shows no stale message when the dialog is reopened', async () => {
+    const { result, queryClient } = await renderManager()
+    await seedStaleMessage(queryClient)
+
+    await act(async () => {
+      result.current.handleDialogOpenChange(false)
+    })
+    await act(async () => {
+      result.current.handleDialogOpenChange(true)
+    })
+
+    expect(cachedMessage(queryClient)).toBeNull()
+    expect(result.current.message).toBeNull()
+  })
+})
+
+describe('UPLOAD-05: starting an upload clears the previous message', () => {
+  it('nulls the cached message before the first progress event arrives', async () => {
+    const { result, queryClient } = await renderManager()
+    await seedStaleMessage(queryClient)
+
+    await act(async () => {
+      await result.current.handleUploadAndAdd()
+    })
+
+    expect(mockUploadFile).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(cachedMessage(queryClient)).toBeNull()
+    })
+  })
+})

--- a/src/features/Trello/hooks/useVideoLinksManager.ts
+++ b/src/features/Trello/hooks/useVideoLinksManager.ts
@@ -77,7 +77,7 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
     uploadFile,
     resetUploadState
   } = useFileUpload()
-  const { progress, message } = useUploadEvents()
+  const { progress, message, setMessage } = useUploadEvents()
 
   // UI state
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -238,6 +238,10 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
   const handleUploadAndAdd = async () => {
     if (!selectedFile || !apiKey) return
 
+    // Clear any previous attempt's message before the new one starts, so a
+    // stale error cannot sit under a live progress bar.
+    setMessage(null)
+
     try {
       await uploadFile(apiKey, formData.title)
     } catch (error) {
@@ -356,6 +360,9 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
       setFetchError(null)
       setAddMode('url')
       resetUploadState()
+      // The message lives in the React Query cache, which resetUploadState
+      // does not own -- clear it here or a previous run's text reappears.
+      setMessage(null)
       videoProcessor.reset()
       posterFrame.reset()
     }
@@ -368,6 +375,7 @@ export function useVideoLinksManager({ projectPath }: UseVideoLinksManagerProps)
 
     if (value === 'url') {
       resetUploadState()
+      setMessage(null)
       videoProcessor.reset()
       posterFrame.reset()
     }

--- a/src/features/Upload/components/UploadSprout.test.tsx
+++ b/src/features/Upload/components/UploadSprout.test.tsx
@@ -45,10 +45,19 @@ let mockFileUploadState = {
   selectFile: mockSelectFile,
   uploadFile: mockUploadFile
 }
+/**
+ * Upload messages carry their own severity so nothing has to sniff the text.
+ * Cast at the assignment sites until the shape lands in @features/Upload.
+ */
+type UploadMessage = {
+  text: string
+  severity: 'error' | 'success' | 'info'
+}
+
 let mockUploadEventsState = {
   progress: 0,
   uploading: false,
-  message: null as string | null,
+  message: null as UploadMessage | null,
   setProgress: mockSetProgress,
   setMessage: mockSetMessage,
   setUploading: mockSetUploading
@@ -402,7 +411,7 @@ describe('UploadSprout Page', () => {
       mockUploadEventsState = {
         progress: 100,
         uploading: false,
-        message: 'Upload successful!',
+        message: { text: 'Upload successful!', severity: 'success' },
         setProgress: mockSetProgress,
         setMessage: mockSetMessage,
         setUploading: mockSetUploading
@@ -424,7 +433,7 @@ describe('UploadSprout Page', () => {
       mockUploadEventsState = {
         progress: 0,
         uploading: false,
-        message: 'Upload failed: Network error',
+        message: { text: 'Upload failed: Network error', severity: 'error' },
         setProgress: mockSetProgress,
         setMessage: mockSetMessage,
         setUploading: mockSetUploading
@@ -438,6 +447,65 @@ describe('UploadSprout Page', () => {
       expect(message).toBeInTheDocument()
       // Check it has error styling
       expect(message.closest('div')).toHaveClass('border-red-200')
+    })
+  })
+
+  // ==========================================
+  // UPLOAD-03: severity drives the styling, not the text
+  // ==========================================
+  describe('with an adversarial error message (UPLOAD-03)', () => {
+    // `includes('success')` returns true for this string, so today's
+    // text-sniffing paints a hard failure green.
+    const ADVERSARIAL_TEXT = 'Operation completed — 0 successes recorded'
+
+    beforeEach(() => {
+      mockUploadEventsState = {
+        progress: 0,
+        uploading: false,
+        message: { text: ADVERSARIAL_TEXT, severity: 'error' },
+        setProgress: mockSetProgress,
+        setMessage: mockSetMessage,
+        setUploading: mockSetUploading
+      }
+    })
+
+    it('should render failure styling even though the text contains "success"', () => {
+      expect(ADVERSARIAL_TEXT.toLowerCase()).toContain('success')
+
+      renderUploadSprout()
+
+      const message = screen.getByText(ADVERSARIAL_TEXT)
+      const box = message.closest('div')
+
+      expect(box).toHaveClass('bg-red-100')
+      expect(box).not.toHaveClass('bg-green-100')
+    })
+  })
+
+  describe('with an error message containing neither "failed" nor "success"', () => {
+    const HTTP_413_TEXT = 'Sprout rejected the upload: HTTP 413 — <html>'
+
+    beforeEach(() => {
+      mockUploadEventsState = {
+        progress: 0,
+        uploading: false,
+        message: { text: HTTP_413_TEXT, severity: 'error' },
+        setProgress: mockSetProgress,
+        setMessage: mockSetMessage,
+        setUploading: mockSetUploading
+      }
+    })
+
+    it('should render failure styling for an HTTP 413 rejection', () => {
+      expect(HTTP_413_TEXT.toLowerCase()).not.toContain('failed')
+      expect(HTTP_413_TEXT.toLowerCase()).not.toContain('success')
+
+      renderUploadSprout()
+
+      const box = screen.getByText(HTTP_413_TEXT).closest('div')
+
+      expect(box).toHaveClass('bg-red-100')
+      expect(box).not.toHaveClass('bg-green-100')
     })
   })
 

--- a/src/features/Upload/components/UploadSprout.tsx
+++ b/src/features/Upload/components/UploadSprout.tsx
@@ -149,12 +149,12 @@ const UploadSproutContent: React.FC = () => {
               {message && (
                 <div
                   className={`mt-4 rounded-md border p-3 ${
-                    message.toLowerCase().includes('success')
-                      ? 'border-green-200 bg-green-100 text-green-800'
-                      : 'border-red-200 bg-red-100 text-red-800'
+                    message.severity === 'error'
+                      ? 'border-red-200 bg-red-100 text-red-800'
+                      : 'border-green-200 bg-green-100 text-green-800'
                   }`}
                 >
-                  {message}
+                  {message.text}
                 </div>
               )}
             </div>

--- a/src/features/Upload/hooks/useUploadEvents.test.ts
+++ b/src/features/Upload/hooks/useUploadEvents.test.ts
@@ -1,0 +1,189 @@
+/**
+ * UPLOAD-01 — upload message severity comes from WHICH backend event fired,
+ * never from sniffing the message text.
+ *
+ * The regression this locks down: the backend now emits
+ * "Sprout rejected the upload: HTTP 413 — <excerpt>", which contains neither
+ * "failed" nor "success", so text-sniffing consumers rendered a hard failure
+ * as a neutral (or worse, a green) notice.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import React, { type ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUploadEvents } from './useUploadEvents'
+
+type Listener = (event: { payload: unknown }) => void
+
+// Plain functions (not vi.fn) so the suite-wide `mockReset: true` cannot strip
+// the implementations before a test runs.
+const eventBus = vi.hoisted(() => ({
+  failSetup: false,
+  progress: null as Listener | null,
+  complete: null as Listener | null,
+  error: null as Listener | null
+}))
+
+vi.mock('../api', () => ({
+  listenUploadProgress: async (cb: Listener) => {
+    if (eventBus.failSetup) {
+      // Let the query's own resolver land first so the catch-path write is the
+      // last one to touch the cache.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      throw new Error('listen() rejected')
+    }
+    eventBus.progress = cb
+    return () => {}
+  },
+  listenUploadComplete: async (cb: Listener) => {
+    if (eventBus.failSetup) {
+      // Let the query's own resolver land first so the catch-path write is the
+      // last one to touch the cache.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      throw new Error('listen() rejected')
+    }
+    eventBus.complete = cb
+    return () => {}
+  },
+  listenUploadError: async (cb: Listener) => {
+    if (eventBus.failSetup) {
+      // Let the query's own resolver land first so the catch-path write is the
+      // last one to touch the cache.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      throw new Error('listen() rejected')
+    }
+    eventBus.error = cb
+    return () => {}
+  }
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false }
+    }
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+
+  return { wrapper, queryClient }
+}
+
+const renderUploadEvents = async () => {
+  const { wrapper, queryClient } = createWrapper()
+  const view = renderHook(() => useUploadEvents(), { wrapper })
+
+  if (!eventBus.failSetup) {
+    await waitFor(() => {
+      expect(eventBus.error).not.toBeNull()
+      expect(eventBus.complete).not.toBeNull()
+    })
+  }
+
+  return { ...view, queryClient }
+}
+
+beforeEach(() => {
+  eventBus.failSetup = false
+  eventBus.progress = null
+  eventBus.complete = null
+  eventBus.error = null
+})
+
+describe('UPLOAD-01: message severity is derived from the event, not the text', () => {
+  it('marks an upload_error payload as an error even when it says neither "failed" nor "success"', async () => {
+    const payload =
+      'Sprout rejected the upload: HTTP 413 — <html><body>Request Entity Too Large</body></html>'
+
+    // Guard: the whole regression is that this text defeats text sniffing.
+    expect(payload.toLowerCase()).not.toContain('failed')
+    expect(payload.toLowerCase()).not.toContain('success')
+
+    const { result } = await renderUploadEvents()
+
+    await act(async () => {
+      eventBus.error?.({ payload })
+    })
+
+    await waitFor(() => {
+      expect(result.current.message).toEqual({ text: payload, severity: 'error' })
+    })
+    expect(result.current.uploading).toBe(false)
+  })
+
+  it('marks a non-JSON body rejection as an error', async () => {
+    const payload =
+      'Sprout returned HTTP 200 but the response body was not valid JSON (…)'
+
+    const { result } = await renderUploadEvents()
+
+    await act(async () => {
+      eventBus.error?.({ payload })
+    })
+
+    await waitFor(() => {
+      expect(result.current.message).toEqual({ text: payload, severity: 'error' })
+    })
+  })
+
+  it('marks upload_complete as a success', async () => {
+    const { result } = await renderUploadEvents()
+
+    await act(async () => {
+      eventBus.complete?.({ payload: { id: 'video-1' } })
+    })
+
+    await waitFor(() => {
+      expect(result.current.message).toEqual({
+        text: 'Upload successful',
+        severity: 'success'
+      })
+    })
+    expect(result.current.progress).toBe(100)
+    expect(result.current.uploading).toBe(false)
+  })
+
+  it('does not downgrade an error whose text happens to contain "success"', async () => {
+    const payload = 'Operation completed — 0 successes recorded'
+
+    const { result } = await renderUploadEvents()
+
+    await act(async () => {
+      eventBus.error?.({ payload })
+    })
+
+    await waitFor(() => {
+      expect(result.current.message).toEqual({ text: payload, severity: 'error' })
+    })
+  })
+
+  it('reports a listener setup failure as an error', async () => {
+    eventBus.failSetup = true
+
+    const { result } = await renderUploadEvents()
+
+    await waitFor(() => {
+      expect(result.current.message).toEqual({
+        text: 'Failed to setup event listeners',
+        severity: 'error'
+      })
+    })
+  })
+
+  it('leaves the message alone while progress ticks', async () => {
+    const { result } = await renderUploadEvents()
+
+    await act(async () => {
+      eventBus.progress?.({ payload: 42 })
+    })
+
+    await waitFor(() => {
+      expect(result.current.progress).toBe(42)
+    })
+    expect(result.current.message).toBeNull()
+  })
+})

--- a/src/features/Upload/hooks/useUploadEvents.ts
+++ b/src/features/Upload/hooks/useUploadEvents.ts
@@ -6,14 +6,15 @@ import { useCallback, useEffect, useRef } from 'react'
 import { logger } from '@shared/utils'
 
 import { listenUploadComplete, listenUploadError, listenUploadProgress } from '../api'
+import type { UploadMessage } from '../types'
 
 interface UseUploadEventsReturn {
   progress: number
   uploading: boolean
-  message: string | null
+  message: UploadMessage | null
   setUploading: (uploading: boolean) => void
   setProgress: (progress: number) => void
-  setMessage: (message: string | null) => void
+  setMessage: (message: UploadMessage | null) => void
 }
 
 export const useUploadEvents = (): UseUploadEventsReturn => {
@@ -27,7 +28,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
       async () => ({
         progress: 0,
         uploading: false,
-        message: null as string | null
+        message: null as UploadMessage | null
       }),
       'REALTIME',
       {
@@ -48,7 +49,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
       updates: Partial<{
         progress: number
         uploading: boolean
-        message: string | null
+        message: UploadMessage | null
       }>
     ) => {
       queryClient.setQueryData(
@@ -58,7 +59,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
             | {
                 progress: number
                 uploading: boolean
-                message: string | null
+                message: UploadMessage | null
               }
             | undefined
         ) => ({
@@ -89,7 +90,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
   )
 
   const setMessage = useCallback(
-    (newMessage: string | null) => {
+    (newMessage: UploadMessage | null) => {
       updateUploadState({ message: newMessage })
     },
     [updateUploadState]
@@ -121,7 +122,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
             // Backend sends the response object, not a string message
             // Convert to a success message for display
             updateUploadState({
-              message: 'Upload successful',
+              message: { text: 'Upload successful', severity: 'success' },
               uploading: false,
               progress: 100
             })
@@ -132,7 +133,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
           if (isMounted) {
             const errorMessage = event.payload as string
             updateUploadState({
-              message: errorMessage,
+              message: { text: errorMessage, severity: 'error' },
               uploading: false
             })
           }
@@ -140,7 +141,7 @@ export const useUploadEvents = (): UseUploadEventsReturn => {
       } catch (error) {
         logger.error('Failed to setup upload event listeners:', error)
         updateUploadState({
-          message: 'Failed to setup event listeners',
+          message: { text: 'Failed to setup event listeners', severity: 'error' },
           uploading: false
         })
       }

--- a/src/features/Upload/index.ts
+++ b/src/features/Upload/index.ts
@@ -43,3 +43,7 @@ export type { SproutVideoDetails } from './types'
 export type { PosterFrameRunResult } from './types'
 /** Progress of the poster frame step within an upload */
 export type { PosterFrameStatus } from './types'
+/** Severity of an upload status message -- info, success, or error */
+export type { UploadMessageSeverity } from './types'
+/** Upload status message carrying severity as typed data rather than sniffed from text */
+export type { UploadMessage } from './types'

--- a/src/features/Upload/types.ts
+++ b/src/features/Upload/types.ts
@@ -31,3 +31,23 @@ export interface PosterFrameRunResult {
   /** Human-readable failure text, null on success. */
   error: string | null
 }
+
+/** How an upload status message should be surfaced to the user. */
+export type UploadMessageSeverity = 'info' | 'success' | 'error'
+
+/**
+ * An upload status message with its severity carried as data.
+ *
+ * Severity is decided by which Tauri event fired (`upload_complete` vs
+ * `upload_error`), never by inspecting `text`. Backend wording changes -- such
+ * as "Sprout rejected the upload: HTTP 413 -- ..." -- must not alter styling.
+ */
+export interface UploadMessage {
+  text: string
+  severity: UploadMessageSeverity
+  /**
+   * Forward-compatibility slot for the typed terminal reason planned in issue
+   * #150 (UP-01/UP-07). Unset today; consumers must not depend on it.
+   */
+  reason?: string
+}

--- a/src/shared/ui/sonner.test.tsx
+++ b/src/shared/ui/sonner.test.tsx
@@ -1,0 +1,342 @@
+/**
+ * Toaster (sonner) behavioural tests.
+ *
+ * Covers TOAST-01, TOAST-02, TOAST-04, TOAST-05 and TOAST-06 from the
+ * "toasts are transparent on 10 of 13 themes" bug.
+ *
+ * NOTE: sonner is deliberately NOT mocked in this file — the whole point is to
+ * exercise the real Toaster so we can inspect the attributes and inline custom
+ * properties it actually stamps onto `[data-sonner-toaster]`.
+ */
+
+import '@testing-library/jest-dom'
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { act, render, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Dialog, DialogContent, DialogTitle } from './dialog'
+import { Toaster } from './sonner'
+import { getAllThemeIds, THEMES, type ThemeId } from './theme/themes'
+
+// next-themes is mocked with a mutable holder rather than a vi.fn() so that the
+// suite-wide `mockReset: true` in vite.config.ts cannot wipe the implementation.
+const themeHolder = vi.hoisted(() => ({
+  value: { theme: 'system', resolvedTheme: undefined } as {
+    theme?: string
+    resolvedTheme?: string
+  }
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: () => themeHolder.value
+}))
+
+const SONNER_SOURCE = path.resolve(__dirname, 'sonner.tsx')
+
+/** Fires a toast and waits for sonner's container to exist. */
+const fireToastAndGetContainer = async (
+  fire: () => void = () => toast('hello')
+): Promise<HTMLElement> => {
+  act(() => {
+    fire()
+  })
+
+  let container: HTMLElement | null = null
+  await waitFor(() => {
+    container = document.querySelector<HTMLElement>('[data-sonner-toaster]')
+    expect(container).not.toBeNull()
+  })
+
+  return container as unknown as HTMLElement
+}
+
+/** Collapses whitespace so `style` attribute comparisons are formatting-proof. */
+const normaliseStyle = (element: Element): string =>
+  (element.getAttribute('style') ?? '').replace(/\s+/g, ' ').trim()
+
+const escapeRe = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/** `--name: var(--token)` — matched whitespace-insensitively. */
+const solidVar = (name: string, token: string): readonly [string, RegExp] => [
+  name,
+  new RegExp(`${escapeRe(name)}:\\s*var\\(\\s*${escapeRe(token)}\\s*\\)`)
+]
+
+/**
+ * `--name: color-mix(in oklab, var(--token) N%, var(--color-popover))`.
+ *
+ * Solid `--color-*` fills were rejected: six of the twelve themes fall below
+ * 4.5:1 with them (tokyo-night error reaches 1.78:1) because the `*-foreground`
+ * tokens are not consistently authored as on-solid pairs. Tinting the popover
+ * background keeps the accent legible on every theme.
+ */
+const tintVar = (
+  name: string,
+  token: string,
+  percent: number
+): readonly [string, RegExp] => [
+  name,
+  new RegExp(
+    `${escapeRe(name)}:\\s*color-mix\\(\\s*in\\s+oklab\\s*,\\s*` +
+      `var\\(\\s*${escapeRe(token)}\\s*\\)\\s*${percent}%\\s*,\\s*` +
+      `var\\(\\s*--color-popover\\s*\\)\\s*\\)`
+  )
+]
+
+const severityVars = (severity: string, token: string) => [
+  tintVar(`--${severity}-bg`, token, 15),
+  solidVar(`--${severity}-text`, token),
+  tintVar(`--${severity}-border`, token, 35)
+]
+
+/**
+ * The 17 custom properties the toaster must declare inline so that every theme
+ * — not just sonner's own `light`/`dark` — resolves them. `--normal-bg-hover`
+ * and `--normal-border-hover` are read by sonner's close button and are only
+ * defined under its dark block, so they have to be supplied too.
+ */
+const REQUIRED_TOAST_VARIABLES: ReadonlyArray<readonly [string, RegExp]> = [
+  solidVar('--normal-bg', '--color-popover'),
+  solidVar('--normal-text', '--color-popover-foreground'),
+  solidVar('--normal-border', '--color-border'),
+  solidVar('--normal-bg-hover', '--color-accent'),
+  solidVar('--normal-border-hover', '--color-border'),
+  ...severityVars('error', '--color-destructive'),
+  ...severityVars('success', '--color-success'),
+  ...severityVars('warning', '--color-warning'),
+  ...severityVars('info', '--color-info')
+]
+
+const expectToastVariablesDeclared = (container: Element) => {
+  const style = normaliseStyle(container)
+
+  for (const [name, pattern] of REQUIRED_TOAST_VARIABLES) {
+    expect(style, `${name} is not declared on [data-sonner-toaster]`).toContain(
+      `${name}:`
+    )
+    expect(style, `${name} does not have the agreed value`).toMatch(pattern)
+  }
+}
+
+beforeEach(() => {
+  themeHolder.value = { theme: 'light', resolvedTheme: 'light' }
+
+  // vite.config.ts sets `mockReset: true`, which strips the implementation off
+  // the global matchMedia spy from tests/setup/vitest-setup.ts. sonner calls it
+  // to resolve `theme="system"`, so give it a real (light) implementation back.
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  })) as unknown as typeof window.matchMedia
+})
+
+// ==========================================================================
+// TOAST-01 — the app theme id must never reach sonner's data-sonner-theme
+//
+// The mapping is driven by next-themes' `resolvedTheme` (which never returns
+// 'system'), NOT by `theme`. `THEMES.system.isDark` is hardcoded `true` and
+// 'system' is the app default, so a `getThemeById(theme)?.isDark` mapping would
+// hand every System-on-macOS-Light user a black toast on a white UI.
+// ==========================================================================
+type ThemeCase = {
+  label: string
+  theme: string
+  resolvedTheme: string | undefined
+  expected: 'light' | 'dark'
+}
+
+const CONCRETE_THEME_IDS = getAllThemeIds().filter(
+  (id): id is Exclude<ThemeId, 'system'> => id !== 'system'
+)
+
+const THEME_CASES: ReadonlyArray<ThemeCase> = [
+  ...CONCRETE_THEME_IDS.map((id) => ({
+    label: id,
+    theme: id,
+    resolvedTheme: id,
+    expected: (THEMES[id].isDark ? 'dark' : 'light') as 'light' | 'dark'
+  })),
+  {
+    label: 'system resolved to light',
+    theme: 'system',
+    resolvedTheme: 'light',
+    expected: 'light'
+  },
+  {
+    label: 'system resolved to dark',
+    theme: 'system',
+    resolvedTheme: 'dark',
+    expected: 'dark'
+  },
+  {
+    label: 'an unknown theme id',
+    theme: 'not-a-real-theme',
+    resolvedTheme: 'not-a-real-theme',
+    expected: 'light'
+  }
+]
+
+describe('TOAST-01: sonner only ever sees a light/dark theme', () => {
+  it('covers all 13 registered themes plus the resolved and unknown cases', () => {
+    expect(getAllThemeIds()).toHaveLength(13)
+    expect(CONCRETE_THEME_IDS).toHaveLength(12)
+    expect(THEME_CASES).toHaveLength(15)
+  })
+
+  it.each(THEME_CASES)(
+    'maps $label onto data-sonner-theme="$expected"',
+    async ({ theme, resolvedTheme, expected }: ThemeCase) => {
+      themeHolder.value = { theme, resolvedTheme }
+
+      render(<Toaster />)
+      const container = await fireToastAndGetContainer(() =>
+        toast(`toast for ${theme}/${resolvedTheme}`)
+      )
+
+      const sonnerTheme = container.getAttribute('data-sonner-theme')
+
+      // Whatever happens, sonner must be told a theme it actually has
+      // stylesheet rules for — it only defines --normal-bg and friends under
+      // its own `light` and `dark` selectors.
+      expect(['light', 'dark']).toContain(sonnerTheme)
+      expect(sonnerTheme).toBe(expected)
+    }
+  )
+
+  it('does not map through the "system" pseudo-theme when it is the app default', async () => {
+    // Documenting, not asserting a desired value: THEMES.system.isDark is
+    // deliberately left as-is because other code may depend on it. That is
+    // precisely why the mapping must read resolvedTheme instead.
+    expect(THEMES.system.isDark).toBe(true)
+
+    themeHolder.value = { theme: 'system', resolvedTheme: 'light' }
+
+    render(<Toaster />)
+    const container = await fireToastAndGetContainer(() => toast('system light toast'))
+
+    expect(container.getAttribute('data-sonner-theme')).toBe('light')
+  })
+})
+
+// ==========================================================================
+// TOAST-02 — the toaster declares its own colour variables inline
+// ==========================================================================
+describe('TOAST-02: the toaster declares the theme tokens inline', () => {
+  it('expects exactly 17 declarations', () => {
+    expect(REQUIRED_TOAST_VARIABLES).toHaveLength(17)
+  })
+
+  it('declares all 17 sonner colour variables on [data-sonner-toaster]', async () => {
+    themeHolder.value = { theme: 'dracula', resolvedTheme: 'dracula' }
+
+    render(<Toaster />)
+    const container = await fireToastAndGetContainer(() => toast('variables toast'))
+
+    expectToastVariablesDeclared(container)
+  })
+
+  it('tints the popover background rather than filling with the solid accent', async () => {
+    themeHolder.value = { theme: 'tokyo-night', resolvedTheme: 'tokyo-night' }
+
+    render(<Toaster />)
+    const container = await fireToastAndGetContainer(() => toast('tint toast'))
+    const style = normaliseStyle(container)
+
+    // The rejected mapping: a solid fill paired with *-foreground text.
+    expect(style).not.toMatch(/--error-bg:\s*var\(\s*--color-destructive\s*\)\s*;/)
+    expect(style).not.toMatch(
+      /--error-text:\s*var\(\s*--color-destructive-foreground\s*\)/
+    )
+    expect(style).not.toMatch(/--success-bg:\s*var\(\s*--color-success\s*\)\s*;/)
+  })
+})
+
+// ==========================================================================
+// TOAST-04 — the shadcn group-[.toaster]: overrides are gone
+// ==========================================================================
+describe('TOAST-04: no group-[.toaster]: overrides remain', () => {
+  it('does not use group-[.toaster]: utilities anywhere in sonner.tsx', () => {
+    const source = fs.readFileSync(SONNER_SOURCE, 'utf8')
+
+    expect(source).not.toContain('group-[.toaster]:')
+  })
+})
+
+// ==========================================================================
+// TOAST-05 — rich colours are on so severity is visually distinct
+// ==========================================================================
+describe('TOAST-05: rich colours are enabled by default', () => {
+  it('marks error and success toasts with their type and rich-colors flag', async () => {
+    themeHolder.value = { theme: 'one-light', resolvedTheme: 'one-light' }
+
+    render(<Toaster />)
+    await fireToastAndGetContainer(() => {
+      toast.error('boom')
+      toast.success('yay')
+    })
+
+    const toasts = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-sonner-toast]')
+    )
+
+    const errorToast = toasts.find((el) => el.textContent?.includes('boom'))
+    const successToast = toasts.find((el) => el.textContent?.includes('yay'))
+
+    expect(errorToast).toBeTruthy()
+    expect(successToast).toBeTruthy()
+
+    expect(errorToast?.getAttribute('data-type')).toBe('error')
+    expect(successToast?.getAttribute('data-type')).toBe('success')
+
+    expect(errorToast?.getAttribute('data-rich-colors')).toBe('true')
+    expect(successToast?.getAttribute('data-rich-colors')).toBe('true')
+  })
+})
+
+// ==========================================================================
+// TOAST-06 — toasts stay readable above an open Radix dialog
+// ==========================================================================
+describe('TOAST-06: toasts rendered over an open dialog', () => {
+  it('renders outside the dialog overlay and still declares its variables', async () => {
+    themeHolder.value = { theme: 'catppuccin-mocha', resolvedTheme: 'catppuccin-mocha' }
+
+    render(
+      <>
+        <Toaster />
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Add video</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </>
+    )
+
+    const container = await fireToastAndGetContainer(() =>
+      toast.error('Sprout rejected the upload: HTTP 413')
+    )
+
+    const toastEl = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-sonner-toast]')
+    ).find((el) => el.textContent?.includes('HTTP 413'))
+
+    expect(toastEl).toBeTruthy()
+
+    const overlay = document.querySelector('.bg-black\\/80')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.contains(toastEl as Node)).toBe(false)
+
+    // Deliberately NOT asserting getComputedStyle(...).backgroundColor: vitest
+    // runs without the app stylesheet, so such an assertion would be vacuous.
+    expectToastVariablesDeclared(container)
+  })
+})

--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -1,23 +1,77 @@
 import { useTheme } from 'next-themes'
 import { Toaster as Sonner } from 'sonner'
 
+import { getThemeById } from './theme/themes'
+
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
+/**
+ * Sonner stamps `data-sonner-theme="<value>"` verbatim and only defines its
+ * colour variables under its own `light` and `dark` selectors. Passing a Bucket
+ * theme id (`dracula`, `one-light`, …) leaves `--normal-bg` and friends
+ * undefined, which makes `background: var(--normal-bg)` invalid at
+ * computed-value time — a fully transparent toast.
+ *
+ * Resolve through `resolvedTheme` rather than `theme`: `theme` can be the
+ * literal `'system'`, and `THEMES.system.isDark` is hardcoded `true`, so every
+ * System-on-Light user would otherwise get a black toast on a white UI.
+ */
+const toSonnerTheme = (resolvedTheme: string | undefined): ToasterProps['theme'] =>
+  (getThemeById(resolvedTheme ?? 'light')?.isDark ?? false) ? 'dark' : 'light'
+
+/**
+ * Toast colours, supplied inline so they beat sonner's own stylesheet.
+ *
+ * Sonner injects its CSS at runtime (`__insertCSS`) after Vite's extracted
+ * `<link>`, so an equal-specificity class override loses on source order in
+ * production while appearing to work in dev. Inline styles are immune, and
+ * custom properties inherit down to each `[data-sonner-toast]`.
+ *
+ * Severity backgrounds are tints of the popover surface rather than solid
+ * `--color-destructive` etc. The `*-foreground` tokens are not consistently
+ * authored as on-solid pairs, so the solid mapping falls below 4.5:1 in six of
+ * the twelve themes (tokyo-night error reaches 1.78:1). Tinting keeps the
+ * accent colour as text, which is legible on every theme.
+ */
+const TOAST_COLOR_VARIABLES = {
+  '--normal-bg': 'var(--color-popover)',
+  '--normal-text': 'var(--color-popover-foreground)',
+  '--normal-border': 'var(--color-border)',
+  '--normal-bg-hover': 'var(--color-accent)',
+  '--normal-border-hover': 'var(--color-border)',
+  '--error-bg': 'color-mix(in oklab, var(--color-destructive) 15%, var(--color-popover))',
+  '--error-text': 'var(--color-destructive)',
+  '--error-border':
+    'color-mix(in oklab, var(--color-destructive) 35%, var(--color-popover))',
+  '--success-bg': 'color-mix(in oklab, var(--color-success) 15%, var(--color-popover))',
+  '--success-text': 'var(--color-success)',
+  '--success-border':
+    'color-mix(in oklab, var(--color-success) 35%, var(--color-popover))',
+  '--warning-bg': 'color-mix(in oklab, var(--color-warning) 15%, var(--color-popover))',
+  '--warning-text': 'var(--color-warning)',
+  '--warning-border':
+    'color-mix(in oklab, var(--color-warning) 35%, var(--color-popover))',
+  '--info-bg': 'color-mix(in oklab, var(--color-info) 15%, var(--color-popover))',
+  '--info-text': 'var(--color-info)',
+  '--info-border': 'color-mix(in oklab, var(--color-info) 35%, var(--color-popover))'
+} as React.CSSProperties
+
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme()
+  const { resolvedTheme } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme={toSonnerTheme(resolvedTheme)}
+      richColors
       className="toaster group"
+      style={TOAST_COLOR_VARIABLES}
       toastOptions={{
         classNames: {
-          toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
-          actionButton:
-            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'
+          // The `group toast` classes anchor the `group-[.toast]:` variants
+          // below; the colour utilities that used to live here lost a
+          // specificity tie with sonner's own rules and never applied.
+          toast: 'group toast',
+          description: 'group-[.toast]:opacity-90'
         }
       }}
       {...props}

--- a/src/shared/ui/theme/theme-tokens.test.ts
+++ b/src/shared/ui/theme/theme-tokens.test.ts
@@ -1,0 +1,98 @@
+/**
+ * TOAST-03 — every concrete theme block in src/index.css must declare the HSL
+ * variables that the toaster's `--color-*` tokens dereference. A theme that
+ * omits one of these makes `background: var(--normal-bg)` resolve to nothing,
+ * which is exactly how toasts ended up transparent.
+ *
+ * This is a source-level guard: the tokens are only meaningful when they are
+ * present in *every* theme, so a plain declaration count is the assertion.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const INDEX_CSS = path.resolve(__dirname, '../../../index.css')
+
+/**
+ * The concrete (non-`system`) theme blocks in src/index.css. `:root` carries
+ * the light theme, the remaining 11 are class selectors applied by next-themes.
+ */
+const THEME_BLOCK_SELECTORS = [
+  ':root',
+  '.dark',
+  '.dracula',
+  '.tokyo-night',
+  '.catppuccin-latte',
+  '.catppuccin-frappe',
+  '.catppuccin-macchiato',
+  '.catppuccin-mocha',
+  '.solarized-light',
+  '.github-light',
+  '.nord-light',
+  '.one-light'
+] as const
+
+const EXPECTED_THEME_BLOCKS = THEME_BLOCK_SELECTORS.length // 12
+
+/** HSL variables the toaster's `--color-*` tokens resolve through. */
+const REQUIRED_HSL_VARIABLES = [
+  '--popover',
+  '--popover-foreground',
+  '--border',
+  '--destructive',
+  '--destructive-foreground',
+  '--success',
+  '--success-foreground',
+  '--warning',
+  '--warning-foreground',
+  '--info',
+  '--info-foreground'
+] as const
+
+const css = fs.readFileSync(INDEX_CSS, 'utf8')
+
+const countDeclarations = (variable: string): number =>
+  css.split('\n').filter((line) => line.trim().startsWith(`${variable}:`)).length
+
+describe('TOAST-03: theme tokens are declared in every theme', () => {
+  it('still has exactly 12 concrete theme blocks', () => {
+    for (const selector of THEME_BLOCK_SELECTORS) {
+      const pattern = new RegExp(
+        `^\\s*${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{`,
+        'm'
+      )
+      expect(css, `${selector} block missing from index.css`).toMatch(pattern)
+    }
+
+    expect(THEME_BLOCK_SELECTORS).toHaveLength(EXPECTED_THEME_BLOCKS)
+  })
+
+  it.each(REQUIRED_HSL_VARIABLES)(
+    'declares %s in all 12 theme blocks',
+    (variable: string) => {
+      expect(countDeclarations(variable)).toBe(EXPECTED_THEME_BLOCKS)
+    }
+  )
+
+  it('exposes each toaster token as a --color-* alias', () => {
+    const aliases = [
+      '--color-popover: hsl(var(--popover))',
+      '--color-popover-foreground: hsl(var(--popover-foreground))',
+      '--color-border: hsl(var(--border))',
+      '--color-destructive: hsl(var(--destructive))',
+      '--color-destructive-foreground: hsl(var(--destructive-foreground))',
+      '--color-success: hsl(var(--success))',
+      '--color-success-foreground: hsl(var(--success-foreground))',
+      '--color-warning: hsl(var(--warning))',
+      '--color-warning-foreground: hsl(var(--warning-foreground))',
+      '--color-info: hsl(var(--info))',
+      '--color-info-foreground: hsl(var(--info-foreground))'
+    ]
+
+    for (const alias of aliases) {
+      expect(css).toContain(alias)
+    }
+  })
+})

--- a/tests/unit/components/AddVideoDialog.test.tsx
+++ b/tests/unit/components/AddVideoDialog.test.tsx
@@ -65,7 +65,7 @@ export interface UploadModeState {
   selectedFile: string | null
   uploading: boolean
   progress: number
-  message: string | null
+  message: { text: string; severity: 'info' | 'success' | 'error' } | null
   uploadSuccess: boolean
   onSelectFile: () => void
   onUploadAndAdd: () => void
@@ -302,7 +302,7 @@ describe('AddVideoDialog - URL Mode State Group', () => {
     // When fetching, button should be disabled and show no text (just spinner icon)
     const buttons = screen.getAllByRole('button')
     const fetchButton = buttons.find(
-      btn => btn.hasAttribute('disabled') && btn.closest('.flex')
+      (btn) => btn.hasAttribute('disabled') && btn.closest('.flex')
     )
     expect(fetchButton).toBeDisabled()
   })
@@ -414,7 +414,10 @@ describe('AddVideoDialog - Upload Mode State Group', () => {
   test('displays upload message when present', () => {
     const props = createDefaultProps()
     props.mode.addMode = 'upload'
-    props.uploadMode.message = 'Upload completed successfully'
+    props.uploadMode.message = {
+      text: 'Upload completed successfully',
+      severity: 'success'
+    }
 
     render(<AddVideoDialog {...props} />)
 


### PR DESCRIPTION
Closes #150 (partially — see Scope below) and closes #151.

Two defects that compound each other: an upload could fail and tell you nothing, and even when it did tell you, you couldn't see the message.

## What was wrong

**Uploads hung silently.** `upload_video` is fire-and-forget, and `upload_error` was emitted from exactly one place — a non-2xx response whose body *parsed as JSON*. But `response.json()` ran **before** the status check, so any non-2xx with an HTML or empty body (an nginx `413`, a `502`/`504` from a load balancer) failed to deserialise and exited through `?` into a bare `println!`. The one path that could report the failure was unreachable for precisely the class of failure a multi-GB upload is most likely to hit.

Confirmed in the wild — an upload stalled at 11.61% and logged:

```
Upload progress: 11.61%
Upload failed: error decoding response body: expected value at line 1 column 1
```

That is a reqwest error, so a response *arrived*; `expected value at line 1 column 1` is serde reporting the body was never JSON. This excluded the other candidates: not a wedged socket (a response came back), not a stalled source read, and not the stdout-pipe theory (the process kept printing).

**Toasts were invisible on 10 of 13 themes.** `sonner.tsx` passed the app's theme name through verbatim, so sonner stamped `data-sonner-theme="dracula"` and left `--normal-bg` undefined — its palette is only declared under its own `light`/`dark` selectors — making `background: var(--normal-bg)` invalid at computed-value time. The shadcn `group-[.toaster]:` override that should have covered this ties on specificity (0,2,0) and loses on source order, because sonner injects its stylesheet at runtime after Vite's extracted `<link>`. Over a Radix dialog's `bg-black/80` on the light custom themes, contrast reached ~1.15:1.

That override is a **dev/prod divergence** — under `vite dev` the CSS lands at a different point in head order — which is likely why this shipped.

## Two things the review caught before they shipped

**`richColors` would have reintroduced the bug.** It uses a *separate* variable family at higher specificity — `[data-rich-colors=true][data-sonner-toast][data-type=error]` is (0,3,0) and reads `--error-bg`, not `--normal-bg`. Inlining only `--normal-*` would have left every typed toast transparent again: 34 of the 50 call sites.

**Solid severity fills fail contrast in half the themes.** An audit of all 12 found six below 4.5:1 on at least one severity — Tokyo Night error at **1.78:1**, `.dark` success at **1.59:1** — because the `*-foreground` tokens are not consistently authored as on-solid pairs (in `:root` `--success-foreground` is a dark green; in `.dark` it's a pale green for text on the page background). Severity backgrounds are therefore `color-mix` tints of the popover surface with the accent as text, which is contrast-safe by construction and mirrors sonner's own palettes.

**And `THEMES.system.isDark` is hardcoded `true`** (`themes.ts:58`) while `system` is the default, so resolving through `theme` rather than `resolvedTheme` would have given every System-on-Light user a black toast on a white UI.

## Changes

**Rust** — `classify_response(status, body)` decides from the status first and parses JSON only on success, reporting the status plus a 512-char body excerpt otherwise. Also rejects a 2xx carrying `null`/`[]`/a bare string, which parsed fine but held no video record, so the upload reported success while no link appeared.

**Toaster** — resolve via `resolvedTheme`, supply 17 colour variables inline (immune to the source-order problem), enable `richColors`, drop the dead `group-[.toaster]:*` utilities.

**Upload severity** — now `UploadMessage { text, severity }` derived from *which* Tauri event fired. This kills both string-sniffing sites: `AddVideoDialog` tested `includes('failed')` and would have rendered the new `"Sprout rejected the upload: HTTP 413"` as a *neutral* alert; `UploadSprout` tested `includes('success')` and would paint `"0 successes recorded"` green. The message is also cleared on dialog close, tab change and upload start.

## Scope — #150 is not fully closed

This fixes the response-classification hole. **Transport-level failures at `sprout_upload.rs:191` still exit silently** — a genuine connection drop will still hang the dialog until the frontend's 45-minute timer. That needs the terminal-event work (UP-01/UP-07) plus the stall watchdog, keepalive, and cancellation in #150's Tier 1, which remain outstanding. `UploadMessage.reason` is the forward-compatibility slot for that.

## Verification

Frontend 4725 passed / 296 files. Rust 119 passed. ESLint and Prettier clean. Written TDD — 32 tests red first (`efc4ca4`), then green (`640f7cc`). TOAST-01 failed on exactly the 10 affected themes.

**Automated tests cannot prove the visual fix.** jsdom does not resolve `var()` or `color-mix()`, and Vitest runs without `test.css`, so the assertions pin that the right declarations are emitted, not that they compute to an opaque colour. Before merging, please check in the running app:

- [ ] A toast on Dracula shows an opaque card with a border
- [ ] A toast on a light custom theme **with the Add Video dialog open** is plainly readable — this is the ~1.15:1 case and the real acceptance gate
- [ ] Error and success toasts differ by background hue, not just icon
- [ ] **Repeat on a production build** (`bun run build:tauri`) — the dev/prod CSS-order divergence means a dev-only pass proves nothing about the shipped binary

One dependency worth flagging: `color-mix(in oklab, …)` is safe in current WKWebView but I haven't verified it against the oldest macOS you support.

Version bumped to `0.18.1` on this branch, per the master-only bump convention.
