### PR TITLE
fix(e2e): speak the current transfer protocol in Tauri mocks; revive dormant workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,21 +3,24 @@ name: E2E Tests
 on:
   pull_request:
     paths:
-      - 'src/pages/BuildProject/**'
-      - 'src/hooks/use*Progress*'
-      - 'src/hooks/useCreateProject*'
+      - 'src/features/build-project/**'
+      - 'src/features/BuildProject/**'
       - 'tests/e2e/**'
       - 'playwright.config.ts'
       - '.github/workflows/e2e-tests.yml'
   push:
     branches:
+      - master
       - release
-      - main
     paths:
-      - 'src/pages/BuildProject/**'
-      - 'src/hooks/use*Progress*'
-      - 'src/hooks/useCreateProject*'
+      - 'src/features/build-project/**'
+      - 'src/features/BuildProject/**'
       - 'tests/e2e/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/e2e-tests.yml'
+  # Manual full-suite runs from the Actions tab (the large-file job below is
+  # push/dispatch-gated, so this is the way to exercise it on a branch)
+  workflow_dispatch:
 
 jobs:
   e2e-tests:
@@ -87,7 +90,7 @@ jobs:
     runs-on: ubuntu-24.04  # Use Linux (10x cheaper than macOS)
     timeout-minutes: 90
     # Run only on push to main branches, not on every PR
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code

--- a/tests/contract/e2e-mock-protocol.contract.test.ts
+++ b/tests/contract/e2e-mock-protocol.contract.test.ts
@@ -1,0 +1,106 @@
+/**
+ * E2E Mock Protocol Contract Tests (#161)
+ *
+ * The Playwright mock layer must speak the same IPC protocol as the real
+ * Rust backend (src-tauri/src/build_project/commands.rs). In March the app
+ * moved from the legacy `move_files` / `copy_*` protocol to
+ * `transfer_files_with_progress` + `file-transfer-progress` /
+ * `file-transfer-complete` (#112), but the e2e mocks were never updated, so
+ * every mocked transfer stalled at 0% until the stall watchdog aborted it.
+ *
+ * These tests lock the mock (and the e2e specs that drive it) to the current
+ * protocol so the two can never silently diverge again:
+ *
+ * - B2.1 — the mock contains no legacy command/event names
+ * - B2.2 — the mock handles the current commands and event names
+ * - B2.3 — no e2e spec references the legacy names
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+const E2E_DIR = path.resolve(__dirname, '../e2e')
+const MOCK_FILE = path.join(E2E_DIR, 'fixtures/tauri-e2e-mocks.ts')
+
+/** Names from the protocol deleted in #112 — must never reappear */
+const LEGACY_NAMES = [
+  'move_files',
+  'cancel_copy',
+  'copy_progress',
+  'copy_complete',
+  'copy_error',
+  'copy_cancelled'
+]
+
+/** The protocol the app and Rust backend actually speak */
+const CURRENT_COMMANDS = ['transfer_files_with_progress', 'cancel_file_transfer']
+const CURRENT_EVENTS = ['file-transfer-progress', 'file-transfer-complete']
+
+/** Recursively collect .ts files under a directory */
+function collectTsFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  return entries.flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return collectTsFiles(full)
+    return entry.name.endsWith('.ts') ? [full] : []
+  })
+}
+
+describe('e2e mock protocol — B2.1 no legacy residue in the mock', () => {
+  const mockSource = fs.readFileSync(MOCK_FILE, 'utf-8')
+
+  it.each(LEGACY_NAMES)('tauri-e2e-mocks.ts does not reference `%s`', (name) => {
+    expect(
+      mockSource.includes(name),
+      `tests/e2e/fixtures/tauri-e2e-mocks.ts still references legacy name "${name}" — ` +
+        'the app no longer speaks this protocol (#112), simulate ' +
+        'transfer_files_with_progress / file-transfer-* instead'
+    ).toBe(false)
+  })
+})
+
+describe('e2e mock protocol — B2.2 mock speaks the current protocol', () => {
+  const mockSource = fs.readFileSync(MOCK_FILE, 'utf-8')
+
+  it.each(CURRENT_COMMANDS)('tauri-e2e-mocks.ts handles the `%s` command', (cmd) => {
+    expect(
+      mockSource.includes(cmd),
+      `tests/e2e/fixtures/tauri-e2e-mocks.ts has no handler for "${cmd}" — ` +
+        'unknown commands fall through to undefined and the transfer stalls'
+    ).toBe(true)
+  })
+
+  it.each(CURRENT_EVENTS)('tauri-e2e-mocks.ts emits the `%s` event', (eventName) => {
+    expect(
+      mockSource.includes(eventName),
+      `tests/e2e/fixtures/tauri-e2e-mocks.ts never emits "${eventName}" — ` +
+        'the app listens for this event (src/features/build-project/stages/fileTransfer.ts)'
+    ).toBe(true)
+  })
+})
+
+describe('e2e mock protocol — B2.3 no legacy residue in the e2e specs', () => {
+  const specFiles = collectTsFiles(E2E_DIR)
+
+  it('scans a plausible number of e2e files', () => {
+    expect(specFiles.length).toBeGreaterThan(5)
+  })
+
+  it('no e2e file references any legacy command or event name', () => {
+    const offenders: string[] = []
+    for (const file of specFiles) {
+      const content = fs.readFileSync(file, 'utf-8')
+      for (const name of LEGACY_NAMES) {
+        if (content.includes(name)) {
+          offenders.push(`${path.relative(E2E_DIR, file)} → ${name}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Legacy protocol names found in e2e files:\n${offenders.join('\n')}`
+    ).toEqual([])
+  })
+})

--- a/tests/e2e/buildproject/cancellation.spec.ts
+++ b/tests/e2e/buildproject/cancellation.spec.ts
@@ -174,8 +174,8 @@ test.describe('Transfer Cancellation - Page Navigation', () => {
     await page.waitForTimeout(500)
 
     // Check listeners before navigation
-    const progressListenersBefore = await mock.getListenerCount('copy_progress')
-    const completeListenersBefore = await mock.getListenerCount('copy_complete')
+    const progressListenersBefore = await mock.getListenerCount('file-transfer-progress')
+    const completeListenersBefore = await mock.getListenerCount('file-transfer-complete')
     expect(progressListenersBefore + completeListenersBefore).toBeGreaterThan(0)
 
     // Navigate away
@@ -385,7 +385,7 @@ test.describe('Transfer Cancellation - State Cleanup', () => {
     // Wait for listeners to be registered
     await page.waitForTimeout(500)
 
-    const listenersDuring = await mock.getListenerCount('copy_progress')
+    const listenersDuring = await mock.getListenerCount('file-transfer-progress')
     expect(listenersDuring).toBeGreaterThan(0)
 
     // Cancel

--- a/tests/e2e/buildproject/error-recovery.spec.ts
+++ b/tests/e2e/buildproject/error-recovery.spec.ts
@@ -1,8 +1,12 @@
 /**
  * Error Recovery Tests
  *
- * Validates that the application handles file operation failures gracefully.
- * Tests partial failures (some files fail), complete failures, and retry scenarios.
+ * Validates that the application surfaces file transfer failures.
+ *
+ * The native transfer backend (#112) aborts the WHOLE transfer when any file
+ * fails and reports it via a failed `file-transfer-complete` event - there is
+ * no skip-and-continue mode. The mock mirrors those semantics, so a failure
+ * part-way through must end in an error state, never a success message.
  */
 
 import { test, expect } from '@playwright/test'
@@ -11,10 +15,14 @@ import { createTauriMock } from '../fixtures/tauri-e2e-mocks'
 import { SCENARIOS, generateMockFiles } from '../utils/large-file-simulator'
 import { TEST_PROJECTS, generateFilesWithFailures } from '../fixtures/mock-file-data'
 
-test.describe('Error Recovery - Partial Failures', () => {
-  test('handles partial file failures gracefully', async ({ page }) => {
-    // Setup with failure injection: files 5-8 fail (reduced file count for speed)
-    const { files } = generateFilesWithFailures(20, 2, [5, 6, 7, 8])
+/** The constant description shown on every BuildProject error toast */
+const ERROR_TOAST_TEXT = 'Please try again or contact support if the issue persists.'
+
+test.describe('Error Recovery - Mid-Transfer Failures', () => {
+  test('aborts and surfaces an error when a file fails mid-transfer', async ({
+    page
+  }) => {
+    const { files } = generateFilesWithFailures(20, 2, [5])
 
     const mock = createTauriMock(page)
     mock
@@ -24,9 +32,8 @@ test.describe('Error Recovery - Partial Failures', () => {
       .setSpeedMultiplier(1000)
       .setMaxEventsPerFile(3)
       .injectFailure({
-        type: 'partial',
-        failingFileIndices: [5, 6, 7, 8],
-        errorMessage: 'Permission denied'
+        errorMessage: 'Permission denied',
+        failAtFileIndex: 5
       })
     await mock.setup()
 
@@ -34,40 +41,39 @@ test.describe('Error Recovery - Partial Failures', () => {
     await buildPage.goto()
     await mock.injectMocks()
 
-    await buildPage.fillProjectDetails('Partial Failure Test', 4)
+    await buildPage.fillProjectDetails('Mid-Transfer Failure Test', 4)
     await buildPage.clickSelectDestination()
     await buildPage.clickSelectFiles()
     await buildPage.clickCreateProject()
 
-    // Wait for operation to complete (should continue despite failures)
-    await buildPage.waitForCompletion(120000)
+    // The transfer aborts, so the error toast must appear...
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
 
-    // Operation should complete (remaining files succeeded)
-    await expect(buildPage.successMessage).toBeVisible()
+    // ...and the success message must never appear
+    expect(await buildPage.isComplete()).toBe(false)
 
-    // Get emitted events to verify progress continued
+    // Progress was made before the failure, but never reached 100%
     const events = await mock.getEmittedEvents()
     expect(events.length).toBeGreaterThan(0)
-
-    // Final progress should still reach 100%
-    const lastEvent = events[events.length - 1]
-    expect(lastEvent.percent).toBeGreaterThanOrEqual(99)
+    const maxPercent = Math.max(...events.map((e) => e.percent))
+    expect(maxPercent).toBeLessThan(100)
   })
 
-  test('progress continues after individual file failure', async ({ page }) => {
-    const { files } = generateFilesWithFailures(10, 2, [5]) // One file fails in middle (reduced files for speed)
+  test('progress events stop at the failure point', async ({ page }) => {
+    const failAt = 5
+    const totalFiles = 10
+    const { files } = generateFilesWithFailures(totalFiles, 2, [failAt])
 
     const mock = createTauriMock(page)
     mock
       .setScenario(SCENARIOS.SMOKE_TEST)
       .setMockFiles(files)
       .setSelectedFolder(TEST_PROJECTS.BASIC.folder)
-      .setSpeedMultiplier(1000) // Fast for CI
+      .setSpeedMultiplier(1000)
       .setMaxEventsPerFile(3)
       .injectFailure({
-        type: 'partial',
-        failingFileIndices: [5],
-        errorMessage: 'Disk full'
+        errorMessage: 'Disk full',
+        failAtFileIndex: failAt
       })
     await mock.setup()
 
@@ -75,56 +81,25 @@ test.describe('Error Recovery - Partial Failures', () => {
     await buildPage.goto()
     await mock.injectMocks()
 
-    await buildPage.fillProjectDetails('Continue After Failure', 2)
+    await buildPage.fillProjectDetails('Abort Point Test', 2)
     await buildPage.clickSelectDestination()
     await buildPage.clickSelectFiles()
     await buildPage.clickCreateProject()
 
-    // Wait for completion directly instead of monitoring progress
-    await buildPage.waitForCompletion(60000)
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
 
-    // Verify success message shown (operation completed despite partial failure)
-    await expect(buildPage.successMessage).toBeVisible()
-  })
+    // No events may come from files at or beyond the failure index
+    const events = await mock.getDetailedEvents()
+    const beyondFailure = events.filter((e) => e.fileIndex >= failAt)
+    expect(beyondFailure).toEqual([])
 
-  test('handles multiple scattered failures', async ({ page }) => {
-    // Failures at various points: beginning, middle, end
-    const failureIndices = [0, 1, 5, 10, 15, 18, 19]
-    const { files } = generateFilesWithFailures(20, 4, failureIndices)
-
-    const mock = createTauriMock(page)
-    mock
-      .setScenario(SCENARIOS.SMOKE_TEST)
-      .setMockFiles(files)
-      .setSelectedFolder(TEST_PROJECTS.PROFESSIONAL.folder)
-      .setSpeedMultiplier(500)
-      .setMaxEventsPerFile(5)
-      .injectFailure({
-        type: 'partial',
-        failingFileIndices: failureIndices,
-        errorMessage: 'File corrupted'
-      })
-    await mock.setup()
-
-    const buildPage = new BuildProjectPage(page)
-    await buildPage.goto()
-    await mock.injectMocks()
-
-    await buildPage.fillProjectDetails('Scattered Failures', 4)
-    await buildPage.clickSelectDestination()
-    await buildPage.clickSelectFiles()
-    await buildPage.clickCreateProject()
-
-    // Wait for completion
-    await buildPage.waitForCompletion(60000)
-
-    // Operation should complete despite multiple failures
-    await expect(buildPage.successMessage).toBeVisible()
+    // The mock's operation flag must be cleared (transfer ended)
+    expect(await mock.isOperationActive()).toBe(false)
   })
 })
 
 test.describe('Error Recovery - Complete Failure', () => {
-  test('handles complete operation failure', async ({ page }) => {
+  test('handles failure of the very first file (immediate abort)', async ({ page }) => {
     const mock = createTauriMock(page)
     mock
       .setScenario(SCENARIOS.SMOKE_TEST)
@@ -133,7 +108,6 @@ test.describe('Error Recovery - Complete Failure', () => {
       .setSpeedMultiplier(500)
       .setMaxEventsPerFile(5)
       .injectFailure({
-        type: 'complete',
         errorMessage: 'Destination not writable'
       })
     await mock.setup()
@@ -147,20 +121,54 @@ test.describe('Error Recovery - Complete Failure', () => {
     await buildPage.clickSelectFiles()
     await buildPage.clickCreateProject()
 
-    // Wait for error to be shown
-    await page.waitForTimeout(2000)
+    // Error surfaces without any progress having been made
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
+    expect(await buildPage.isComplete()).toBe(false)
 
-    // Success message should NOT be visible (operation failed)
-    const isComplete = await buildPage.isComplete()
-    expect(isComplete).toBe(false)
-
-    // Look for error indication (dialog, toast, or error message)
-    // The exact behavior depends on implementation
-    const errorVisible = await page.locator('text=/error|failed/i').isVisible().catch(() => false)
-    // Note: If no error UI exists, this test documents expected behavior
-    console.log('Error indicator visible:', errorVisible)
+    const events = await mock.getEmittedEvents()
+    expect(events).toEqual([])
   })
 
+  test('aborts at the last file without reporting success', async ({ page }) => {
+    const totalFiles = 10
+    const { files } = generateFilesWithFailures(totalFiles, 2, [totalFiles - 1])
+
+    const mock = createTauriMock(page)
+    mock
+      .setScenario(SCENARIOS.SMOKE_TEST)
+      .setMockFiles(files)
+      .setSelectedFolder(TEST_PROJECTS.BASIC.folder)
+      .setSpeedMultiplier(500)
+      .setMaxEventsPerFile(5)
+      .injectFailure({
+        errorMessage: 'Write failed',
+        failAtFileIndex: totalFiles - 1
+      })
+    await mock.setup()
+
+    const buildPage = new BuildProjectPage(page)
+    await buildPage.goto()
+    await mock.injectMocks()
+
+    await buildPage.fillProjectDetails('Last File Failure', 2)
+    await buildPage.clickSelectDestination()
+    await buildPage.clickSelectFiles()
+    await buildPage.clickCreateProject()
+
+    // Even 90% of the way through, a failed transfer is a failed project
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
+    expect(await buildPage.isComplete()).toBe(false)
+
+    // Progress got close to, but never reached, 100%
+    const events = await mock.getEmittedEvents()
+    expect(events.length).toBeGreaterThan(0)
+    const maxPercent = Math.max(...events.map((e) => e.percent))
+    expect(maxPercent).toBeGreaterThan(50)
+    expect(maxPercent).toBeLessThan(100)
+  })
+})
+
+test.describe('Error Recovery - User Experience', () => {
   test.skip('allows retry after complete failure', async ({ page }) => {
     const mock = createTauriMock(page)
     mock
@@ -170,7 +178,6 @@ test.describe('Error Recovery - Complete Failure', () => {
       .setSpeedMultiplier(1000)
       .setMaxEventsPerFile(3)
       .injectFailure({
-        type: 'complete',
         errorMessage: 'Destination not writable'
       })
     await mock.setup()
@@ -185,7 +192,7 @@ test.describe('Error Recovery - Complete Failure', () => {
     await buildPage.clickCreateProject()
 
     // Wait for failure
-    await page.waitForTimeout(2000)
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
 
     // Clear failure injection and reset
     mock.clearFailure()
@@ -203,156 +210,7 @@ test.describe('Error Recovery - Complete Failure', () => {
     await buildPage.waitForCompletion(60000)
     await expect(buildPage.successMessage).toBeVisible()
   })
-})
 
-test.describe('Error Recovery - Edge Cases', () => {
-  test('handles failure at first file', async ({ page }) => {
-    const { files } = generateFilesWithFailures(10, 2, [0])
-
-    const mock = createTauriMock(page)
-    mock
-      .setScenario(SCENARIOS.SMOKE_TEST)
-      .setMockFiles(files)
-      .setSelectedFolder(TEST_PROJECTS.BASIC.folder)
-      .setSpeedMultiplier(500)
-      .setMaxEventsPerFile(5)
-      .injectFailure({
-        type: 'partial',
-        failingFileIndices: [0],
-        errorMessage: 'Access denied'
-      })
-    await mock.setup()
-
-    const buildPage = new BuildProjectPage(page)
-    await buildPage.goto()
-    await mock.injectMocks()
-
-    await buildPage.fillProjectDetails('First File Failure', 2)
-    await buildPage.clickSelectDestination()
-    await buildPage.clickSelectFiles()
-    await buildPage.clickCreateProject()
-
-    // Should complete (remaining files succeed)
-    await buildPage.waitForCompletion(30000)
-    await expect(buildPage.successMessage).toBeVisible()
-  })
-
-  test('handles failure at last file', async ({ page }) => {
-    const { files } = generateFilesWithFailures(10, 2, [9]) // Last file
-
-    const mock = createTauriMock(page)
-    mock
-      .setScenario(SCENARIOS.SMOKE_TEST)
-      .setMockFiles(files)
-      .setSelectedFolder(TEST_PROJECTS.BASIC.folder)
-      .setSpeedMultiplier(500)
-      .setMaxEventsPerFile(5)
-      .injectFailure({
-        type: 'partial',
-        failingFileIndices: [9],
-        errorMessage: 'Write failed'
-      })
-    await mock.setup()
-
-    const buildPage = new BuildProjectPage(page)
-    await buildPage.goto()
-    await mock.injectMocks()
-
-    await buildPage.fillProjectDetails('Last File Failure', 2)
-    await buildPage.clickSelectDestination()
-    await buildPage.clickSelectFiles()
-    await buildPage.clickCreateProject()
-
-    // Should complete (previous files succeeded)
-    await buildPage.waitForCompletion(30000)
-    await expect(buildPage.successMessage).toBeVisible()
-  })
-
-  test('handles all files failing except one', async ({ page }) => {
-    // All files fail except the last one
-    const failureIndices = Array.from({ length: 9 }, (_, i) => i) // [0,1,2,3,4,5,6,7,8]
-    const { files } = generateFilesWithFailures(10, 2, failureIndices)
-
-    const mock = createTauriMock(page)
-    mock
-      .setScenario(SCENARIOS.SMOKE_TEST)
-      .setMockFiles(files)
-      .setSelectedFolder(TEST_PROJECTS.BASIC.folder)
-      .setSpeedMultiplier(500)
-      .setMaxEventsPerFile(5)
-      .injectFailure({
-        type: 'partial',
-        failingFileIndices: failureIndices,
-        errorMessage: 'Various errors'
-      })
-    await mock.setup()
-
-    const buildPage = new BuildProjectPage(page)
-    await buildPage.goto()
-    await mock.injectMocks()
-
-    await buildPage.fillProjectDetails('Almost All Fail', 2)
-    await buildPage.clickSelectDestination()
-    await buildPage.clickSelectFiles()
-    await buildPage.clickCreateProject()
-
-    // Should still complete (one file succeeded)
-    await buildPage.waitForCompletion(30000)
-    await expect(buildPage.successMessage).toBeVisible()
-  })
-
-  test('maintains progress state after transient error', async ({ page }) => {
-    // Simulates a scenario where an error occurs but doesn't stop the operation
-    const { files } = generateFilesWithFailures(10, 2, [3, 4, 5])
-
-    const mock = createTauriMock(page)
-    mock
-      .setScenario(SCENARIOS.SMOKE_TEST)
-      .setMockFiles(files)
-      .setSelectedFolder(TEST_PROJECTS.PROFESSIONAL.folder)
-      .setSpeedMultiplier(1000)
-      .setMaxEventsPerFile(3)
-      .injectFailure({
-        type: 'partial',
-        failingFileIndices: [3, 4, 5],
-        errorMessage: 'Transient error'
-      })
-    await mock.setup()
-
-    const buildPage = new BuildProjectPage(page)
-    await buildPage.goto()
-    await mock.injectMocks()
-
-    await buildPage.fillProjectDetails('Transient Error Test', 2)
-    await buildPage.clickSelectDestination()
-    await buildPage.clickSelectFiles()
-    await buildPage.clickCreateProject()
-
-    // Wait for completion
-    await buildPage.waitForCompletion(60000)
-
-    // Get emitted events after completion
-    const events = await mock.getEmittedEvents()
-
-    // Categorize events
-    const progressBefore = events.filter((e) => e.fileIndex < 3).map((e) => e.percent)
-    const progressAfter = events.filter((e) => e.fileIndex > 5).map((e) => e.percent)
-
-    // Progress should continue after errors
-    expect(progressAfter.length).toBeGreaterThan(0)
-
-    // Progress after errors should be higher than before
-    if (progressBefore.length > 0 && progressAfter.length > 0) {
-      const maxBefore = Math.max(...progressBefore)
-      const minAfter = Math.min(...progressAfter)
-      expect(minAfter).toBeGreaterThan(maxBefore)
-    }
-
-    await expect(buildPage.successMessage).toBeVisible()
-  })
-})
-
-test.describe('Error Recovery - User Experience', () => {
   test.skip('user can clear and start new project after failure', async ({ page }) => {
     const mock = createTauriMock(page)
     mock
@@ -362,7 +220,6 @@ test.describe('Error Recovery - User Experience', () => {
       .setSpeedMultiplier(1000)
       .setMaxEventsPerFile(3)
       .injectFailure({
-        type: 'complete',
         errorMessage: 'Operation failed'
       })
     await mock.setup()
@@ -376,7 +233,7 @@ test.describe('Error Recovery - User Experience', () => {
     await buildPage.clickSelectDestination()
     await buildPage.clickSelectFiles()
     await buildPage.clickCreateProject()
-    await page.waitForTimeout(2000)
+    await expect(page.getByText(ERROR_TOAST_TEXT)).toBeVisible({ timeout: 30000 })
 
     // Clear everything
     await buildPage.clickClearAll()

--- a/tests/e2e/buildproject/external-drive.spec.ts
+++ b/tests/e2e/buildproject/external-drive.spec.ts
@@ -281,9 +281,8 @@ test.describe('External Drive - Error Handling', () => {
       .setSpeedMultiplier(500)
       .setMaxEventsPerFile(5)
       .injectFailure({
-        type: 'partial',
-        failingFileIndices: [3, 4, 5], // Simulate failure at specific files
-        errorMessage: 'Drive disconnected'
+        errorMessage: 'Drive disconnected',
+        failAtFileIndex: 3 // Simulate the drive vanishing mid-transfer
       })
     await mock.setup()
 
@@ -296,14 +295,17 @@ test.describe('External Drive - Error Handling', () => {
     await buildPage.clickSelectFiles()
     await buildPage.clickCreateProject()
 
-    // Operation should still complete (partial failure skips files)
-    await buildPage.waitForCompletion(60000)
+    // A disconnected drive aborts the transfer - the error toast appears
+    // and the operation never reports success
+    await expect(
+      page.getByText('Please try again or contact support if the issue persists.')
+    ).toBeVisible({ timeout: 30000 })
 
-    // Get events to verify some files were processed
+    // Some files were processed before the disconnection
     const events = await mock.getDetailedEvents()
     expect(events.length).toBeGreaterThan(0)
 
-    await expect(buildPage.successMessage).toBeVisible()
+    expect(await buildPage.isComplete()).toBe(false)
   })
 
   test('handles complete drive failure gracefully', async ({ page }) => {
@@ -316,7 +318,6 @@ test.describe('External Drive - Error Handling', () => {
       .setSpeedMultiplier(500)
       .setMaxEventsPerFile(5)
       .injectFailure({
-        type: 'complete',
         errorMessage: 'Drive not found: /Volumes/Production'
       })
     await mock.setup()
@@ -334,7 +335,7 @@ test.describe('External Drive - Error Handling', () => {
     await page.waitForTimeout(2000)
 
     // Operation should have failed - no success message
-    // (The mock emits copy_error event which the frontend should handle)
+    // (The mock emits a failed file-transfer-complete event which the frontend handles)
     const isOperationActive = await mock.isOperationActive()
     expect(isOperationActive).toBe(false)
   })

--- a/tests/e2e/buildproject/memory-stability.spec.ts
+++ b/tests/e2e/buildproject/memory-stability.spec.ts
@@ -141,8 +141,8 @@ test.describe('Memory Stability - Long Running Operations', () => {
     await mock.injectMocks()
 
     // Check initial listener count
-    const initialProgressListeners = await mock.getListenerCount('copy_progress')
-    const initialCompleteListeners = await mock.getListenerCount('copy_complete')
+    const initialProgressListeners = await mock.getListenerCount('file-transfer-progress')
+    const initialCompleteListeners = await mock.getListenerCount('file-transfer-complete')
 
     await buildPage.fillProjectDetails('Cleanup Test', 2)
     await buildPage.clickSelectDestination()
@@ -151,8 +151,8 @@ test.describe('Memory Stability - Long Running Operations', () => {
 
     // During operation, listeners should exist
     await page.waitForTimeout(500)
-    const duringProgressListeners = await mock.getListenerCount('copy_progress')
-    const duringCompleteListeners = await mock.getListenerCount('copy_complete')
+    const duringProgressListeners = await mock.getListenerCount('file-transfer-progress')
+    const duringCompleteListeners = await mock.getListenerCount('file-transfer-complete')
 
     // At least one listener should be registered during operation
     expect(duringProgressListeners + duringCompleteListeners).toBeGreaterThan(0)
@@ -166,8 +166,8 @@ test.describe('Memory Stability - Long Running Operations', () => {
     // After completion, listeners should be cleaned up
     // Note: The exact behavior depends on useCopyProgress implementation
     // Some implementations may keep listeners but stop processing
-    const finalProgressListeners = await mock.getListenerCount('copy_progress')
-    const finalCompleteListeners = await mock.getListenerCount('copy_complete')
+    const finalProgressListeners = await mock.getListenerCount('file-transfer-progress')
+    const finalCompleteListeners = await mock.getListenerCount('file-transfer-complete')
 
     console.log('Listener counts:', {
       initial: { progress: initialProgressListeners, complete: initialCompleteListeners },

--- a/tests/e2e/fixtures/tauri-e2e-mocks.ts
+++ b/tests/e2e/fixtures/tauri-e2e-mocks.ts
@@ -10,9 +10,14 @@ import type { Page } from '@playwright/test'
 import type { SimulatedFileSet, MockFile } from '../utils/large-file-simulator'
 
 export interface FailureInjection {
-  type: 'partial' | 'complete'
-  failingFileIndices?: number[]
+  /** Error message carried on the failed `file-transfer-complete` event */
   errorMessage: string
+  /**
+   * File index at which the transfer aborts (default 0 — fail immediately).
+   * Mirrors the real backend: any file error aborts the whole transfer;
+   * there is no skip-and-continue mode.
+   */
+  failAtFileIndex?: number
 }
 
 export interface TauriMockConfig {
@@ -152,6 +157,7 @@ export class TauriE2EMock {
         __E2E_EVENTS__: Array<{ percent: number; fileIndex: number; fileProgress?: number }>
         __E2E_LISTENERS__: Map<string, Map<number, EventCallback>>
         __E2E_NEXT_EVENT_ID__: number
+        __E2E_NEXT_OPERATION_ID__: number
         __E2E_CALLBACKS__: Record<number, (response: unknown) => void>
         __E2E_CANCELLED__: boolean
         __E2E_OPERATION_IN_PROGRESS__: boolean
@@ -169,6 +175,7 @@ export class TauriE2EMock {
       win.__E2E_EVENTS__ = []
       win.__E2E_LISTENERS__ = new Map()
       win.__E2E_NEXT_EVENT_ID__ = 1
+      win.__E2E_NEXT_OPERATION_ID__ = 1
       win.__E2E_CANCELLED__ = false
       win.__E2E_OPERATION_IN_PROGRESS__ = false
 
@@ -260,22 +267,38 @@ export class TauriE2EMock {
             return
           }
 
-          // Handle cancel_copy command
-          if (cmd === 'cancel_copy') {
-            console.log('[E2E Mock] Cancelling copy operation')
+          // Handle cancel_file_transfer (mirrors src-tauri/src/build_project/commands.rs:
+          // returns a boolean; the running transfer notices the flag and emits a
+          // cancelled `file-transfer-complete` event)
+          if (cmd === 'cancel_file_transfer') {
+            console.log('[E2E Mock] Cancelling file transfer:', args?.operationId)
             win.__E2E_CANCELLED__ = true
-            return { success: true }
+            return true
           }
 
-          // Handle move_files with intra-file progress simulation
-          if (cmd === 'move_files') {
-            console.log('[E2E Mock] Mocking move_files')
+          // Handle transfer_files_with_progress with intra-file progress simulation.
+          // Mirrors the real backend: returns an operation ID immediately, then runs
+          // the transfer in the background emitting `file-transfer-progress` events
+          // and exactly one `file-transfer-complete` event (success, failure or
+          // cancellation). Any file error aborts the whole transfer.
+          if (cmd === 'transfer_files_with_progress') {
+            const request = args?.request as
+              | { files: Array<{ source: string; destination: string }> }
+              | undefined
+            const requestFiles = request?.files ?? []
+            const operationId = `e2e-op-${win.__E2E_NEXT_OPERATION_ID__++}`
+            console.log(
+              '[E2E Mock] Mocking transfer_files_with_progress:',
+              operationId,
+              requestFiles.length,
+              'files'
+            )
 
             // Reset cancellation flag
             win.__E2E_CANCELLED__ = false
             win.__E2E_OPERATION_IN_PROGRESS__ = true
 
-            const totalFiles = cfg.mockFiles.length || 10
+            const totalFiles = requestFiles.length || cfg.mockFiles.length || 10
             const enableIntraFile = cfg.enableIntraFileProgress !== false
             const maxEventsPerFile = cfg.maxEventsPerFile || 100
             const BUFFER_SIZE = 8192 // 8KB - matches Rust backend
@@ -283,8 +306,11 @@ export class TauriE2EMock {
             // Calculate base interval (adjusted by speed multiplier)
             const baseIntervalMs = Math.max(1, cfg.scenario.progressIntervalMs / cfg.speedMultiplier)
 
+            const baseName = (p: string) => p.split('/').pop() || p
+
             setTimeout(async () => {
-              console.log('[E2E Mock] Starting file copy simulation', {
+              console.log('[E2E Mock] Starting file transfer simulation', {
+                operationId,
                 totalFiles,
                 enableIntraFile,
                 maxEventsPerFile,
@@ -292,50 +318,80 @@ export class TauriE2EMock {
                 speedMultiplier: cfg.speedMultiplier
               })
 
-              const movedFiles: string[] = []
+              const startedAt = Date.now()
+              let filesTransferred = 0
+
+              const emitComplete = (success: boolean, error: string | null) => {
+                emitEvent('file-transfer-complete', {
+                  operationId,
+                  success,
+                  filesTransferred,
+                  error
+                })
+                win.__E2E_OPERATION_IN_PROGRESS__ = false
+              }
+
+              const emitProgress = (
+                currentFile: string,
+                bytesTransferred: number,
+                totalBytes: number,
+                percentage: number
+              ) => {
+                const elapsedMs = Math.max(1, Date.now() - startedAt)
+                const bytesPerSecond = Math.round((bytesTransferred / elapsedMs) * 1000)
+                const estimatedTimeRemaining =
+                  percentage > 0
+                    ? Math.round((elapsedMs / percentage) * (100 - percentage))
+                    : 0
+                emitEvent('file-transfer-progress', {
+                  operationId,
+                  currentFile,
+                  filesCompleted: filesTransferred,
+                  totalFiles,
+                  bytesTransferred,
+                  totalBytes,
+                  percentage,
+                  bytesPerSecond,
+                  estimatedTimeRemaining
+                })
+              }
 
               for (let fileIndex = 0; fileIndex < totalFiles; fileIndex++) {
                 // Check for cancellation
                 if (win.__E2E_CANCELLED__) {
-                  console.log('[E2E Mock] Operation cancelled at file', fileIndex)
-                  emitEvent('copy_cancelled', { filesCompleted: fileIndex, movedFiles })
-                  win.__E2E_OPERATION_IN_PROGRESS__ = false
+                  console.log('[E2E Mock] Transfer cancelled at file', fileIndex)
+                  emitComplete(false, 'Transfer cancelled by user')
                   return
                 }
 
-                // Check for failure injection
-                if (cfg.failureInjection?.type === 'complete') {
-                  console.log('[E2E Mock] Complete failure injected')
-                  emitEvent('copy_error', { error: cfg.failureInjection.errorMessage })
-                  win.__E2E_OPERATION_IN_PROGRESS__ = false
-                  return
-                }
-
+                // Check for failure injection - like the real backend, a file
+                // error aborts the whole transfer with a failed complete event
                 if (
-                  cfg.failureInjection?.type === 'partial' &&
-                  cfg.failureInjection.failingFileIndices?.includes(fileIndex)
+                  cfg.failureInjection &&
+                  fileIndex >= (cfg.failureInjection.failAtFileIndex ?? 0)
                 ) {
-                  console.log('[E2E Mock] Partial failure at file', fileIndex)
-                  // Skip this file but continue
-                  continue
+                  console.log('[E2E Mock] Failure injected at file', fileIndex)
+                  emitComplete(false, cfg.failureInjection.errorMessage)
+                  return
                 }
 
                 const mockFile = cfg.mockFiles[fileIndex]
                 const fileSize = mockFile?.simulatedSize || cfg.scenario.averageFileSize
+                const currentFile = baseName(
+                  requestFiles[fileIndex]?.source || mockFile?.file.path || `file_${fileIndex}`
+                )
 
                 if (enableIntraFile) {
                   // Intra-file progress: emit events as if reading 8KB chunks
                   // Cap the number of events per file for performance
                   const theoreticalChunks = Math.ceil(fileSize / BUFFER_SIZE)
                   const eventsPerFile = Math.min(maxEventsPerFile, theoreticalChunks)
-                  // Note: bytesPerEvent = fileSize / eventsPerFile (used for simulation timing)
 
                   for (let chunk = 0; chunk < eventsPerFile; chunk++) {
                     // Check for cancellation within file
                     if (win.__E2E_CANCELLED__) {
-                      console.log('[E2E Mock] Operation cancelled during file', fileIndex)
-                      emitEvent('copy_cancelled', { filesCompleted: fileIndex, movedFiles })
-                      win.__E2E_OPERATION_IN_PROGRESS__ = false
+                      console.log('[E2E Mock] Transfer cancelled during file', fileIndex)
+                      emitComplete(false, 'Transfer cancelled by user')
                       return
                     }
 
@@ -349,7 +405,12 @@ export class TauriE2EMock {
                       fileIndex,
                       fileProgress
                     })
-                    emitEvent('copy_progress', overallProgress)
+                    emitProgress(
+                      currentFile,
+                      Math.round(fileSize * fileProgress),
+                      fileSize,
+                      overallProgress
+                    )
 
                     // Only wait between chunks, not after the last one
                     if (chunk < eventsPerFile - 1) {
@@ -357,13 +418,13 @@ export class TauriE2EMock {
                     }
                   }
                 } else {
-                  // Legacy mode: one event per file (for backward compatibility)
+                  // One event per file
                   const percent = ((fileIndex + 1) / totalFiles) * 100
                   win.__E2E_EVENTS__.push({ percent, fileIndex })
-                  emitEvent('copy_progress', percent)
+                  emitProgress(currentFile, fileSize, fileSize, percent)
                 }
 
-                movedFiles.push(mockFile?.file.path || `file_${fileIndex}`)
+                filesTransferred++
 
                 // Small delay between files
                 if (fileIndex < totalFiles - 1) {
@@ -371,15 +432,19 @@ export class TauriE2EMock {
                 }
               }
 
-              // Ensure we emit exactly 100% at the end
+              // Ensure we emit exactly 100% at the end, then the success event
               win.__E2E_EVENTS__.push({ percent: 100, fileIndex: totalFiles - 1 })
-              emitEvent('copy_progress', 100)
-              emitEvent('copy_complete', movedFiles)
-              win.__E2E_OPERATION_IN_PROGRESS__ = false
-              console.log('[E2E Mock] move_files complete, files moved:', movedFiles.length)
+              emitProgress('', 0, 0, 100)
+              emitComplete(true, null)
+              console.log(
+                '[E2E Mock] Transfer complete:',
+                operationId,
+                'files transferred:',
+                filesTransferred
+              )
             }, 10)
 
-            return { success: true }
+            return operationId
           }
 
           // Handle other commands


### PR DESCRIPTION
Closes #161

The e2e Tauri mock layer still simulated the `move_files` / `copy_*` protocol deleted from the app in #112, so every mocked file transfer stalled at 0% until the 30-second watchdog aborted it - and the E2E Tests workflow had been dormant since 26 March because its path filters referenced the pre-restructure layout and its push trigger watched `main` instead of `master`. First surfaced by PR #159, which touched `tests/e2e/**` and woke the suite against four months of drift.

## B1 - Mock speaks the current transfer protocol
`tests/e2e/fixtures/tauri-e2e-mocks.ts` now handles `transfer_files_with_progress` (returns an operation ID immediately, emits `file-transfer-progress` events with the full `FileTransferProgress` payload, always finishes with exactly one `file-transfer-complete` `{operationId, success, filesTransferred, error}`) and `cancel_file_transfer` (returns `true`; the running simulation notices and completes with `"Transfer cancelled by user"`) - mirroring `src-tauri/src/build_project/commands.rs`. Simulation knobs (scenario, speed multiplier, intra-file progress, max events per file, `__E2E_EVENTS__` capture) are preserved. Failure injection is now `{errorMessage, failAtFileIndex?}` and aborts the transfer like the real backend; the legacy skip-and-continue `partial` mode is gone because the app never had that behaviour.

## B2 - No legacy protocol residue (red → green)
New contract test `tests/contract/e2e-mock-protocol.contract.test.ts` locks the mock and all e2e files to the current protocol, in the style of the existing `build-project` no-legacy contracts. Committed red first (11 failed / 1 passed against the old mock, commit `1b0ee4a` "test: add failing e2e mock protocol contract tests"), green after the rewrite (12/12).

## B3 - Spec drift repair
- `error-recovery.spec.ts`: rewritten to abort-on-failure semantics - failures now assert the error toast ("Please try again or contact support…"), the absence of the success message, and that progress events stop at the failure index. The two retry-after-failure tests remain `test.skip` as before (the mock's config is captured at `addInitScript` time, so `clearFailure()` mid-test cannot take effect - same limitation that got them skipped originally).
- `external-drive.spec.ts`: drive-disconnection test now expects an aborted transfer instead of silent skip-and-continue.
- `cancellation.spec.ts` / `memory-stability.spec.ts`: listener-count assertions renamed to `file-transfer-progress` / `file-transfer-complete`.
- No genuine app bugs surfaced - no `test.fixme` quarantines were needed.

## B4 - Workflow can no longer rot silently
`.github/workflows/e2e-tests.yml`: PR/push path filters now point at `src/features/build-project/**` and `src/features/BuildProject/**`; push watches `master` and `release`; `workflow_dispatch` added (and the large-file job accepts it) so the full suite can be fired manually from the Actions tab.

## Testing evidence

| Suite | Result |
|---|---|
| Contract test (red, against old mock) | 11 failed / 1 passed |
| Contract test (green) | 12 passed |
| Playwright `smoke` (the CI failure on #159) | 9 passed |
| Playwright `progress` + `memory` + `errors` | 13 passed, 5 skipped (pre-existing skips + the 2 retry skips) |
| Playwright `cancellation` + `long-operations` | 23 passed |
| Playwright `large-files` (E2E_SPEED_MULTIPLIER=100) | 20 passed |
| Full vitest suite | 299 files, 4752 tests passed |
| eslint | 0 errors (17 pre-existing warnings in `src/shared/ui`) |

## Notes for review
- The push-gated projects (`cancellation`, `long-operations`, `large-files`) get their first CI proof on merge to master; until then the local totals above are the evidence. `workflow_dispatch` is available if you want a CI run on this branch first.
- The mock's ETA/speed fields are rough simulations (linear extrapolation from elapsed time); nothing in the specs asserts on them.
- `tests/e2e/specs/*.spec.ts` (baker-workflow, example-management, smoke) are matched by no Playwright project, and the `debug` project matches no file - pre-existing, left untouched per the issue's out-of-scope list.
- After merge: update #159 from master so its E2E check reruns green.
