### PR TITLE
fix(posterframe): report a background folder that cannot be read

### DIFF
--- a/docs/posterframe-background-verification.md
+++ b/docs/posterframe-background-verification.md
@@ -35,8 +35,8 @@ Run this checklist against a real build before releasing a change that touches
 5. **Expect not** "The background folder contains no image files", and not
    "No default background folder configured".
 6. Settings > Backgrounds.
-7. **Expect** the path still printed, now with "This folder no longer exists on
-   this machine", and the stored value unchanged.
+7. **Expect** the path still printed, now with "Bucket cannot read this folder",
+   and the stored value unchanged.
 
 ## 3. Session recovery leaves the default alone
 

--- a/docs/posterframe-background-verification.md
+++ b/docs/posterframe-background-verification.md
@@ -1,0 +1,103 @@
+# Poster frame background folder: manual verification
+
+Issue #166. The automated coverage for this fix mocks Tauri IPC, so it proves the
+UI wiring and the state transitions but not the filesystem behaviour underneath.
+Specifically, it cannot prove that:
+
+- Tauri's `readDir` rejects with `os error 2` for a directory that is not there,
+  which is what `exists() === false` stands in for in the fixture.
+- A macOS TCC permission denial on a protected directory (`~/Documents`,
+  `~/Desktop`, an external volume) surfaces as a rejection rather than an empty
+  listing. This is the case that originally hid behind "contains no image files".
+- A genuinely malformed `api_keys.json` reaches `JSON.parse` and rethrows, rather
+  than being caught earlier.
+
+Run this checklist against a real build before releasing a change that touches
+`listDirectory`, `useBackgroundFolder`, `BackgroundsSection`, `SettingsPage` or
+`storage.ts`.
+
+## 1. Baseline: a folder that works
+
+1. Settings > Backgrounds > Choose Folder, pick a folder containing at least one
+   `.jpg` or `.png`. Save.
+2. Expect the path printed with no warning beside it.
+3. Upload content > Posterframe.
+4. **Expect** the folder path shown, the background dropdown populated, and no
+   warning.
+
+## 2. The reported bug: folder no longer on disk
+
+1. With the above still configured, quit Bucket.
+2. Rename or move the folder in Finder.
+3. Reopen Bucket, go to Posterframe.
+4. **Expect** `Cannot read background folder: <path>`, the path named in full,
+   and the "Select Background Folder" button still usable.
+5. **Expect not** "The background folder contains no image files", and not
+   "No default background folder configured".
+6. Settings > Backgrounds.
+7. **Expect** the path still printed, now with "This folder no longer exists on
+   this machine", and the stored value unchanged.
+
+## 3. Session recovery leaves the default alone
+
+1. From the warning state in step 2, click "Select Background Folder" and pick a
+   folder that does have images.
+2. **Expect** the dropdown populates, the chosen folder is labelled as the
+   session folder, the configured default is still shown, and a "Use default"
+   control appears.
+3. Click "Use default".
+4. **Expect** the warning returns, because the default is still the dead path.
+5. Settings > Backgrounds.
+6. **Expect** the original stored path, unchanged. Nothing on the Posterframe
+   page may write to `api_keys.json`.
+
+## 4. Permission denial, not absence
+
+This is the case that mocks cannot model. Do not skip it.
+
+1. Point the default background folder at a folder inside `~/Documents`.
+2. Confirm it works.
+3. System Settings > Privacy & Security > Files and Folders, revoke Bucket's
+   access to Documents (or remove Bucket from Full Disk Access if that is how it
+   was granted). Quit and reopen Bucket.
+4. Posterframe.
+5. **Expect** `Cannot read background folder: <path>`. The wording is
+   deliberately true for both absence and denial, so it should read correctly
+   here without claiming the folder is missing.
+6. Check the log for the underlying detail (`os error 13` or similar).
+   **Expect** the detail in the log only, never on screen.
+7. Restore the permission afterwards.
+
+## 5. Folder present but holding no images
+
+1. Point the default at a folder containing only non-image files.
+2. Posterframe.
+3. **Expect** "The background folder contains no image files", and **not** the
+   cannot-read message.
+
+## 6. Unreadable settings file
+
+1. Quit Bucket.
+2. Corrupt the settings file: open
+   `~/Library/Application Support/com.bucket-app.devapi_keys.json` and delete a
+   closing brace so it no longer parses. Keep a backup first.
+   (The path looks wrong because it is: see issue #167.)
+3. Reopen Bucket, go to Settings.
+4. **Expect** the banner "Could not read your saved settings", every section
+   still rendered, and **every Save button disabled**. This last point matters:
+   a Save here would overwrite the file with a single field and destroy the
+   Sprout key and Trello token that are still sitting in it.
+5. Posterframe.
+6. **Expect** "Could not read your settings, so the background folder is
+   unknown", and **not** "No default background folder configured". Those two
+   screens must agree about what went wrong.
+7. Restore the backup and confirm normal operation returns.
+
+## 7. First run
+
+1. Quit Bucket, move `api_keys.json` aside entirely.
+2. Reopen Bucket, go to Settings.
+3. **Expect** no banner and Save enabled. An absent file is a first run, not a
+   failure.
+4. Posterframe.
+5. **Expect** "No default background folder configured. Set one in Settings."

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:buildproject": "playwright test tests/e2e/buildproject/",
     "test:e2e:sprout": "playwright test --project=sprout-folders",
+    "test:e2e:posterframe": "playwright test --project=posterframe-backgrounds",
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:report": "playwright show-report playwright-report",
     "version:patch": "node scripts/bump-version.js patch",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,6 +77,13 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] }
     },
     {
+      // Every project here uses an explicit testMatch, so a spec that matches
+      // none of them never runs at all. Issue #166.
+      name: 'posterframe-backgrounds',
+      testMatch: /posterframe-backgrounds\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
       name: 'long-operations',
       testMatch: /long-operation-states\.spec\.ts/,
       use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,14 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] }
     },
     {
+      // Walks Baker to reach the poster frame dialogs. Scan completion arrives
+      // via useBakerScan's 2s status poll, so these are slower than the
+      // folder-only specs. Issue #166.
+      name: 'posterframe-baker',
+      testMatch: /posterframe-baker-journey\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
       name: 'long-operations',
       testMatch: /long-operation-states\.spec\.ts/,
       use: {

--- a/src/features/Baker/components/SetPosterFrameDialog.test.tsx
+++ b/src/features/Baker/components/SetPosterFrameDialog.test.tsx
@@ -180,6 +180,49 @@ describe('SetPosterFrameDialog - unavailable configuration', () => {
     expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
   })
 
+  // Issue #166 B6.1. The b4_* cases above predate the cannot-read state, so
+  // without this the dialog had no test proving it renders the new reason: the
+  // one a user actually hits when a configured folder stops resolving.
+  it('b6_1_explains_a_background_folder_it_cannot_read_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason:
+              'Cannot read background folder: /Users/me/Documents/backgrounds',
+            backgrounds: []
+          })
+        })}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        /Cannot read background folder: \/Users\/me\/Documents\/backgrounds/i
+      )
+    ).toBeInTheDocument()
+    // Must not regress to blaming an empty folder for one that is not there.
+    expect(screen.queryByText(/no image files/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
+  it('b6_3_explains_a_font_check_that_could_not_run_and_disables_the_action', () => {
+    render(
+      <SetPosterFrameDialog
+        {...baseProps({
+          posterFrame: panelState({
+            unavailableReason:
+              'Could not check whether the poster frame font is installed.'
+          })
+        })}
+      />
+    )
+
+    expect(screen.getByText(/could not check whether/i)).toBeInTheDocument()
+    expect(screen.queryByText(/requires Cabrito/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^set poster frame$/i })).toBeDisabled()
+  })
+
   it('b4_2_explains_a_folder_with_no_images_and_disables_the_action', () => {
     render(
       <SetPosterFrameDialog

--- a/src/features/Settings/__contracts__/settings.contract.test.ts
+++ b/src/features/Settings/__contracts__/settings.contract.test.ts
@@ -104,7 +104,13 @@ vi.mock('@shared/constants/timing', async (importOriginal) => {
 vi.mock('@shared/lib/query-keys', () => ({
   queryKeys: {
     settings: {
-      apiKeys: () => ['settings', 'api-keys']
+      apiKeys: () => ['settings', 'api-keys'],
+      // BackgroundsSection checks the saved folder is still on disk (issue #166).
+      backgroundFolderPresent: (folderPath: string | null) => [
+        'settings',
+        'background-folder-present',
+        folderPath ?? 'none'
+      ]
     },
     // SproutVideoSection now renders the default-folder picker (issue #155).
     sprout: {

--- a/src/features/Settings/api.ts
+++ b/src/features/Settings/api.ts
@@ -5,6 +5,7 @@
  * are wrapped here. Mock this one file to isolate the entire module.
  */
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
+import { exists } from '@tauri-apps/plugin-fs'
 import { open as openShell } from '@tauri-apps/plugin-shell'
 
 import { providerRegistry } from '@shared/services/ai/providerConfig'
@@ -20,6 +21,24 @@ export type { ApiKeys } from '@shared/utils'
 export async function openFolderPicker(): Promise<string | null> {
   const result = await openDialog({ directory: true, multiple: false })
   return typeof result === 'string' ? result : null
+}
+
+// --- Filesystem ---
+
+/**
+ * Whether a saved directory is still present (issue #166).
+ *
+ * Settings printed stored paths verbatim, so a folder that had been moved or
+ * deleted was presented as valid configuration. A failed probe reports false:
+ * from the user's point of view a folder that cannot be checked is not one they
+ * should be told is fine.
+ */
+export async function directoryExists(path: string): Promise<boolean> {
+  try {
+    return await exists(path)
+  } catch {
+    return false
+  }
 }
 
 // --- Shell ---

--- a/src/features/Settings/components/AIModelsSection.tsx
+++ b/src/features/Settings/components/AIModelsSection.tsx
@@ -20,9 +20,18 @@ import type { ConnectionStatus } from '../types'
 
 interface AIModelsSectionProps {
   apiKeys: ApiKeys
+  /**
+   * The settings file could not be read, so `apiKeys` is the empty fallback.
+   * Saving is blocked while this holds, or one save would overwrite a merely
+   * unparseable file and destroy the credentials still in it (#166 B8.4).
+   */
+  settingsUnavailable?: boolean
 }
 
-const AIModelsSection: React.FC<AIModelsSectionProps> = ({ apiKeys }) => {
+const AIModelsSection: React.FC<AIModelsSectionProps> = ({
+  apiKeys,
+  settingsUnavailable = false
+}) => {
   const queryClient = useQueryClient()
   const ollamaUrl = useAppStore((state) => state.ollamaUrl)
   const setOllamaUrl = useAppStore((state) => state.setOllamaUrl)
@@ -108,6 +117,7 @@ const AIModelsSection: React.FC<AIModelsSectionProps> = ({ apiKeys }) => {
         </label>
         <div className="space-y-2">
           <ApiKeyInput
+            saveDisabled={settingsUnavailable}
             id="ollama-url-input"
             apiKey={ollamaUrl || 'http://localhost:11434'}
             setApiKey={handleOllamaUrlChange}

--- a/src/features/Settings/components/BackgroundsSection.test.tsx
+++ b/src/features/Settings/components/BackgroundsSection.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for BackgroundsSection - flagging a saved folder that no longer exists.
+ * Tests for BackgroundsSection - flagging a saved folder that cannot be read.
  * Issue #166 (B7.1-B7.4)
  *
  * Settings is the one screen a user checks to answer "is this configured?".
@@ -51,7 +51,7 @@ describe('BackgroundsSection - dead path warning (#166)', () => {
 
     expect(await screen.findByText(FOLDER)).toBeInTheDocument()
     await waitFor(() =>
-      expect(screen.queryByText(/no longer exists/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/cannot read this folder/i)).not.toBeInTheDocument()
     )
   })
 
@@ -61,9 +61,7 @@ describe('BackgroundsSection - dead path warning (#166)', () => {
     renderSection()
 
     expect(await screen.findByText(FOLDER)).toBeInTheDocument()
-    expect(
-      await screen.findByText(/this folder no longer exists on this machine/i)
-    ).toBeInTheDocument()
+    expect(await screen.findByText(/bucket cannot read this folder/i)).toBeInTheDocument()
   })
 
   it('b7_3_does_not_modify_or_clear_the_stored_value_when_it_warns', async () => {
@@ -71,7 +69,7 @@ describe('BackgroundsSection - dead path warning (#166)', () => {
 
     renderSection()
 
-    await screen.findByText(/no longer exists/i)
+    await screen.findByText(/cannot read this folder/i)
     expect(useAppStore.getState().defaultBackgroundFolder).toBe(FOLDER)
     expect(api.saveSettingsApiKeys).not.toHaveBeenCalled()
   })
@@ -81,7 +79,7 @@ describe('BackgroundsSection - dead path warning (#166)', () => {
 
     renderSection()
 
-    await screen.findByText(/no longer exists/i)
+    await screen.findByText(/cannot read this folder/i)
     // The folder may be on an unmounted volume; saving must not be blocked.
     expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled()
   })

--- a/src/features/Settings/components/BackgroundsSection.test.tsx
+++ b/src/features/Settings/components/BackgroundsSection.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for BackgroundsSection - flagging a saved folder that no longer exists.
+ * Issue #166 (B7.1-B7.4)
+ *
+ * Settings is the one screen a user checks to answer "is this configured?".
+ * Before this fix it answered "yes" for a path that returns os error 2.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAppStore } from '@shared/store'
+
+import BackgroundsSection from './BackgroundsSection'
+import * as api from '../api'
+
+vi.mock('../api', () => ({
+  openFolderPicker: vi.fn(),
+  saveSettingsApiKeys: vi.fn().mockResolvedValue(undefined),
+  directoryExists: vi.fn()
+}))
+
+const FOLDER = '/backgrounds/wbs'
+
+function renderSection(
+  apiKeys = { defaultBackgroundFolder: FOLDER },
+  settingsUnavailable = false
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BackgroundsSection apiKeys={apiKeys} settingsUnavailable={settingsUnavailable} />
+    </QueryClientProvider>
+  )
+}
+
+describe('BackgroundsSection - dead path warning (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStore.setState({ defaultBackgroundFolder: FOLDER })
+  })
+
+  it('b7_1_shows_the_path_with_no_warning_when_it_exists', async () => {
+    vi.mocked(api.directoryExists).mockResolvedValue(true)
+
+    renderSection()
+
+    expect(await screen.findByText(FOLDER)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByText(/no longer exists/i)).not.toBeInTheDocument()
+    )
+  })
+
+  it('b7_2_warns_beside_the_path_when_it_no_longer_exists', async () => {
+    vi.mocked(api.directoryExists).mockResolvedValue(false)
+
+    renderSection()
+
+    expect(await screen.findByText(FOLDER)).toBeInTheDocument()
+    expect(
+      await screen.findByText(/this folder no longer exists on this machine/i)
+    ).toBeInTheDocument()
+  })
+
+  it('b7_3_does_not_modify_or_clear_the_stored_value_when_it_warns', async () => {
+    vi.mocked(api.directoryExists).mockResolvedValue(false)
+
+    renderSection()
+
+    await screen.findByText(/no longer exists/i)
+    expect(useAppStore.getState().defaultBackgroundFolder).toBe(FOLDER)
+    expect(api.saveSettingsApiKeys).not.toHaveBeenCalled()
+  })
+
+  it('b7_4_still_allows_saving_a_path_that_does_not_exist', async () => {
+    vi.mocked(api.directoryExists).mockResolvedValue(false)
+
+    renderSection()
+
+    await screen.findByText(/no longer exists/i)
+    // The folder may be on an unmounted volume; saving must not be blocked.
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled()
+  })
+
+  it('b8_4_disables_saving_while_the_settings_read_is_failing', async () => {
+    vi.mocked(api.directoryExists).mockResolvedValue(true)
+
+    // A file that failed to parse may still hold recoverable credentials, and
+    // every section writes {...apiKeys, ...newKeys} over the {} fallback, so one
+    // Save would overwrite them permanently.
+    renderSection({ defaultBackgroundFolder: FOLDER }, true)
+
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  })
+})

--- a/src/features/Settings/components/BackgroundsSection.tsx
+++ b/src/features/Settings/components/BackgroundsSection.tsx
@@ -1,29 +1,54 @@
 /**
  * Backgrounds Settings Section
  *
- * Default folder picker and save.
+ * Default folder picker and save, plus a warning when the saved folder is no
+ * longer on this machine (issue #166).
  */
 import { toast } from 'sonner'
+import { AlertTriangle } from 'lucide-react'
 import { Button } from '@shared/ui/button'
 import { useAppStore } from '@shared/store'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys, createQueryError } from '@shared/lib'
 import { logger } from '@shared/utils'
 import React from 'react'
 
-import { openFolderPicker, saveSettingsApiKeys } from '../api'
+import { directoryExists, openFolderPicker, saveSettingsApiKeys } from '../api'
 import type { ApiKeys } from '../api'
 
 interface BackgroundsSectionProps {
   apiKeys: ApiKeys
+  /**
+   * The settings file could not be read, so `apiKeys` is the empty fallback.
+   * Saving is blocked while this holds: every section writes
+   * `{...apiKeys, ...newKeys}`, so one save would overwrite a file that is
+   * merely unparseable and destroy the credentials still in it (#166 B8.4).
+   */
+  settingsUnavailable?: boolean
 }
 
-const BackgroundsSection: React.FC<BackgroundsSectionProps> = ({ apiKeys }) => {
+const BackgroundsSection: React.FC<BackgroundsSectionProps> = ({
+  apiKeys,
+  settingsUnavailable = false
+}) => {
   const queryClient = useQueryClient()
   const defaultBackgroundFolder = useAppStore((state) => state.defaultBackgroundFolder)
   const setDefaultBackgroundFolder = useAppStore(
     (state) => state.setDefaultBackgroundFolder
   )
+
+  // Checks the path on display rather than only the saved one, so what the user
+  // is looking at is what gets verified. A query, not an effect, per the
+  // repo's data-fetching convention.
+  const { data: folderPresent } = useQuery({
+    queryKey: queryKeys.settings.backgroundFolderPresent(defaultBackgroundFolder),
+    queryFn: async () => {
+      if (!defaultBackgroundFolder) return true
+      return directoryExists(defaultBackgroundFolder)
+    },
+    enabled: !!defaultBackgroundFolder,
+    retry: false
+  })
 
   const saveMutation = useMutation({
     mutationFn: async (newKeys: Partial<ApiKeys>) => {
@@ -76,12 +101,25 @@ const BackgroundsSection: React.FC<BackgroundsSectionProps> = ({ apiKeys }) => {
           <Button onClick={handleSelectFolder} className="rounded border px-3 py-1">
             Choose Folder
           </Button>
-          <Button onClick={handleSave} className="rounded border px-3 py-1">
+          <Button
+            onClick={handleSave}
+            disabled={settingsUnavailable}
+            className="rounded border px-3 py-1"
+          >
             Save
           </Button>
         </div>
         {defaultBackgroundFolder && (
           <p className="text-muted-foreground mt-1 text-sm">{defaultBackgroundFolder}</p>
+        )}
+        {defaultBackgroundFolder && folderPresent === false && (
+          <p className="text-destructive mt-1 flex items-start gap-1.5 text-sm">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              This folder no longer exists on this machine. Choose another folder, or
+              reconnect the drive it lives on.
+            </span>
+          </p>
         )}
       </div>
     </section>

--- a/src/features/Settings/components/BackgroundsSection.tsx
+++ b/src/features/Settings/components/BackgroundsSection.tsx
@@ -1,8 +1,8 @@
 /**
  * Backgrounds Settings Section
  *
- * Default folder picker and save, plus a warning when the saved folder is no
- * longer on this machine (issue #166).
+ * Default folder picker and save, plus a warning when the saved folder cannot
+ * be read on this machine (issue #166).
  */
 import { toast } from 'sonner'
 import { AlertTriangle } from 'lucide-react'
@@ -116,8 +116,15 @@ const BackgroundsSection: React.FC<BackgroundsSectionProps> = ({
           <p className="text-destructive mt-1 flex items-start gap-1.5 text-sm">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <span>
-              This folder no longer exists on this machine. Choose another folder, or
-              reconnect the drive it lives on.
+              {/*
+                Worded to be true whether the folder is absent or present but
+                unreadable, matching the Posterframe page. Asserting absence
+                here would repeat the misattribution this fix removes: a TCC
+                denial on ~/Documents makes the probe fail, not the folder
+                vanish (issue #166, review round).
+              */}
+              Bucket cannot read this folder. It may have moved, or be on a drive that is
+              not connected.
             </span>
           </p>
         )}

--- a/src/features/Settings/components/SettingsPage.test.tsx
+++ b/src/features/Settings/components/SettingsPage.test.tsx
@@ -74,8 +74,13 @@ describe('SettingsPage - settings read failure (#166)', () => {
 
     renderPage()
 
+    // The 'settings' retry strategy deliberately retries a read/parse failure
+    // once after 500ms (query-utils.ts:179-184), so the banner is legitimately
+    // slower than the 1s default wait.
     expect(
-      await screen.findByText(/could not read your saved settings/i)
+      await screen.findByText(/could not read your saved settings/i, undefined, {
+        timeout: 5000
+      })
     ).toBeInTheDocument()
     for (const name of SECTIONS) {
       expect(screen.getByTestId(`section-${name}`)).toBeInTheDocument()
@@ -87,7 +92,9 @@ describe('SettingsPage - settings read failure (#166)', () => {
 
     renderPage()
 
-    await screen.findByText(/could not read your saved settings/i)
+    await screen.findByText(/could not read your saved settings/i, undefined, {
+      timeout: 5000
+    })
     for (const name of SAVING_SECTIONS) {
       expect(sectionProps[name]).toMatchObject({ settingsUnavailable: true })
     }
@@ -101,7 +108,9 @@ describe('SettingsPage - settings read failure (#166)', () => {
     renderPage()
 
     await screen.findByTestId('section-backgrounds')
-    expect(screen.queryByText(/could not read your saved settings/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/could not read your saved settings/i)
+    ).not.toBeInTheDocument()
     for (const name of SAVING_SECTIONS) {
       expect(sectionProps[name]).toMatchObject({ settingsUnavailable: false })
     }

--- a/src/features/Settings/components/SettingsPage.test.tsx
+++ b/src/features/Settings/components/SettingsPage.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for SettingsPage - reporting a settings file that cannot be read.
+ * Issue #166 (B8.3-B8.5)
+ *
+ * loadApiKeys used to swallow read failures and resolve {}, so an unreadable
+ * api_keys.json rendered every section as never-configured. Now that it
+ * rethrows, the page has to say so, and it must stop sections from saving over
+ * a file whose contents are merely unparseable rather than lost.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SettingsPage from './SettingsPage'
+import * as api from '../api'
+
+vi.mock('../api', () => ({
+  loadSettingsApiKeys: vi.fn(),
+  openFolderPicker: vi.fn(),
+  saveSettingsApiKeys: vi.fn(),
+  directoryExists: vi.fn().mockResolvedValue(true)
+}))
+
+vi.mock('@shared/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/hooks')>()
+  return { ...actual, useBreadcrumb: vi.fn() }
+})
+
+vi.mock('../hooks/useSettingsScroll', () => ({ useSettingsScroll: vi.fn() }))
+
+/** Each section is stubbed so we can read the props the page hands it. */
+const sectionProps: Record<string, Record<string, unknown>> = {}
+
+function stubSection(name: string) {
+  return {
+    default: (props: Record<string, unknown>) => {
+      sectionProps[name] = props
+      return <div data-testid={`section-${name}`} />
+    }
+  }
+}
+
+vi.mock('./AIModelsSection', () => stubSection('ai-models'))
+vi.mock('./AppearanceSection', () => stubSection('appearance'))
+vi.mock('./BackgroundsSection', () => stubSection('backgrounds'))
+vi.mock('./SproutVideoSection', () => stubSection('sprout'))
+vi.mock('./TrelloSection', () => stubSection('trello'))
+
+const SECTIONS = ['ai-models', 'appearance', 'backgrounds', 'sprout', 'trello']
+/** Sections that receive api keys and can write them back. */
+const SAVING_SECTIONS = ['ai-models', 'backgrounds', 'sprout', 'trello']
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsPage />
+    </QueryClientProvider>
+  )
+}
+
+describe('SettingsPage - settings read failure (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const key of Object.keys(sectionProps)) delete sectionProps[key]
+  })
+
+  it('b8_3_shows_a_banner_and_still_renders_every_section', async () => {
+    vi.mocked(api.loadSettingsApiKeys).mockRejectedValue(new Error('unparseable'))
+
+    renderPage()
+
+    expect(
+      await screen.findByText(/could not read your saved settings/i)
+    ).toBeInTheDocument()
+    for (const name of SECTIONS) {
+      expect(screen.getByTestId(`section-${name}`)).toBeInTheDocument()
+    }
+  })
+
+  it('b8_4_tells_every_saving_section_that_settings_are_unavailable', async () => {
+    vi.mocked(api.loadSettingsApiKeys).mockRejectedValue(new Error('unparseable'))
+
+    renderPage()
+
+    await screen.findByText(/could not read your saved settings/i)
+    for (const name of SAVING_SECTIONS) {
+      expect(sectionProps[name]).toMatchObject({ settingsUnavailable: true })
+    }
+  })
+
+  it('b8_5_shows_no_banner_and_leaves_saving_enabled_on_a_successful_read', async () => {
+    vi.mocked(api.loadSettingsApiKeys).mockResolvedValue({
+      defaultBackgroundFolder: '/backgrounds'
+    })
+
+    renderPage()
+
+    await screen.findByTestId('section-backgrounds')
+    expect(screen.queryByText(/could not read your saved settings/i)).not.toBeInTheDocument()
+    for (const name of SAVING_SECTIONS) {
+      expect(sectionProps[name]).toMatchObject({ settingsUnavailable: false })
+    }
+  })
+})

--- a/src/features/Settings/components/SettingsPage.tsx
+++ b/src/features/Settings/components/SettingsPage.tsx
@@ -26,7 +26,7 @@ const SettingsPageContent: React.FC = () => {
 
   useBreadcrumb([{ label: 'Settings', href: '/settings/general' }, { label: 'General' }])
 
-  const { data: apiKeys = {} } = useQuery({
+  const { data: apiKeys = {}, isError: settingsUnavailable } = useQuery({
     ...createQueryOptions(
       queryKeys.settings.apiKeys(),
       async () => {
@@ -58,11 +58,38 @@ const SettingsPageContent: React.FC = () => {
         </div>
 
         <div className="max-w-full space-y-8 px-6 py-4">
-          <AIModelsSection apiKeys={apiKeys} />
+          {/*
+            loadApiKeys rethrows on an unreadable or unparseable file rather than
+            resolving {} (issue #166 B8.1), so a read failure is now visible
+            instead of masquerading as "nothing configured". Sections still
+            render so their state is inspectable, but they cannot save.
+          */}
+          {settingsUnavailable && (
+            <div
+              role="alert"
+              className="border-destructive/50 bg-destructive/10 text-destructive flex items-start gap-2 rounded-lg border p-4 text-sm"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <p className="font-medium">Could not read your saved settings.</p>
+                <p className="mt-0.5">
+                  The values below may be incomplete. Saving is disabled to avoid
+                  overwriting credentials that may still be recoverable.
+                </p>
+              </div>
+            </div>
+          )}
+          <AIModelsSection apiKeys={apiKeys} settingsUnavailable={settingsUnavailable} />
           <AppearanceSection />
-          <BackgroundsSection apiKeys={apiKeys} />
-          <SproutVideoSection apiKeys={apiKeys} />
-          <TrelloSection apiKeys={apiKeys} />
+          <BackgroundsSection
+            apiKeys={apiKeys}
+            settingsUnavailable={settingsUnavailable}
+          />
+          <SproutVideoSection
+            apiKeys={apiKeys}
+            settingsUnavailable={settingsUnavailable}
+          />
+          <TrelloSection apiKeys={apiKeys} settingsUnavailable={settingsUnavailable} />
         </div>
       </div>
     </div>

--- a/src/features/Settings/components/SproutVideoSection.tsx
+++ b/src/features/Settings/components/SproutVideoSection.tsx
@@ -18,9 +18,18 @@ import type { ApiKeys } from '../api'
 
 interface SproutVideoSectionProps {
   apiKeys: ApiKeys
+  /**
+   * The settings file could not be read, so `apiKeys` is the empty fallback.
+   * Saving is blocked while this holds, or one save would overwrite a merely
+   * unparseable file and destroy the credentials still in it (#166 B8.4).
+   */
+  settingsUnavailable?: boolean
 }
 
-const SproutVideoSection: React.FC<SproutVideoSectionProps> = ({ apiKeys }) => {
+const SproutVideoSection: React.FC<SproutVideoSectionProps> = ({
+  apiKeys,
+  settingsUnavailable = false
+}) => {
   const queryClient = useQueryClient()
   const [localKey, setLocalKey] = useState(apiKeys.sproutVideo || '')
   const [prevPropValue, setPrevPropValue] = useState(apiKeys.sproutVideo)
@@ -103,6 +112,7 @@ const SproutVideoSection: React.FC<SproutVideoSectionProps> = ({ apiKeys }) => {
           SproutVideo API Key
         </label>
         <ApiKeyInput
+          saveDisabled={settingsUnavailable}
           id="sprout-video-api-key-input"
           apiKey={localKey}
           setApiKey={setLocalKey}

--- a/src/features/Settings/components/TrelloSection.tsx
+++ b/src/features/Settings/components/TrelloSection.tsx
@@ -17,9 +17,18 @@ import type { ApiKeys } from '../api'
 
 interface TrelloSectionProps {
   apiKeys: ApiKeys
+  /**
+   * The settings file could not be read, so `apiKeys` is the empty fallback.
+   * Saving is blocked while this holds, or one save would overwrite a merely
+   * unparseable file and destroy the credentials still in it (#166 B8.4).
+   */
+  settingsUnavailable?: boolean
 }
 
-const TrelloSection: React.FC<TrelloSectionProps> = ({ apiKeys }) => {
+const TrelloSection: React.FC<TrelloSectionProps> = ({
+  apiKeys,
+  settingsUnavailable = false
+}) => {
   const queryClient = useQueryClient()
   const [localTrelloKey, setLocalTrelloKey] = useState(apiKeys.trello || '')
   const [localTrelloToken, setLocalTrelloToken] = useState(apiKeys.trelloToken || '')
@@ -100,6 +109,7 @@ const TrelloSection: React.FC<TrelloSectionProps> = ({ apiKeys }) => {
           Trello API Key
         </label>
         <ApiKeyInput
+          saveDisabled={settingsUnavailable}
           id="trello-api-key-input"
           apiKey={localTrelloKey}
           setApiKey={setLocalTrelloKey}
@@ -118,6 +128,7 @@ const TrelloSection: React.FC<TrelloSectionProps> = ({ apiKeys }) => {
           Trello API Token
         </label>
         <ApiKeyInput
+          saveDisabled={settingsUnavailable}
           id="trello-api-token-input"
           apiKey={localTrelloToken}
           setApiKey={setLocalTrelloToken}

--- a/src/features/Upload/__contracts__/api.backgroundFolder.test.ts
+++ b/src/features/Upload/__contracts__/api.backgroundFolder.test.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as tauriFs from '@tauri-apps/plugin-fs'
 
-import { listDirectory } from './api'
+import { listDirectory } from '../api'
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
   exists: vi.fn(),

--- a/src/features/Upload/__contracts__/upload.contract.test.ts
+++ b/src/features/Upload/__contracts__/upload.contract.test.ts
@@ -62,7 +62,18 @@ vi.mock('@shared/utils/logger', () => ({
 vi.mock('@shared/lib/query-keys', () => ({
   queryKeys: {
     upload: {
-      events: () => ['upload', 'events']
+      events: () => ['upload', 'events'],
+      // Issue #166: useBackgroundFolder keys its listing on the folder, and
+      // reads the settings query's status to tell "not configured" from
+      // "settings unreadable".
+      backgroundFolder: (folderPath: string | null) => [
+        'upload',
+        'background-folder',
+        folderPath ?? 'none'
+      ]
+    },
+    settings: {
+      apiKeys: () => ['settings', 'api-keys']
     },
     images: {
       refresh: (id: string) => ['images', 'refresh', id],

--- a/src/features/Upload/__contracts__/upload.contract.test.ts
+++ b/src/features/Upload/__contracts__/upload.contract.test.ts
@@ -26,7 +26,9 @@ vi.mock('../api', () => ({
   openFolderDialog: vi.fn().mockResolvedValue(null),
   saveFile: vi.fn().mockResolvedValue(undefined),
   readFileAsBytes: vi.fn().mockResolvedValue(new Uint8Array()),
-  listDirectory: vi.fn().mockResolvedValue([]),
+  // Tagged result since issue #166: a bare array would be read as a missing
+  // `status` and misclassify inside the test rather than failing loudly.
+  listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
   getFontDir: vi.fn().mockResolvedValue('/fonts'),
   fileExists: vi.fn().mockResolvedValue(false),
   posterFrameFontAvailable: vi.fn().mockResolvedValue(false),

--- a/src/features/Upload/api.backgroundFolder.test.ts
+++ b/src/features/Upload/api.backgroundFolder.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for listDirectory's background-folder classification.
+ * Issue #166 (B1.1-B1.5)
+ *
+ * listDirectory no longer throws on an unusable folder. It returns a tagged
+ * result so callers can tell "not there" from "there but unreadable" from
+ * "there, readable, no images" without matching on Tauri's error strings.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as tauriFs from '@tauri-apps/plugin-fs'
+
+import { listDirectory } from './api'
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: vi.fn(),
+  readDir: vi.fn(),
+  readFile: vi.fn(),
+  readTextFile: vi.fn(),
+  writeFile: vi.fn(),
+  writeTextFile: vi.fn()
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn(), save: vi.fn() }))
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: vi.fn().mockResolvedValue('/appdata/'),
+  fontDir: vi.fn().mockResolvedValue('/fonts')
+}))
+
+const FOLDER = '/backgrounds'
+
+function entry(name: string) {
+  return { name, isFile: true, isDirectory: false, isSymlink: false }
+}
+
+describe('listDirectory - background folder classification (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('b1_1_returns_ok_with_sorted_image_paths_for_a_readable_folder', async () => {
+    vi.mocked(tauriFs.exists).mockResolvedValue(true)
+    vi.mocked(tauriFs.readDir).mockResolvedValue([
+      entry('wbs-red.png'),
+      entry('notes.txt'),
+      entry('wbs-blue.jpg')
+    ] as never)
+
+    const result = await listDirectory(FOLDER)
+
+    expect(result).toEqual({
+      status: 'ok',
+      files: ['/backgrounds/wbs-blue.jpg', '/backgrounds/wbs-red.png']
+    })
+  })
+
+  it('b1_2_returns_missing_without_throwing_when_the_path_does_not_exist', async () => {
+    vi.mocked(tauriFs.exists).mockResolvedValue(false)
+
+    const result = await listDirectory(FOLDER)
+
+    expect(result).toEqual({ status: 'missing' })
+    // The listing must not even be attempted for a path that isn't there.
+    expect(tauriFs.readDir).not.toHaveBeenCalled()
+  })
+
+  it('b1_3_returns_unreadable_with_detail_when_the_listing_rejects', async () => {
+    vi.mocked(tauriFs.exists).mockResolvedValue(true)
+    vi.mocked(tauriFs.readDir).mockRejectedValue(new Error('forbidden (os error 13)'))
+
+    const result = await listDirectory(FOLDER)
+
+    expect(result.status).toBe('unreadable')
+    expect(result).toHaveProperty('detail')
+    expect((result as { detail: string }).detail).toContain('os error 13')
+  })
+
+  it('b1_4_returns_unreadable_when_the_existence_probe_itself_rejects', async () => {
+    vi.mocked(tauriFs.exists).mockRejectedValue(new Error('probe denied'))
+
+    const result = await listDirectory(FOLDER)
+
+    expect(result.status).toBe('unreadable')
+    expect((result as { detail: string }).detail).toContain('probe denied')
+  })
+
+  it('b1_5_returns_ok_with_no_files_for_a_readable_folder_holding_no_images', async () => {
+    vi.mocked(tauriFs.exists).mockResolvedValue(true)
+    vi.mocked(tauriFs.readDir).mockResolvedValue([
+      entry('notes.txt'),
+      entry('script.md')
+    ] as never)
+
+    const result = await listDirectory(FOLDER)
+
+    expect(result).toEqual({ status: 'ok', files: [] })
+  })
+})

--- a/src/features/Upload/api.ts
+++ b/src/features/Upload/api.ts
@@ -186,17 +186,48 @@ const IMAGE_EXTENSIONS = new Set([
   '.tif'
 ])
 
-export async function listDirectory(folderPath: string): Promise<string[]> {
-  const entries = await readDir(folderPath)
-  const imageFiles = entries
-    .filter((entry) => {
-      const name = entry.name || ''
-      const ext = name.slice(name.lastIndexOf('.')).toLowerCase()
-      return IMAGE_EXTENSIONS.has(ext)
-    })
-    .map((entry) => `${folderPath}/${entry.name}`)
-    .sort()
-  return imageFiles
+/**
+ * Outcome of listing a background folder (issue #166).
+ *
+ * Tagged rather than thrown, because callers need to tell "not there" from
+ * "there but unreadable" from "there, readable, no images". Previously readDir's
+ * rejection was swallowed into an empty array, so all three -- and "never
+ * configured" -- rendered identically.
+ *
+ * `missing` and `unreadable` stay distinct here even though the UI shows one
+ * message for both: the distinction is worth logging, and worth having if the
+ * UI ever wants to act on it.
+ */
+export type BackgroundFolderResult =
+  | { status: 'ok'; files: string[] }
+  | { status: 'missing' }
+  | { status: 'unreadable'; detail: string }
+
+export async function listDirectory(folderPath: string): Promise<BackgroundFolderResult> {
+  // An existence probe rather than matching on readDir's rejection text: that
+  // text is unversioned and locale-sensitive, the same brittleness as the
+  // `includes('4')` retry heuristic flagged in #156.
+  try {
+    if (!(await exists(folderPath))) return { status: 'missing' }
+  } catch (error) {
+    // A probe that cannot run is not evidence of absence.
+    return { status: 'unreadable', detail: String(error) }
+  }
+
+  try {
+    const entries = await readDir(folderPath)
+    const files = entries
+      .filter((entry) => {
+        const name = entry.name || ''
+        const ext = name.slice(name.lastIndexOf('.')).toLowerCase()
+        return IMAGE_EXTENSIONS.has(ext)
+      })
+      .map((entry) => `${folderPath}/${entry.name}`)
+      .sort()
+    return { status: 'ok', files }
+  } catch (error) {
+    return { status: 'unreadable', detail: String(error) }
+  }
 }
 
 export async function getFontDir(): Promise<string> {

--- a/src/features/Upload/components/Posterframe.test.tsx
+++ b/src/features/Upload/components/Posterframe.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Tests for the Posterframe page - saying which folder is in use, and why it
+ * cannot be used.
+ * Issue #166 (B4.1, B4.2, B5.1-B5.6)
+ *
+ * The page previously gated the whole background picker on files.length > 0 and
+ * never printed the folder, so a dead configured path looked identical to a
+ * first-run app.
+ */
+
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Posterframe from './Posterframe'
+import { useBackgroundFolder } from '../hooks/useBackgroundFolder'
+import { useFileSelection } from '../hooks/useFileSelection'
+
+vi.mock('../hooks/useBackgroundFolder', () => ({ useBackgroundFolder: vi.fn() }))
+vi.mock('../hooks/useFileSelection', () => ({ useFileSelection: vi.fn() }))
+
+// Canvas work cannot run in jsdom; the page's rendering decisions are what
+// these tests are about.
+vi.mock('../hooks/usePosterframeCanvas', () => ({
+  usePosterframeCanvas: () => ({
+    canvasRef: { current: null },
+    draw: vi.fn(),
+    fontStatus: 'available'
+  })
+}))
+vi.mock('../hooks/usePosterframeAutoRedraw', () => ({
+  usePosterframeAutoRedraw: vi.fn()
+}))
+vi.mock('../hooks/useAutoFileSelection', () => ({ useAutoFileSelection: vi.fn() }))
+vi.mock('../hooks/useZoomPan', () => ({
+  useZoomPan: () => ({
+    zoomLevel: 1,
+    pan: { x: 0, y: 0 },
+    setZoomLevel: vi.fn(),
+    setPan: vi.fn()
+  })
+}))
+vi.mock('@shared/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/hooks')>()
+  return { ...actual, useBreadcrumb: vi.fn() }
+})
+vi.mock('../api', () => ({
+  openFolder: vi.fn(),
+  openFolderDialog: vi.fn(),
+  saveFile: vi.fn()
+}))
+
+const DEFAULT_FOLDER = '/backgrounds/wbs'
+const SESSION_FOLDER = '/Volumes/Media/bgs'
+
+type FolderState = Partial<ReturnType<typeof useBackgroundFolder>>
+
+function folderState(overrides: FolderState = {}) {
+  return {
+    files: [],
+    status: 'ready',
+    reason: null,
+    folderInUse: DEFAULT_FOLDER,
+    defaultFolder: DEFAULT_FOLDER,
+    isSessionOverride: false,
+    isLoading: false,
+    loadFolder: vi.fn(),
+    useDefaultFolder: vi.fn(),
+    ...overrides
+  } as ReturnType<typeof useBackgroundFolder>
+}
+
+function selectionState(selectedFilePath: string | null = null) {
+  return {
+    selectedFilePath,
+    selectedFileBlob: selectedFilePath ? 'blob:preview' : null,
+    selectFile: vi.fn(),
+    clearSelection: vi.fn()
+  } as unknown as ReturnType<typeof useFileSelection>
+}
+
+function renderPage(state: FolderState = {}, selected: string | null = null) {
+  vi.mocked(useBackgroundFolder).mockReturnValue(folderState(state))
+  vi.mocked(useFileSelection).mockReturnValue(selectionState(selected))
+  return render(<Posterframe />)
+}
+
+describe('Posterframe page - background folder diagnostics (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('b5_1_displays_the_folder_currently_in_use', () => {
+    renderPage({ status: 'ready', files: ['/backgrounds/wbs/a.jpg'] })
+
+    expect(screen.getByText(DEFAULT_FOLDER)).toBeInTheDocument()
+  })
+
+  it('b5_2_warns_with_the_path_and_keeps_the_picker_available', () => {
+    renderPage({
+      status: 'cannot-read',
+      reason: `Cannot read background folder: ${DEFAULT_FOLDER}`
+    })
+
+    expect(
+      screen.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /select background folder/i })
+    ).toBeEnabled()
+  })
+
+  it('b5_3_explains_a_folder_with_no_images', () => {
+    renderPage({
+      status: 'empty',
+      reason: 'The background folder contains no image files.'
+    })
+
+    expect(screen.getByText(/contains no image files/i)).toBeInTheDocument()
+  })
+
+  it('b5_4_explains_that_no_folder_is_configured', () => {
+    renderPage({
+      status: 'not-configured',
+      reason: 'No default background folder configured. Set one in Settings.',
+      folderInUse: null,
+      defaultFolder: null
+    })
+
+    expect(screen.getByText(/set one in settings/i)).toBeInTheDocument()
+  })
+
+  it('b5_5_explains_that_settings_could_not_be_read', () => {
+    renderPage({
+      status: 'settings-error',
+      reason: 'Could not read your settings, so the background folder is unknown.',
+      folderInUse: null,
+      defaultFolder: null
+    })
+
+    expect(screen.getByText(/could not read your settings/i)).toBeInTheDocument()
+  })
+
+  it('b5_6_shows_no_warning_while_the_listing_is_still_in_flight', () => {
+    renderPage({ status: 'loading', reason: null, isLoading: true })
+
+    expect(screen.queryByText(/cannot read background folder/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/contains no image files/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/set one in settings/i)).not.toBeInTheDocument()
+  })
+
+  it('b3_2_labels_a_session_override_alongside_the_default', () => {
+    renderPage({
+      status: 'ready',
+      files: ['/Volumes/Media/bgs/a.jpg'],
+      folderInUse: SESSION_FOLDER,
+      isSessionOverride: true
+    })
+
+    expect(screen.getByText(SESSION_FOLDER)).toBeInTheDocument()
+    expect(screen.getByText(DEFAULT_FOLDER)).toBeInTheDocument()
+  })
+
+  it('b3_3_offers_a_reset_to_the_default_while_an_override_is_active', () => {
+    renderPage({
+      status: 'ready',
+      files: ['/Volumes/Media/bgs/a.jpg'],
+      folderInUse: SESSION_FOLDER,
+      isSessionOverride: true
+    })
+
+    expect(screen.getByRole('button', { name: /use default/i })).toBeEnabled()
+  })
+
+  it('b3_4_offers_no_reset_when_no_override_is_active', () => {
+    renderPage({ status: 'ready', files: ['/backgrounds/wbs/a.jpg'] })
+
+    expect(screen.queryByRole('button', { name: /use default/i })).not.toBeInTheDocument()
+  })
+
+  it('b4_2_shows_an_empty_preview_and_disables_generate_without_a_selection', () => {
+    renderPage({
+      status: 'cannot-read',
+      reason: `Cannot read background folder: ${DEFAULT_FOLDER}`
+    })
+
+    expect(screen.getByText(/select a background to preview/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /generate thumbnail/i })).toBeDisabled()
+  })
+})
+
+describe('Posterframe page - selection coherence (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('b4_1_clears_a_selection_the_resolved_listing_no_longer_contains', () => {
+    const clearSelection = vi.fn()
+    vi.mocked(useBackgroundFolder).mockReturnValue(
+      folderState({
+        status: 'cannot-read',
+        files: [],
+        reason: `Cannot read background folder: ${DEFAULT_FOLDER}`
+      })
+    )
+    vi.mocked(useFileSelection).mockReturnValue({
+      ...selectionState('/backgrounds/wbs/gone.jpg'),
+      clearSelection
+    } as unknown as ReturnType<typeof useFileSelection>)
+
+    render(<Posterframe />)
+
+    // Rendering a preview from a folder the page is simultaneously warning it
+    // cannot read is exactly the mixed message this issue exists to remove.
+    expect(clearSelection).toHaveBeenCalled()
+  })
+})

--- a/src/features/Upload/components/Posterframe.tsx
+++ b/src/features/Upload/components/Posterframe.tsx
@@ -29,6 +29,7 @@ import {
   Maximize2,
   RefreshCw,
   Save,
+  Undo2,
   ZoomIn,
   ZoomOut
 } from 'lucide-react'
@@ -41,8 +42,18 @@ const PosterframeContent: React.FC = () => {
   const [videoTitle, setVideoTitle] = useState('')
   const [savePath, setSavePath] = useState<string | null>(null)
 
-  const { files: backgroundFiles, loadFolder } = useBackgroundFolder()
-  const { selectedFilePath, selectedFileBlob, selectFile } = useFileSelection()
+  const {
+    files: backgroundFiles,
+    loadFolder,
+    useDefaultFolder,
+    status: folderStatus,
+    reason: folderReason,
+    folderInUse,
+    defaultFolder,
+    isSessionOverride
+  } = useBackgroundFolder()
+  const { selectedFilePath, selectedFileBlob, selectFile, clearSelection } =
+    useFileSelection()
   const { canvasRef, draw, fontStatus } = usePosterframeCanvas()
   // Toast exactly once when we first discover the font isn't installed —
   // otherwise the user gets a blank thumbnail with no explanation and no
@@ -79,6 +90,14 @@ const PosterframeContent: React.FC = () => {
     selectFile,
     criteria: { preferImage: true } // Prefer images for posterframe
   })
+
+  // Never keep a preview of an image from a folder the page is simultaneously
+  // warning it cannot read (issue #166 B4.1).
+  useEffect(() => {
+    if (selectedFilePath && !backgroundFiles.includes(selectedFilePath)) {
+      clearSelection()
+    }
+  }, [backgroundFiles, selectedFilePath, clearSelection])
 
   const chooseSavePath = async () => {
     const folder = await openFolderDialog()
@@ -182,6 +201,60 @@ const PosterframeContent: React.FC = () => {
                 </div>
 
                 <div className="space-y-3">
+                  {/*
+                    Which folder is in use was never shown before, so a dead
+                    configured path was indistinguishable from no configuration
+                    at all: there was nothing on screen to contradict "the
+                    setting is being ignored" (issue #166 B5.1, B3.2).
+                  */}
+                  {folderInUse && (
+                    <div className="text-xs">
+                      {isSessionOverride ? (
+                        <>
+                          <p className="text-muted-foreground">
+                            Using this session:{' '}
+                            <span className="text-foreground font-medium break-all">
+                              {folderInUse}
+                            </span>
+                          </p>
+                          {defaultFolder && (
+                            <p className="text-muted-foreground mt-0.5">
+                              Default: <span className="break-all">{defaultFolder}</span>
+                            </p>
+                          )}
+                        </>
+                      ) : (
+                        <p className="text-muted-foreground">
+                          Folder:{' '}
+                          <span className="text-foreground font-medium break-all">
+                            {folderInUse}
+                          </span>
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {/*
+                    No reason is reported while a check is in flight, so nothing
+                    flashes a wrong cause mid-read (B5.6).
+                  */}
+                  {folderReason && (
+                    <p
+                      role="alert"
+                      className="text-destructive flex items-start gap-1.5 text-xs"
+                    >
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span className="break-all">
+                        {folderReason}
+                        {folderStatus === 'cannot-read' && (
+                          <span className="text-muted-foreground block break-normal">
+                            Pick another folder below, or update the default in Settings.
+                          </span>
+                        )}
+                      </span>
+                    </p>
+                  )}
+
                   <Button
                     onClick={() =>
                       openFolderDialog().then(
@@ -195,6 +268,23 @@ const PosterframeContent: React.FC = () => {
                     <FolderOpen className="h-3.5 w-3.5" />
                     Select Background Folder
                   </Button>
+
+                  {/*
+                    Without this, a session pick is sticky until restart: the
+                    resolved folder is `session || default`, so there was no way
+                    back to the configured default (B3.3).
+                  */}
+                  {isSessionOverride && (
+                    <Button
+                      onClick={useDefaultFolder}
+                      variant="ghost"
+                      size="sm"
+                      className="w-full gap-1.5"
+                    >
+                      <Undo2 className="h-3.5 w-3.5" />
+                      Use default
+                    </Button>
+                  )}
 
                   {backgroundFiles.length > 0 && (
                     <Select

--- a/src/features/Upload/hooks/useBackgroundFolder.test.ts
+++ b/src/features/Upload/hooks/useBackgroundFolder.test.ts
@@ -44,6 +44,17 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return React.createElement(QueryClientProvider, { client: queryClient }, children)
 }
 
+/**
+ * A client whose default IS to retry, so a test asserting "did not retry"
+ * actually exercises the query's own `retry: false` rather than the harness's.
+ */
+function retryingWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: 3, retryDelay: 1, gcTime: 0 } }
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
 /** Settings query resolved successfully. */
 function settingsLoaded() {
   vi.mocked(useApiKeys).mockReturnValue({
@@ -172,7 +183,12 @@ describe('useBackgroundFolder - state classification (#166)', () => {
   it('b2_9_surfaces_an_unexpected_rejection_without_retrying', async () => {
     vi.mocked(api.listDirectory).mockRejectedValue(new Error('boom'))
 
-    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+    // Deliberately a client that DOES retry: with `retry: false` in the wrapper
+    // defaults this assertion could not fail, because nothing would retry even
+    // without the query's own override.
+    const { result } = renderHook(() => useBackgroundFolder(), {
+      wrapper: retryingWrapper
+    })
 
     await waitFor(() => expect(result.current.status).toBe('cannot-read'))
     // One attempt only: a deterministic failure must not burn ~7s of backoff.

--- a/src/features/Upload/hooks/useBackgroundFolder.test.ts
+++ b/src/features/Upload/hooks/useBackgroundFolder.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for useBackgroundFolder - the three-state classification and its
+ * user-facing reasons.
+ * Issue #166 (B2.1-B2.9, B3.1-B3.4)
+ *
+ * The hook must distinguish six situations that all rendered identically
+ * before: settings still loading, settings unreadable, no folder configured,
+ * listing in flight, folder unusable, and folder empty.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAppStore } from '@shared/store'
+import { logger } from '@shared/utils'
+
+import * as api from '../api'
+import { useBackgroundFolder } from './useBackgroundFolder'
+
+vi.mock('../api', () => ({
+  listDirectory: vi.fn()
+}))
+
+vi.mock('@shared/hooks', () => ({
+  useApiKeys: vi.fn()
+}))
+
+vi.mock('@shared/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/utils')>()
+  return { ...actual, logger: { ...actual.logger, error: vi.fn(), warn: vi.fn() } }
+})
+
+import { useApiKeys } from '@shared/hooks'
+
+const DEFAULT_FOLDER = '/backgrounds'
+const SESSION_FOLDER = '/Volumes/Media/bgs'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+/** Settings query resolved successfully. */
+function settingsLoaded() {
+  vi.mocked(useApiKeys).mockReturnValue({
+    isPending: false,
+    isError: false,
+    error: null
+  } as never)
+}
+
+describe('useBackgroundFolder - state classification (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStore.setState({ defaultBackgroundFolder: DEFAULT_FOLDER })
+    settingsLoaded()
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'ok', files: [] })
+  })
+
+  it('b2_1_reports_unknown_and_reads_nothing_while_settings_are_pending', async () => {
+    vi.mocked(useApiKeys).mockReturnValue({
+      isPending: true,
+      isError: false,
+      error: null
+    } as never)
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    expect(result.current.status).toBe('unknown')
+    expect(result.current.reason).toBeNull()
+    expect(api.listDirectory).not.toHaveBeenCalled()
+  })
+
+  it('b2_2_explains_that_the_folder_is_unknown_when_settings_could_not_be_read', async () => {
+    vi.mocked(useApiKeys).mockReturnValue({
+      isPending: false,
+      isError: true,
+      error: new Error('unparseable')
+    } as never)
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    expect(result.current.status).toBe('settings-error')
+    expect(result.current.reason).toBe(
+      'Could not read your settings, so the background folder is unknown.'
+    )
+  })
+
+  it('b2_3_explains_that_no_folder_is_configured_once_settings_have_loaded', async () => {
+    useAppStore.setState({ defaultBackgroundFolder: null })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    expect(result.current.status).toBe('not-configured')
+    expect(result.current.reason).toBe(
+      'No default background folder configured. Set one in Settings.'
+    )
+    expect(api.listDirectory).not.toHaveBeenCalled()
+  })
+
+  it('b2_4_reports_no_reason_while_the_listing_is_in_flight', async () => {
+    vi.mocked(api.listDirectory).mockReturnValue(new Promise(() => {}) as never)
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    expect(result.current.status).toBe('loading')
+    expect(result.current.reason).toBeNull()
+  })
+
+  it('b2_5_names_the_path_when_the_folder_is_missing', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'missing' })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('cannot-read'))
+    expect(result.current.reason).toBe(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+  })
+
+  it('b2_5_gives_the_same_message_when_the_folder_is_unreadable', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({
+      status: 'unreadable',
+      detail: 'os error 13'
+    })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('cannot-read'))
+    expect(result.current.reason).toBe(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+  })
+
+  it('b2_6_logs_the_unreadable_detail_and_keeps_it_out_of_the_reason', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({
+      status: 'unreadable',
+      detail: 'os error 13'
+    })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('cannot-read'))
+    expect(result.current.reason).not.toContain('os error 13')
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining('os error 13')
+    )
+  })
+
+  it('b2_7_explains_an_empty_folder', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'ok', files: [] })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('empty'))
+    expect(result.current.reason).toBe('The background folder contains no image files.')
+  })
+
+  it('b2_8_reports_ready_with_the_files_when_the_folder_has_images', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({
+      status: 'ok',
+      files: ['/backgrounds/a.jpg']
+    })
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.reason).toBeNull()
+    expect(result.current.files).toEqual(['/backgrounds/a.jpg'])
+  })
+
+  it('b2_9_surfaces_an_unexpected_rejection_without_retrying', async () => {
+    vi.mocked(api.listDirectory).mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await waitFor(() => expect(result.current.status).toBe('cannot-read'))
+    // One attempt only: a deterministic failure must not burn ~7s of backoff.
+    expect(api.listDirectory).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useBackgroundFolder - session override (#166)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStore.setState({ defaultBackgroundFolder: DEFAULT_FOLDER })
+    settingsLoaded()
+    vi.mocked(api.listDirectory).mockResolvedValue({
+      status: 'ok',
+      files: ['/x/a.jpg']
+    })
+  })
+
+  it('b3_1_uses_a_picked_folder_for_the_session_without_touching_the_default', async () => {
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await act(async () => {
+      await result.current.loadFolder(SESSION_FOLDER)
+    })
+
+    expect(result.current.folderInUse).toBe(SESSION_FOLDER)
+    expect(useAppStore.getState().defaultBackgroundFolder).toBe(DEFAULT_FOLDER)
+  })
+
+  it('b3_2_exposes_the_override_and_the_default_separately', async () => {
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await act(async () => {
+      await result.current.loadFolder(SESSION_FOLDER)
+    })
+
+    expect(result.current.isSessionOverride).toBe(true)
+    expect(result.current.defaultFolder).toBe(DEFAULT_FOLDER)
+  })
+
+  it('b3_3_returns_to_the_default_when_the_override_is_reset', async () => {
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    await act(async () => {
+      await result.current.loadFolder(SESSION_FOLDER)
+    })
+    act(() => {
+      result.current.useDefaultFolder()
+    })
+
+    expect(result.current.folderInUse).toBe(DEFAULT_FOLDER)
+    expect(result.current.isSessionOverride).toBe(false)
+  })
+
+  it('b3_4_reports_no_override_before_any_folder_is_picked', async () => {
+    const { result } = renderHook(() => useBackgroundFolder(), { wrapper })
+
+    expect(result.current.isSessionOverride).toBe(false)
+    expect(result.current.folderInUse).toBe(DEFAULT_FOLDER)
+  })
+})

--- a/src/features/Upload/hooks/useBackgroundFolder.ts
+++ b/src/features/Upload/hooks/useBackgroundFolder.ts
@@ -3,7 +3,7 @@ import { queryKeys } from '@shared/lib'
 import { useAppStore } from '@shared/store'
 import { logger } from '@shared/utils'
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { listDirectory } from '../api'
 
@@ -84,9 +84,14 @@ export function useBackgroundFolder(): BackgroundFolderData {
     retry: false
   })
 
-  if (data?.status === 'unreadable') {
-    logger.error(`Background folder unreadable (${folderInUse}): ${data.detail}`)
-  }
+  // In an effect, not the render body: any unrelated re-render would otherwise
+  // log the same failure again and bury the first occurrence.
+  const unreadableDetail = data?.status === 'unreadable' ? data.detail : null
+  useEffect(() => {
+    if (unreadableDetail !== null) {
+      logger.error(`Background folder unreadable (${folderInUse}): ${unreadableDetail}`)
+    }
+  }, [unreadableDetail, folderInUse])
 
   const { status, reason } = resolveState({
     settingsPending,

--- a/src/features/Upload/hooks/useBackgroundFolder.ts
+++ b/src/features/Upload/hooks/useBackgroundFolder.ts
@@ -1,52 +1,160 @@
+import { useApiKeys } from '@shared/hooks'
+import { queryKeys } from '@shared/lib'
 import { useAppStore } from '@shared/store'
+import { logger } from '@shared/utils'
 import { useQuery } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 
 import { listDirectory } from '../api'
 
+/**
+ * Why the background folder cannot be used, or `ready` when it can.
+ *
+ * Six situations rendered identically before issue #166. Separating them is the
+ * whole point of this hook: "no folder set" and "the folder you set is gone" are
+ * different problems with different fixes, and telling the user the wrong one
+ * sent them to Settings to re-enter a path that was already correct.
+ */
+export type BackgroundFolderStatus =
+  /** Settings have not loaded yet, so we do not know what is configured. */
+  | 'unknown'
+  /** Settings could not be read, so the configured folder is unknowable. */
+  | 'settings-error'
+  /** Settings loaded and hold no background folder. */
+  | 'not-configured'
+  /** A folder is configured and its listing is in flight. */
+  | 'loading'
+  /** The folder is absent, or present but unreadable. */
+  | 'cannot-read'
+  /** The folder listed fine but holds no images. */
+  | 'empty'
+  /** The folder listed fine and holds at least one image. */
+  | 'ready'
+
 interface BackgroundFolderData {
   files: string[]
-  currentFolder: string | null
+  status: BackgroundFolderStatus
+  /** User-facing explanation, or null when there is nothing to explain. */
+  reason: string | null
+  /** The folder actually being read: the session override if set, else the default. */
+  folderInUse: string | null
+  /** The folder saved in Settings. */
+  defaultFolder: string | null
+  /** Whether a session pick is currently overriding the saved default. */
+  isSessionOverride: boolean
   isLoading: boolean
   loadFolder: (folderPath: string) => Promise<void>
-  defaultFolder: string | null
+  /** Drop the session override and go back to the saved default. */
+  useDefaultFolder: () => void
+  /** Kept for consumers that only care about the resolved folder. */
+  currentFolder: string | null
 }
+
+const REASONS = {
+  settingsError: 'Could not read your settings, so the background folder is unknown.',
+  notConfigured: 'No default background folder configured. Set one in Settings.',
+  empty: 'The background folder contains no image files.'
+} as const
+
+/** Worded to be true whether the folder is absent or merely unreadable. */
+const cannotReadReason = (path: string) => `Cannot read background folder: ${path}`
 
 export function useBackgroundFolder(): BackgroundFolderData {
   const defaultFolder = useAppStore((state) => state.defaultBackgroundFolder)
-  const [currentFolder, setCurrentFolder] = useState<string | null>(null)
+  const [sessionFolder, setSessionFolder] = useState<string | null>(null)
 
-  // Determine which folder to load (current folder takes precedence over default)
-  const folderToLoad = currentFolder || defaultFolder
+  // The store's folder is only ever hydrated as a side effect of loadApiKeys, so
+  // a null value alone cannot distinguish "not configured" from "not loaded yet"
+  // from "load failed". The settings query's status supplies that (#166 F1).
+  const { isPending: settingsPending, isError: settingsError } = useApiKeys()
 
-  const {
-    data: files = [],
-    isLoading,
-    refetch
-  } = useQuery({
-    queryKey: ['backgroundFolder', folderToLoad],
+  const folderInUse = sessionFolder || defaultFolder
+  const settingsKnown = !settingsPending && !settingsError
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.upload.backgroundFolder(folderInUse),
     queryFn: async () => {
-      if (!folderToLoad) return []
-
-      // listDirectory already filters for image files and returns sorted paths
-      return listDirectory(folderToLoad)
+      if (!folderInUse) return null
+      return listDirectory(folderInUse)
     },
-    enabled: !!folderToLoad
+    enabled: settingsKnown && !!folderInUse,
+    // A folder that is absent or denied will not become present within a retry
+    // window, and the shared default would spend ~7s of backoff before the user
+    // is told anything. Unexpected rejections surface at once too.
+    retry: false
   })
 
-  const loadFolder = useCallback(
-    async (folderPath: string) => {
-      setCurrentFolder(folderPath)
-      refetch()
-    },
-    [refetch]
-  )
+  if (data?.status === 'unreadable') {
+    logger.error(`Background folder unreadable (${folderInUse}): ${data.detail}`)
+  }
+
+  const { status, reason } = resolveState({
+    settingsPending,
+    settingsError,
+    folderInUse,
+    isLoading,
+    isError,
+    result: data ?? null
+  })
+
+  const loadFolder = useCallback(async (folderPath: string) => {
+    // The query key is derived from this, so changing it refetches. The old
+    // refetch() call here was a no-op against the previous key (#166).
+    setSessionFolder(folderPath)
+  }, [])
+
+  const useDefaultFolder = useCallback(() => {
+    setSessionFolder(null)
+  }, [])
 
   return {
-    files,
-    currentFolder: folderToLoad,
+    files: data?.status === 'ok' ? data.files : [],
+    status,
+    reason,
+    folderInUse,
+    defaultFolder,
+    isSessionOverride: sessionFolder !== null,
     isLoading,
     loadFolder,
-    defaultFolder
+    useDefaultFolder,
+    currentFolder: folderInUse
   }
+}
+
+/**
+ * Priority order matters: a problem we already know about is reported before a
+ * check that has not finished, and no state is claimed while its own check is
+ * still in flight.
+ */
+function resolveState({
+  settingsPending,
+  settingsError,
+  folderInUse,
+  isLoading,
+  isError,
+  result
+}: {
+  settingsPending: boolean
+  settingsError: boolean
+  folderInUse: string | null
+  isLoading: boolean
+  isError: boolean
+  result: Awaited<ReturnType<typeof listDirectory>> | null
+}): { status: BackgroundFolderStatus; reason: string | null } {
+  if (settingsError) return { status: 'settings-error', reason: REASONS.settingsError }
+  if (settingsPending) return { status: 'unknown', reason: null }
+  if (!folderInUse) return { status: 'not-configured', reason: REASONS.notConfigured }
+
+  // An unexpected rejection is still a folder we cannot read.
+  if (isError) return { status: 'cannot-read', reason: cannotReadReason(folderInUse) }
+  if (isLoading || !result) return { status: 'loading', reason: null }
+
+  if (result.status === 'missing' || result.status === 'unreadable') {
+    // The detail from `unreadable` is logged above, never shown: it is Tauri
+    // error text, not something a user can act on.
+    return { status: 'cannot-read', reason: cannotReadReason(folderInUse) }
+  }
+
+  if (result.files.length === 0) return { status: 'empty', reason: REASONS.empty }
+  return { status: 'ready', reason: null }
 }

--- a/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
+++ b/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
@@ -68,14 +68,28 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return React.createElement(QueryClientProvider, { client: queryClient }, children)
 }
 
-function renderPosterFrameHook(videoTitle = 'WBS - MSc - Managing Change') {
+/**
+ * A client whose default IS to retry, so a test asserting "did not retry"
+ * exercises the query's own `retry: false` rather than the harness's (#166).
+ */
+function retryingWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: 3, retryDelay: 1, gcTime: 0 } }
+  })
+  return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+function renderPosterFrameHook(
+  videoTitle = 'WBS - MSc - Managing Change',
+  hookWrapper = wrapper
+) {
   return renderHook(
     (props: { videoTitle: string }) =>
       usePosterFrameForUpload({
         projectPath: PROJECT_PATH,
         videoTitle: props.videoTitle
       }),
-    { initialProps: { videoTitle }, wrapper }
+    { initialProps: { videoTitle }, wrapper: hookWrapper }
   )
 }
 
@@ -196,10 +210,48 @@ describe('usePosterFrameForUpload - accurate unavailable reasons (#166)', () => 
     expect(result.current.available).toBe(false)
   })
 
+  it('b6_2_still_names_an_empty_folder_exactly', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'ok', files: [] })
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() =>
+      expect(result.current.unavailableReason).toBe(
+        'The background folder contains no image files.'
+      )
+    )
+  })
+
+  it('b6_4_gives_the_full_font_guidance_when_the_font_is_genuinely_absent', async () => {
+    vi.mocked(api.posterFrameFontAvailable).mockResolvedValue(false)
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() =>
+      expect(result.current.unavailableReason).toBe(
+        'Poster frame text requires Cabrito.otf in ~/Library/Fonts.'
+      )
+    )
+  })
+
+  it('b6_5_claims_no_font_reason_while_the_font_check_is_in_flight', async () => {
+    // Never resolves: the folder is fine, so only the font check is outstanding.
+    vi.mocked(api.posterFrameFontAvailable).mockReturnValue(
+      new Promise(() => {}) as never
+    )
+
+    const { result } = renderPosterFrameHook()
+
+    // Wait for the folder to resolve, then assert the font check stays silent.
+    await waitFor(() => expect(api.listDirectory).toHaveBeenCalled())
+    expect(result.current.unavailableReason).toBeNull()
+    expect(result.current.available).toBe(false)
+  })
+
   it('b6_6_does_not_retry_a_failed_font_check', async () => {
     vi.mocked(api.posterFrameFontAvailable).mockRejectedValue(new Error('probe failed'))
 
-    const { result } = renderPosterFrameHook()
+    const { result } = renderPosterFrameHook(undefined, retryingWrapper)
 
     await waitFor(() => expect(result.current.unavailableReason).not.toBeNull())
     expect(api.posterFrameFontAvailable).toHaveBeenCalledTimes(1)

--- a/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
+++ b/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
@@ -14,8 +14,10 @@ import { useAppStore } from '@shared/store'
 import * as api from '../api'
 import { usePosterFrameForUpload } from './usePosterFrameForUpload'
 
+// Issue #166: listDirectory returns a tagged result rather than a bare array,
+// so a missing folder is distinguishable from an empty one.
 vi.mock('../api', () => ({
-  listDirectory: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
   readFileAsBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getFontDir: vi.fn().mockResolvedValue('/fonts'),
   fileExists: vi.fn().mockResolvedValue(true),
@@ -30,6 +32,17 @@ vi.mock('../api', () => ({
     assets: { poster_frames: ['https://sproutvideo.com/custom-poster.jpg'] }
   })
 }))
+
+// useBackgroundFolder now reads the settings query's status so it can tell
+// "not configured" from "settings not loaded yet" from "settings unreadable"
+// (issue #166 B2.1-B2.3). Report settings as loaded unless a test says otherwise.
+vi.mock('@shared/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/hooks')>()
+  return {
+    ...actual,
+    useApiKeys: vi.fn(() => ({ isPending: false, isError: false, error: null }))
+  }
+})
 
 // The canvas export and the retry sleeps are the two pieces that cannot run in
 // jsdom; everything else in the internals module stays real.
@@ -78,7 +91,7 @@ beforeAll(() => {
 beforeEach(() => {
   localStorage.clear()
   useAppStore.setState({ defaultBackgroundFolder: '/backgrounds' })
-  vi.mocked(api.listDirectory).mockResolvedValue(BACKGROUNDS)
+  vi.mocked(api.listDirectory).mockResolvedValue({ status: 'ok', files: BACKGROUNDS })
   vi.mocked(api.posterFrameFontAvailable).mockResolvedValue(true)
   vi.mocked(api.setSproutPosterFrame).mockResolvedValue(undefined)
   vi.mocked(api.savePosterFrameCopy).mockResolvedValue(
@@ -128,13 +141,68 @@ describe('usePosterFrameForUpload - availability', () => {
   })
 
   it('b1_5_is_unavailable_when_the_background_folder_has_no_images', async () => {
-    vi.mocked(api.listDirectory).mockResolvedValue([])
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'ok', files: [] })
 
     const { result } = renderPosterFrameHook()
 
     // The gating checks resolve asynchronously — wait for the reason itself
     await waitFor(() => expect(result.current.unavailableReason).toMatch(/no image/i))
     expect(result.current.available).toBe(false)
+  })
+})
+
+describe('usePosterFrameForUpload - accurate unavailable reasons (#166)', () => {
+  it('b6_1_names_a_missing_folder_instead_of_claiming_it_is_empty', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({ status: 'missing' })
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() =>
+      expect(result.current.unavailableReason).toBe(
+        'Cannot read background folder: /backgrounds'
+      )
+    )
+    expect(result.current.unavailableReason).not.toMatch(/no image/i)
+    expect(result.current.available).toBe(false)
+  })
+
+  it('b6_1_names_an_unreadable_folder_the_same_way', async () => {
+    vi.mocked(api.listDirectory).mockResolvedValue({
+      status: 'unreadable',
+      detail: 'os error 13'
+    })
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() =>
+      expect(result.current.unavailableReason).toBe(
+        'Cannot read background folder: /backgrounds'
+      )
+    )
+    // The detail belongs in the log, not in front of the user.
+    expect(result.current.unavailableReason).not.toContain('os error 13')
+  })
+
+  it('b6_3_distinguishes_a_failed_font_check_from_an_absent_font', async () => {
+    vi.mocked(api.posterFrameFontAvailable).mockRejectedValue(new Error('probe failed'))
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() => expect(result.current.unavailableReason).not.toBeNull())
+    // Blaming a missing font for a check that never completed is the same
+    // misattribution as claiming an absent folder is empty.
+    expect(result.current.unavailableReason).toMatch(/could not check/i)
+    expect(result.current.unavailableReason).not.toMatch(/requires Cabrito/i)
+    expect(result.current.available).toBe(false)
+  })
+
+  it('b6_6_does_not_retry_a_failed_font_check', async () => {
+    vi.mocked(api.posterFrameFontAvailable).mockRejectedValue(new Error('probe failed'))
+
+    const { result } = renderPosterFrameHook()
+
+    await waitFor(() => expect(result.current.unavailableReason).not.toBeNull())
+    expect(api.posterFrameFontAvailable).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/features/Upload/hooks/usePosterFrameForUpload.ts
+++ b/src/features/Upload/hooks/usePosterFrameForUpload.ts
@@ -87,18 +87,24 @@ export function usePosterFrameForUpload({
 
   const text = ownText ?? titleToPosterFrameText(videoTitle)
 
-  const {
-    files: backgrounds,
-    currentFolder,
-    isLoading: backgroundsLoading
-  } = useBackgroundFolder()
-  const { selectedFilePath, selectedFileBlob, selectFile } = useFileSelection()
+  // The folder path itself is no longer needed here: the hook reports its own
+  // reason, already worded with the path in it (issue #166 B6.1).
+  const { files: backgrounds, reason: folderReason } = useBackgroundFolder()
+  const { selectedFilePath, selectedFileBlob, selectFile, clearSelection } =
+    useFileSelection()
   const { canvasRef, draw } = usePosterframeCanvas()
 
-  const { data: fontAvailable, isPending: fontCheckPending } = useQuery({
+  const {
+    data: fontAvailable,
+    isPending: fontCheckPending,
+    isError: fontCheckFailed
+  } = useQuery({
     queryKey: ['posterframe', 'font-available'],
     queryFn: posterFrameFontAvailable,
-    staleTime: Infinity
+    staleTime: Infinity,
+    // A missing font file is as deterministic as a missing folder, so retrying
+    // only delays the message (issue #166 B6.6).
+    retry: false
   })
 
   // Keep the preview in step with the chosen background and text (B4.2).
@@ -111,21 +117,31 @@ export function usePosterFrameForUpload({
     }
   }, [backgrounds, selectedFilePath, selectFile])
 
-  // Configuration problems are reported before the font check, and neither is
-  // claimed while its check is still in flight (B1.3-B1.5).
-  const unavailableReason = !currentFolder
-    ? 'No default background folder configured. Set one in Settings.'
-    : backgroundsLoading
-      ? null
-      : backgrounds.length === 0
-        ? 'The background folder contains no image files.'
-        : fontCheckPending
-          ? null
-          : !fontAvailable
-            ? 'Poster frame text requires Cabrito.otf in ~/Library/Fonts.'
-            : null
+  // Never hold a selection the folder no longer offers, or the dialog reports
+  // itself unavailable while still carrying a background (issue #166 B4.1).
+  useEffect(() => {
+    if (selectedFilePath && !backgrounds.includes(selectedFilePath)) {
+      clearSelection()
+    }
+  }, [backgrounds, selectedFilePath, clearSelection])
 
-  const available = unavailableReason === null && fontAvailable === true
+  // The folder hook already reports its own state, including which of "not
+  // configured", "cannot read" and "no images" applies; deriving it again from
+  // truthiness here is what made a missing folder report as empty (#166 B6.1).
+  // Font problems are reported only once the folder is known to be fine, and
+  // neither is claimed while its own check is in flight.
+  const unavailableReason =
+    folderReason ??
+    (fontCheckFailed
+      ? 'Could not check whether the poster frame font is installed.'
+      : fontCheckPending
+        ? null
+        : !fontAvailable
+          ? 'Poster frame text requires Cabrito.otf in ~/Library/Fonts.'
+          : null)
+
+  const available =
+    unavailableReason === null && fontAvailable === true && backgrounds.length > 0
 
   const setEnabled = useCallback((enabled: boolean) => {
     setPreferences((current) => {

--- a/src/shared/lib/query-keys.ts
+++ b/src/shared/lib/query-keys.ts
@@ -68,7 +68,10 @@ export const queryKeys = {
     configuration: () => ['settings', 'configuration'] as const,
     theme: () => ['settings', 'theme'] as const,
     integrations: () => ['settings', 'integrations'] as const,
-    apiKeys: () => ['settings', 'api-keys'] as const
+    apiKeys: () => ['settings', 'api-keys'] as const,
+    /** Whether the saved background folder is still on disk (issue #166). */
+    backgroundFolderPresent: (folderPath: string | null) =>
+      ['settings', 'background-folder-present', folderPath ?? 'none'] as const
   },
 
   // Sprout domain
@@ -89,6 +92,9 @@ export const queryKeys = {
     event: (eventId: string) => ['upload', 'event', eventId] as const,
     progress: (uploadId: string) => ['upload', 'progress', uploadId] as const,
     status: (uploadId: string) => ['upload', 'status', uploadId] as const,
+    /** Background folder listing, keyed on the folder being read (issue #166). */
+    backgroundFolder: (folderPath: string | null) =>
+      ['upload', 'background-folder', folderPath ?? 'none'] as const,
     sprout: {
       all: () => ['upload', 'sprout'] as const,
       video: (videoId: string) => ['upload', 'sprout', 'video', videoId] as const,

--- a/src/shared/ui/ApiKeyInput.tsx
+++ b/src/shared/ui/ApiKeyInput.tsx
@@ -9,6 +9,8 @@ type Props = {
   id?: string // Optional ID for label association
   inputType?: 'text' | 'password' // Allow specifying input type (default: password for API keys)
   placeholder?: string // Optional custom placeholder
+  /** Block saving, e.g. while the settings file cannot be read (issue #166). */
+  saveDisabled?: boolean
 }
 
 const ApiKeyInput: React.FC<Props> = ({
@@ -17,7 +19,8 @@ const ApiKeyInput: React.FC<Props> = ({
   onSave,
   id,
   inputType = 'password',
-  placeholder = 'Enter your API key...'
+  placeholder = 'Enter your API key...',
+  saveDisabled = false
 }) => {
   // State to track whether the API key should be visible
   const [showApiKey, setShowApiKey] = useState(false)
@@ -41,7 +44,7 @@ const ApiKeyInput: React.FC<Props> = ({
         {showApiKey ? 'Hide' : 'Show'}
       </Button>
       {/* Button to save the API key */}
-      <Button onClick={onSave} style={{ marginLeft: '8px' }}>
+      <Button onClick={onSave} disabled={saveDisabled} style={{ marginLeft: '8px' }}>
         Save
       </Button>
     </div>

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -79,6 +79,12 @@ export const loadApiKeys = async (): Promise<ApiKeys> => {
     return result
   } catch (error) {
     logger.error('Error loading API keys:', error)
-    return {}
+    // Rethrow, mirroring saveApiKeys above. Returning {} turned a failure into a
+    // success: every settings section rendered as never-configured and the
+    // Posterframe page claimed no background folder was set, while the file on
+    // disk was merely unreadable rather than lost (issue #166 B8.1). A genuinely
+    // absent file still returns {} at the exists() check above, because a first
+    // run is not a failure.
+    throw error
   }
 }

--- a/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
+++ b/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
@@ -1,0 +1,151 @@
+/**
+ * Posterframe background folder E2E fixture (issue #166)
+ *
+ * Installs a Tauri IPC mock that can put the background folder into each of the
+ * states the app must now tell apart: usable, absent, present-but-unreadable,
+ * present-but-empty, never configured, and unknown-because-settings-failed.
+ *
+ * Note the boundary this cannot cross: IPC is mocked, so nothing here proves
+ * that Tauri's real `readDir` rejects with `os error 2` for an absent directory,
+ * nor that a macOS TCC denial behaves as modelled. Those are covered by
+ * `docs/posterframe-background-verification.md`. The same limit applies to
+ * `sprout-folders.fixture.ts`, which documents it at its own header.
+ */
+import type { Page } from '@playwright/test'
+
+/** What the mocked filesystem should do with the configured background folder. */
+export type FolderScenario =
+  /** Folder exists and holds image files. */
+  | 'ready'
+  /** Folder is not on disk at all: `exists` reports false. */
+  | 'missing'
+  /** Folder exists but the listing rejects, as a permission denial would. */
+  | 'unreadable'
+  /** Folder exists and lists fine, but holds no images. */
+  | 'empty'
+
+export interface BackgroundMockOptions {
+  /** State of the configured folder. Ignored when `configured` is false. */
+  scenario?: FolderScenario
+  /** Whether api_keys.json carries a defaultBackgroundFolder at all. */
+  configured?: boolean
+  /** Make reading api_keys.json fail, so settings status is an error. */
+  settingsUnreadable?: boolean
+  /** The configured background folder path. */
+  folder?: string
+  /** Whether the Cabrito poster frame font should report as installed. */
+  fontInstalled?: boolean
+}
+
+export const DEFAULT_FOLDER = '/Users/e2e/Documents/backgrounds'
+export const IMAGE_NAMES = ['wbs-blue.jpg', 'wbs-red.png']
+export const NON_IMAGE_NAMES = ['notes.txt', 'script.md']
+
+/**
+ * Install the mock. Call before `page.goto`, since it runs as an init script.
+ */
+export async function installBackgroundMocks(
+  page: Page,
+  options: BackgroundMockOptions = {}
+): Promise<void> {
+  const config = {
+    scenario: options.scenario ?? 'ready',
+    configured: options.configured ?? true,
+    settingsUnreadable: options.settingsUnreadable ?? false,
+    folder: options.folder ?? DEFAULT_FOLDER,
+    fontInstalled: options.fontInstalled ?? true,
+    imageNames: IMAGE_NAMES,
+    nonImageNames: NON_IMAGE_NAMES
+  }
+
+  await page.addInitScript((cfg: typeof config) => {
+    const win = window as unknown as {
+      __TAURI_INTERNALS__?: { invoke: (cmd: string, args?: unknown) => Promise<unknown> }
+      __TAURI__?: unknown
+      /** Every folder listing the app attempted, so tests can assert absence. */
+      __backgroundListings__: string[]
+    }
+
+    win.__backgroundListings__ = []
+
+    const settings: Record<string, string> = { sproutVideo: 'e2e-sprout-key' }
+    if (cfg.configured) settings.defaultBackgroundFolder = cfg.folder
+
+    // plugin:fs|read_text_file returns BYTES, which the plugin then decodes.
+    // Returning a string here yields garbage after Uint8Array.from().
+    const settingsBytes = Array.from(new TextEncoder().encode(JSON.stringify(settings)))
+
+    const dirEntry = (name: string) => ({
+      name,
+      isFile: true,
+      isDirectory: false,
+      isSymlink: false
+    })
+
+    const invoke = async (cmd: string, args?: unknown): Promise<unknown> => {
+      const payload = (args ?? {}) as Record<string, unknown>
+      const path = String((payload.path as string) ?? '')
+
+      if (cmd === 'plugin:fs|exists') {
+        if (path.includes('sprout-folder-index')) return false
+        // The Cabrito font probe goes through the same exists() call.
+        if (path.toLowerCase().includes('cabrito')) return cfg.fontInstalled
+        if (path === cfg.folder) return cfg.scenario !== 'missing'
+        return true
+      }
+
+      if (cmd === 'plugin:fs|read_text_file') {
+        if (path.includes('sprout-folder-index')) throw 'not found'
+        if (cfg.settingsUnreadable) throw 'permission denied reading api_keys.json'
+        return settingsBytes
+      }
+
+      if (cmd === 'plugin:fs|read_dir') {
+        win.__backgroundListings__.push(path)
+        if (cfg.scenario === 'unreadable') throw 'forbidden (os error 13)'
+        if (cfg.scenario === 'empty') return cfg.nonImageNames.map(dirEntry)
+        return cfg.imageNames.map(dirEntry)
+      }
+
+      if (cmd === 'plugin:fs|read_file') return Array.from(new Uint8Array([1, 2, 3]))
+      if (cmd === 'plugin:fs|write_text_file') return null
+      if (cmd === 'plugin:fs|write_file') return null
+
+      if (cmd === 'plugin:dialog|open') return '/Volumes/Media/session-bgs'
+      if (cmd === 'plugin:dialog|save') return '/Users/e2e/Desktop'
+
+      if (cmd === 'get_username') return 'E2E User'
+      if (cmd === 'get_version') return '0.0.0-e2e'
+
+      if (cmd === 'tauri' && payload && typeof payload === 'object') {
+        const inner = (payload as { cmd?: string }).cmd
+        if (inner?.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+        return null
+      }
+
+      if (cmd.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+      if (cmd.startsWith('plugin:')) return null
+
+      return null
+    }
+
+    win.__TAURI_INTERNALS__ = {
+      invoke,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...({
+        metadata: {
+          windows: [{ label: 'main' }],
+          currentWindow: { label: 'main' }
+        }
+      } as any)
+    }
+    win.__TAURI__ = win.__TAURI_INTERNALS__
+  }, config)
+}
+
+/** Every folder path the app has tried to list, in order. */
+export async function attemptedListings(page: Page): Promise<string[]> {
+  return page.evaluate(
+    () => (window as unknown as { __backgroundListings__: string[] }).__backgroundListings__
+  )
+}

--- a/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
+++ b/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
@@ -35,7 +35,23 @@ export interface BackgroundMockOptions {
   folder?: string
   /** Whether the Cabrito poster frame font should report as installed. */
   fontInstalled?: boolean
+  /**
+   * Serve the Baker scan and video-link commands too, so a spec can walk
+   * Baker > project > Video Links and reach the poster frame dialogs. Off by
+   * default to keep the folder-only specs from paying for the scan mocks.
+   */
+  bakerJourney?: boolean
+  /**
+   * Whether the project already has a linked Sprout video. Needed to reach
+   * SetPosterFrameDialog, whose trigger is disabled without a Sprout id.
+   */
+  withLinkedVideo?: boolean
 }
+
+export const DRIVE_ROOT = '/Volumes/E2E-Drive'
+export const PROJECT_PATH = `${DRIVE_ROOT}/2026 Managing Change`
+export const PROJECT_NAME = '2026 Managing Change'
+export const LINKED_VIDEO_TITLE = 'Managing Change - Session 1'
 
 export const DEFAULT_FOLDER = '/Users/e2e/Documents/backgrounds'
 export const IMAGE_NAMES = ['wbs-blue.jpg', 'wbs-red.png']
@@ -54,8 +70,14 @@ export async function installBackgroundMocks(
     settingsUnreadable: options.settingsUnreadable ?? false,
     folder: options.folder ?? DEFAULT_FOLDER,
     fontInstalled: options.fontInstalled ?? true,
+    bakerJourney: options.bakerJourney ?? false,
+    withLinkedVideo: options.withLinkedVideo ?? false,
     imageNames: IMAGE_NAMES,
-    nonImageNames: NON_IMAGE_NAMES
+    nonImageNames: NON_IMAGE_NAMES,
+    driveRoot: DRIVE_ROOT,
+    projectPath: PROJECT_PATH,
+    projectName: PROJECT_NAME,
+    linkedVideoTitle: LINKED_VIDEO_TITLE
   }
 
   await page.addInitScript((cfg: typeof config) => {
@@ -64,9 +86,12 @@ export async function installBackgroundMocks(
       __TAURI__?: unknown
       /** Every folder listing the app attempted, so tests can assert absence. */
       __backgroundListings__: string[]
+      /** Monotonic id handed back for each event listener registration. */
+      __nextListenerId__: number
     }
 
     win.__backgroundListings__ = []
+    win.__nextListenerId__ = 1
 
     const settings: Record<string, string> = { sproutVideo: 'e2e-sprout-key' }
     if (cfg.configured) settings.defaultBackgroundFolder = cfg.folder
@@ -111,8 +136,92 @@ export async function installBackgroundMocks(
       if (cmd === 'plugin:fs|write_text_file') return null
       if (cmd === 'plugin:fs|write_file') return null
 
-      if (cmd === 'plugin:dialog|open') return '/Volumes/Media/session-bgs'
+      if (cmd === 'plugin:dialog|open') {
+        const opts = (payload.options ?? payload) as {
+          title?: string
+          directory?: boolean
+        }
+        // A file picker (not a directory one) is the Add Video upload flow.
+        if (!opts?.directory) return `${cfg.driveRoot}/clip.mp4`
+        // Baker's folder dialog passes a `title`; the Posterframe background
+        // picker does not. That is the only thing separating the two callers.
+        return opts?.title ? cfg.driveRoot : '/Volumes/Media/session-bgs'
+      }
       if (cmd === 'plugin:dialog|save') return '/Users/e2e/Desktop'
+
+      // Must be a numeric listener id: returning null makes the upload hook
+      // report "Failed to setup event listeners" and hide the whole panel.
+      // Events are never delivered here, only registered.
+      if (cmd === 'plugin:event|listen') return win.__nextListenerId__++
+      if (cmd === 'plugin:event|unlisten') return null
+
+      if (cmd === 'get_video_duration') return 120
+
+      if (cfg.bakerJourney) {
+        if (cmd === 'baker_start_scan') return 'scan-e2e-1'
+        if (cmd === 'baker_get_scan_status') {
+          // endTime present, so the hook's poll treats the scan as finished.
+          // Events are not mocked here; the poll is the documented fallback.
+          return {
+            startTime: '2026-08-11T10:00:00Z',
+            endTime: '2026-08-11T10:00:02Z',
+            rootPath: cfg.driveRoot,
+            totalFolders: 1,
+            validProjects: 1,
+            updatedBreadcrumbs: 0,
+            createdBreadcrumbs: 0,
+            totalFolderSize: 1024,
+            errors: [],
+            projects: [
+              {
+                path: cfg.projectPath,
+                name: cfg.projectName,
+                isValid: true,
+                hasBreadcrumbs: true,
+                staleBreadcrumbs: false,
+                invalidBreadcrumbs: false,
+                lastScanned: '2026-08-11T10:00:02Z',
+                cameraCount: 1,
+                validationErrors: [],
+                folderSizeBytes: 1024
+              }
+            ]
+          }
+        }
+        if (cmd === 'baker_get_video_links') {
+          if (!cfg.withLinkedVideo) return []
+          return [
+            {
+              url: 'https://sproutvideo.com/videos/abc123',
+              sproutVideoId: 'abc123',
+              title: cfg.linkedVideoTitle,
+              addedAt: '2026-08-11T09:00:00Z'
+            }
+          ]
+        }
+        if (cmd === 'baker_read_breadcrumbs') {
+          return {
+            projectTitle: cfg.projectName,
+            parentFolder: cfg.driveRoot,
+            cameras: [],
+            files: [],
+            videoLinks: cfg.withLinkedVideo
+              ? [
+                  {
+                    url: 'https://sproutvideo.com/videos/abc123',
+                    sproutVideoId: 'abc123',
+                    title: cfg.linkedVideoTitle,
+                    addedAt: '2026-08-11T09:00:00Z'
+                  }
+                ]
+              : []
+          }
+        }
+        if (cmd === 'baker_read_raw_breadcrumbs') return null
+        if (cmd === 'baker_scan_current_files') return []
+        if (cmd === 'baker_get_trello_cards') return []
+        if (cmd === 'get_folder_size') return 1024
+      }
 
       if (cmd === 'get_username') return 'E2E User'
       if (cmd === 'get_version') return '0.0.0-e2e'

--- a/tests/e2e/specs/posterframe-backgrounds.spec.ts
+++ b/tests/e2e/specs/posterframe-backgrounds.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../fixtures/posterframe-backgrounds.fixture'
 
 const POSTERFRAME_ROUTE = '/upload/posterframe'
-const SETTINGS_BACKGROUNDS_ROUTE = '/settings/backgrounds'
+const SETTINGS_BACKGROUNDS_ROUTE = '/settings/general#backgrounds'
 
 test.describe('Posterframe page', () => {
   test('names the folder it cannot read and keeps the picker available', async ({
@@ -158,29 +158,17 @@ test.describe('Settings > Backgrounds', () => {
   })
 })
 
-test.describe('Sprout upload poster frame', () => {
-  test('reports a missing folder rather than an empty one', async ({ page }) => {
-    await installBackgroundMocks(page, { scenario: 'missing' })
-    await page.goto('/upload/sprout')
-
-    await expect(
-      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
-    ).toBeVisible()
-    await expect(page.getByText(/contains no image files/i)).toBeHidden()
-  })
-
-  test('reports an empty folder as empty', async ({ page }) => {
-    await installBackgroundMocks(page, { scenario: 'empty' })
-    await page.goto('/upload/sprout')
-
-    await expect(page.getByText(/contains no image files/i)).toBeVisible()
-  })
-
-  test('distinguishes a missing font from a folder problem', async ({ page }) => {
-    await installBackgroundMocks(page, { scenario: 'ready', fontInstalled: false })
-    await page.goto('/upload/sprout')
-
-    await expect(page.getByText(/Cabrito/i)).toBeVisible()
-    await expect(page.getByText(/cannot read background folder/i)).toBeHidden()
-  })
-})
+/*
+ * The poster frame upload dialog (B6.1-B6.6) is deliberately NOT covered here.
+ *
+ * usePosterFrameForUpload is consumed by Baker's AddVideoDialog and
+ * SetPosterFrameDialog and by Trello's useCardPosterFrame -- not by
+ * /upload/sprout -- so reaching it end to end means driving a drive scan,
+ * project selection and dialog open, which needs the Baker scan fixtures rather
+ * than these filesystem ones.
+ *
+ * B6 is covered instead at:
+ *   - hook level, usePosterFrameForUpload.test.ts (b6_1, b6_3, b6_6)
+ *   - render level, Baker/components/SetPosterFrameDialog.test.tsx (b4_1-b4_3)
+ *   - by hand, docs/posterframe-background-verification.md
+ */

--- a/tests/e2e/specs/posterframe-backgrounds.spec.ts
+++ b/tests/e2e/specs/posterframe-backgrounds.spec.ts
@@ -126,15 +126,15 @@ test.describe('Settings > Backgrounds', () => {
     await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
 
     await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
-    await expect(page.getByText(/no longer exists/i)).toBeHidden()
+    await expect(page.getByText(/cannot read this folder/i)).toBeHidden()
   })
 
-  test('flags a path that no longer exists', async ({ page }) => {
+  test('flags a path it cannot read', async ({ page }) => {
     await installBackgroundMocks(page, { scenario: 'missing' })
     await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
 
     await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
-    await expect(page.getByText(/no longer exists on this machine/i)).toBeVisible()
+    await expect(page.getByText(/bucket cannot read this folder/i)).toBeVisible()
   })
 
   test('banners a settings read failure and disables saving', async ({ page }) => {
@@ -168,7 +168,13 @@ test.describe('Settings > Backgrounds', () => {
  * than these filesystem ones.
  *
  * B6 is covered instead at:
- *   - hook level, usePosterFrameForUpload.test.ts (b6_1, b6_3, b6_6)
- *   - render level, Baker/components/SetPosterFrameDialog.test.tsx (b4_1-b4_3)
+ *   - hook level, usePosterFrameForUpload.test.ts (b6_1 to b6_6)
+ *   - render level, Baker/components/SetPosterFrameDialog.test.tsx (b6_1, b6_3).
+ *     The b4_* cases in that file belong to issue #141 and assert the older
+ *     reason strings, so they do not cover this change on their own.
  *   - by hand, docs/posterframe-background-verification.md
+ *
+ * Still uncovered end to end: that Baker's AddVideoDialog and Trello's
+ * useCardPosterFrame surface the reason in a real browser. Both render the same
+ * panel state as SetPosterFrameDialog, so the render tests carry it.
  */

--- a/tests/e2e/specs/posterframe-backgrounds.spec.ts
+++ b/tests/e2e/specs/posterframe-backgrounds.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E: background folder diagnostics across the three surfaces that consume it.
+ * Issue #166
+ *
+ * The reported bug was that a configured-but-absent folder was indistinguishable
+ * from no configuration at all. These specs drive each state through the real UI
+ * and assert what the user is actually told.
+ *
+ * IPC is mocked, so the real-filesystem behaviour these states model is verified
+ * by hand per docs/posterframe-background-verification.md.
+ */
+import { expect, test } from '@playwright/test'
+
+import {
+  DEFAULT_FOLDER,
+  attemptedListings,
+  installBackgroundMocks
+} from '../fixtures/posterframe-backgrounds.fixture'
+
+const POSTERFRAME_ROUTE = '/upload/posterframe'
+const SETTINGS_BACKGROUNDS_ROUTE = '/settings/backgrounds'
+
+test.describe('Posterframe page', () => {
+  test('names the folder it cannot read and keeps the picker available', async ({
+    page
+  }) => {
+    await installBackgroundMocks(page, { scenario: 'missing' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(
+      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /select background folder/i })
+    ).toBeEnabled()
+    // The old failure mode: an empty picker and no explanation at all.
+    await expect(page.getByText(/contains no image files/i)).toBeHidden()
+  })
+
+  test('gives the same message for a folder it cannot list', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'unreadable' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(
+      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeVisible()
+    // The os error detail belongs in the log, not on screen.
+    await expect(page.getByText(/os error 13/i)).toBeHidden()
+  })
+
+  test('explains a folder that holds no images', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'empty' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(page.getByText(/contains no image files/i)).toBeVisible()
+  })
+
+  test('explains that no folder is configured', async ({ page }) => {
+    await installBackgroundMocks(page, { configured: false })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(page.getByText(/no default background folder configured/i)).toBeVisible()
+    // Nothing to list, so nothing should have been attempted.
+    expect(await attemptedListings(page)).toEqual([])
+  })
+
+  test('says the folder is unknown when settings could not be read', async ({ page }) => {
+    await installBackgroundMocks(page, { settingsUnreadable: true })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(page.getByText(/could not read your settings/i)).toBeVisible()
+    // Must not claim nothing is configured: that is the contradiction #166 fixed.
+    await expect(page.getByText(/no default background folder configured/i)).toBeHidden()
+  })
+
+  test('recovers for the session via the picker, leaving the default alone', async ({
+    page
+  }) => {
+    await installBackgroundMocks(page, { scenario: 'missing' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(
+      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeVisible()
+    await page.getByRole('button', { name: /select background folder/i }).click()
+
+    // The dialog mock returns /Volumes/Media/session-bgs, which lists fine.
+    await expect(page.getByText('/Volumes/Media/session-bgs')).toBeVisible()
+    await expect(page.getByRole('button', { name: /use default/i })).toBeVisible()
+
+    // The stored default is untouched, so Settings still shows it.
+    await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
+    await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
+  })
+
+  test('returns to the configured default when the override is reset', async ({
+    page
+  }) => {
+    await installBackgroundMocks(page, { scenario: 'ready' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await page.getByRole('button', { name: /select background folder/i }).click()
+    await expect(page.getByRole('button', { name: /use default/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /use default/i }).click()
+
+    await expect(page.getByRole('button', { name: /use default/i })).toBeHidden()
+    await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
+  })
+
+  test('shows no preview for a folder it is warning about', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'unreadable' })
+    await page.goto(POSTERFRAME_ROUTE)
+
+    await expect(
+      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeVisible()
+    await expect(page.getByText(/select a background to preview/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /generate thumbnail/i })).toBeDisabled()
+  })
+})
+
+test.describe('Settings > Backgrounds', () => {
+  test('shows a live path with no warning', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'ready' })
+    await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
+
+    await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
+    await expect(page.getByText(/no longer exists/i)).toBeHidden()
+  })
+
+  test('flags a path that no longer exists', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'missing' })
+    await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
+
+    await expect(page.getByText(DEFAULT_FOLDER)).toBeVisible()
+    await expect(page.getByText(/no longer exists on this machine/i)).toBeVisible()
+  })
+
+  test('banners a settings read failure and disables saving', async ({ page }) => {
+    await installBackgroundMocks(page, { settingsUnreadable: true })
+    await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
+
+    await expect(page.getByText(/could not read your saved settings/i)).toBeVisible()
+    // Sections still render, but must not overwrite a merely unparseable file.
+    await expect(page.getByRole('heading', { name: /^backgrounds$/i })).toBeVisible()
+    for (const save of await page.getByRole('button', { name: /^save$/i }).all()) {
+      await expect(save).toBeDisabled()
+    }
+  })
+
+  test('shows no banner on a first run with no settings file', async ({ page }) => {
+    await installBackgroundMocks(page, { configured: false })
+    await page.goto(SETTINGS_BACKGROUNDS_ROUTE)
+
+    await expect(page.getByRole('heading', { name: /^backgrounds$/i })).toBeVisible()
+    await expect(page.getByText(/could not read your saved settings/i)).toBeHidden()
+  })
+})
+
+test.describe('Sprout upload poster frame', () => {
+  test('reports a missing folder rather than an empty one', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'missing' })
+    await page.goto('/upload/sprout')
+
+    await expect(
+      page.getByText(`Cannot read background folder: ${DEFAULT_FOLDER}`)
+    ).toBeVisible()
+    await expect(page.getByText(/contains no image files/i)).toBeHidden()
+  })
+
+  test('reports an empty folder as empty', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'empty' })
+    await page.goto('/upload/sprout')
+
+    await expect(page.getByText(/contains no image files/i)).toBeVisible()
+  })
+
+  test('distinguishes a missing font from a folder problem', async ({ page }) => {
+    await installBackgroundMocks(page, { scenario: 'ready', fontInstalled: false })
+    await page.goto('/upload/sprout')
+
+    await expect(page.getByText(/Cabrito/i)).toBeVisible()
+    await expect(page.getByText(/cannot read background folder/i)).toBeHidden()
+  })
+})

--- a/tests/e2e/specs/posterframe-baker-journey.spec.ts
+++ b/tests/e2e/specs/posterframe-baker-journey.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * E2E: the poster frame dialogs reached the way a user reaches them.
+ * Issue #166 (B6.1-B6.4)
+ *
+ * usePosterFrameForUpload is consumed by Baker's AddVideoDialog and
+ * SetPosterFrameDialog, not by /upload/sprout, so proving those surfaces report
+ * the right cause means walking Baker: pick a drive, scan, open a project, then
+ * open the dialog. The folder-only states live in posterframe-backgrounds.spec.ts;
+ * this file exists to prove the reason survives the journey to the dialog.
+ *
+ * IPC is mocked, so this proves wiring and not real filesystem semantics. See
+ * docs/posterframe-background-verification.md for the manual steps.
+ *
+ * Two kinds of test live here, and it matters which is which:
+ *
+ *   Proves the fix. Asserts a string that does not exist before this change
+ *   ("Cannot read background folder", "Could not read your settings"), so it
+ *   fails against the unfixed code. These are the cannot-read and
+ *   settings-unreadable cases.
+ *
+ *   Guards preserved behaviour. Asserts the empty-folder and absent-font
+ *   messages, which are unchanged (B6.2, B6.4), so it passes before and after.
+ *   Its value is catching this change breaking a path it was not meant to
+ *   touch, not demonstrating the fix. Do not read it as evidence of one.
+ */
+import { expect, test, type Page } from '@playwright/test'
+
+import {
+  DEFAULT_FOLDER,
+  LINKED_VIDEO_TITLE,
+  PROJECT_NAME,
+  installBackgroundMocks,
+  type BackgroundMockOptions
+} from '../fixtures/posterframe-backgrounds.fixture'
+
+const CANNOT_READ = `Cannot read background folder: ${DEFAULT_FOLDER}`
+
+/**
+ * Walk Baker as far as the selected project's detail panel.
+ *
+ * The scan completes through useBakerScan's 2s status poll rather than an
+ * emitted event, so the project list is deliberately awaited generously.
+ */
+async function openProject(page: Page, options: BackgroundMockOptions) {
+  await installBackgroundMocks(page, { ...options, bakerJourney: true })
+  await page.goto('/ingest/baker')
+
+  // Pick the drive. The mock returns a root path for any titled folder dialog.
+  await page.getByRole('button', { name: /select|choose|browse/i }).first().click()
+
+  await page
+    .getByRole('button', { name: /^(start )?scan/i })
+    .first()
+    .click()
+
+  // Poll-driven completion: the project appears once the scan reports endTime.
+  await expect(page.getByText(PROJECT_NAME).first()).toBeVisible({ timeout: 20000 })
+  await page.getByText(PROJECT_NAME).first().click()
+
+  // The detail panel opens on Overview; VideoLinksManager lives behind Videos.
+  await page.getByRole('tab', { name: /^videos/i }).click()
+
+  await expect(page.getByRole('heading', { name: /video links/i })).toBeVisible({
+    timeout: 15000
+  })
+}
+
+/**
+ * Open the upload tab and pick a file, because the poster frame panel only
+ * renders once a file is selected (AddVideoDialog.tsx:528).
+ */
+async function openUploadTabWithFile(page: Page) {
+  await page.getByRole('tab', { name: /upload file/i }).click()
+  await page.getByRole('button', { name: /select video file/i }).click()
+  // The panel appears with the file; its heading is the checkbox label.
+  await expect(page.getByText(/create branded poster frame/i)).toBeVisible({
+    timeout: 15000
+  })
+}
+
+test.describe('Baker > Add Video dialog', () => {
+  test('names a background folder it cannot read, and blocks the option', async ({
+    page
+  }) => {
+    await openProject(page, { scenario: 'missing' })
+
+    await page.getByRole('button', { name: /^add video$/i }).first().click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await openUploadTabWithFile(page)
+
+    await expect(page.getByText(CANNOT_READ)).toBeVisible()
+    // The pre-fix bug: this said "contains no image files" for an absent folder.
+    await expect(page.getByText(/contains no image files/i)).toBeHidden()
+    await expect(
+      page.getByRole('checkbox', { name: /create branded poster frame/i })
+    ).toBeDisabled()
+  })
+
+  // Regression guard: passes before this change too (B6.2 unchanged).
+  test('reports an empty folder as empty, not as unreadable', async ({ page }) => {
+    await openProject(page, { scenario: 'empty' })
+
+    await page.getByRole('button', { name: /^add video$/i }).first().click()
+    await openUploadTabWithFile(page)
+
+    await expect(page.getByText(/contains no image files/i)).toBeVisible()
+    await expect(page.getByText(/cannot read background folder/i)).toBeHidden()
+  })
+
+  // Regression guard: passes before this change too (B6.4 unchanged).
+  test('blames the font, not the folder, when only the font is absent', async ({
+    page
+  }) => {
+    await openProject(page, { scenario: 'ready', fontInstalled: false })
+
+    await page.getByRole('button', { name: /^add video$/i }).first().click()
+    await openUploadTabWithFile(page)
+
+    await expect(page.getByText(/requires Cabrito\.otf/i)).toBeVisible()
+    await expect(page.getByText(/cannot read background folder/i)).toBeHidden()
+  })
+
+  // Regression guard: the happy path must survive the new gating.
+  test('offers the option with no warning when everything is present', async ({
+    page
+  }) => {
+    await openProject(page, { scenario: 'ready' })
+
+    await page.getByRole('button', { name: /^add video$/i }).first().click()
+    await openUploadTabWithFile(page)
+
+    await expect(
+      page.getByRole('checkbox', { name: /create branded poster frame/i })
+    ).toBeEnabled()
+    await expect(page.getByText(/cannot read background folder/i)).toBeHidden()
+    await expect(page.getByText(/contains no image files/i)).toBeHidden()
+  })
+})
+
+test.describe('Baker > Set poster frame dialog', () => {
+  test('names a background folder it cannot read, and disables the action', async ({
+    page
+  }) => {
+    await openProject(page, { scenario: 'missing', withLinkedVideo: true })
+
+    await expect(page.getByText(LINKED_VIDEO_TITLE)).toBeVisible()
+    await page.getByRole('button', { name: /^set poster frame$/i }).first().click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText(CANNOT_READ)).toBeVisible()
+    await expect(dialog.getByText(/contains no image files/i)).toBeHidden()
+    await expect(
+      dialog.getByRole('button', { name: /^set poster frame$/i })
+    ).toBeDisabled()
+  })
+
+  test('says the folder is unknown when settings could not be read', async ({ page }) => {
+    await openProject(page, { settingsUnreadable: true, withLinkedVideo: true })
+
+    await page.getByRole('button', { name: /^set poster frame$/i }).first().click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText(/could not read your settings/i)).toBeVisible()
+    // Must not send the user to Settings to re-enter a path that is already set.
+    await expect(
+      dialog.getByText(/no default background folder configured/i)
+    ).toBeHidden()
+  })
+})

--- a/tests/integration/us06-sprout-upload.test.ts
+++ b/tests/integration/us06-sprout-upload.test.ts
@@ -30,7 +30,9 @@ vi.mock('../../src/features/Upload/api', () => ({
   openFolderDialog: vi.fn().mockResolvedValue(null),
   saveFile: vi.fn().mockResolvedValue(undefined),
   readFileAsBytes: vi.fn().mockResolvedValue(new Uint8Array()),
-  listDirectory: vi.fn().mockResolvedValue([]),
+  // Tagged result since issue #166: a bare array would be read as a missing
+  // `status` and misclassify inside the test rather than failing loudly.
+  listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
   getFontDir: vi.fn().mockResolvedValue('/mock/fonts'),
   fileExists: vi.fn().mockResolvedValue(false),
   openFolder: vi.fn().mockResolvedValue(undefined)

--- a/tests/unit/utils/storage.test.ts
+++ b/tests/unit/utils/storage.test.ts
@@ -205,22 +205,30 @@ describe('storage utility', () => {
       expect(result.trelloBoardId).toBeUndefined()
     })
 
-    it('should handle file read errors gracefully', async () => {
+    // Issue #166 B8.1: these two previously asserted `return {}`. Swallowing a
+    // read failure reported "nothing configured" for a file that was merely
+    // unreadable, so every settings section rendered blank and the Posterframe
+    // page claimed no folder was set. saveApiKeys was hardened the same way for
+    // issue #155 P5-b; this is the read side of that fix.
+    it('b8_1_rethrows_when_the_file_exists_but_cannot_be_read', async () => {
       vi.mocked(tauriFs.exists).mockResolvedValue(true)
       vi.mocked(tauriFs.readTextFile).mockRejectedValue(new Error('Read error'))
 
-      const result = await loadApiKeys()
-
-      expect(result).toEqual({})
+      await expect(loadApiKeys()).rejects.toThrow('Read error')
     })
 
-    it('should handle malformed JSON gracefully', async () => {
+    it('b8_1_rethrows_when_the_file_holds_malformed_json', async () => {
       vi.mocked(tauriFs.exists).mockResolvedValue(true)
       vi.mocked(tauriFs.readTextFile).mockResolvedValue('invalid json {')
 
-      const result = await loadApiKeys()
+      await expect(loadApiKeys()).rejects.toThrow()
+    })
 
-      expect(result).toEqual({})
+    it('b8_2_still_resolves_empty_when_the_file_does_not_exist', async () => {
+      vi.mocked(tauriFs.exists).mockResolvedValue(false)
+
+      // First run is not a failure: absent is distinct from unreadable.
+      await expect(loadApiKeys()).resolves.toEqual({})
     })
   })
 


### PR DESCRIPTION
Closes #166.

A `defaultBackgroundFolder` that no longer resolved was indistinguishable from one that was never configured. Four swallow layers stacked on the same path, so the failure produced no diagnostic anywhere: the Posterframe page looked like a first run, Settings printed the dead path as valid, and the Sprout dialog blamed an empty folder for one that was not there.

Sections below mirror the issue's behaviour areas so implementation can be checked against spec.

## B1 - Folder classification (`Upload/api.ts`)

`listDirectory` returns a tagged result instead of throwing:

```ts
type BackgroundFolderResult =
  | { status: 'ok'; files: string[] }
  | { status: 'missing' }
  | { status: 'unreadable'; detail: string }
```

An `exists()` probe classifies rather than matching `readDir`'s rejection text, which is unversioned and locale-sensitive: the same brittleness as the `includes('4')` retry heuristic flagged in #156. A probe that itself throws classifies as `unreadable`, because a check that cannot run is not evidence of absence.

## B2, B3 - Hook state and session override (`useBackgroundFolder`)

Seven explicit states replace "an empty array means everything". The hook now reads the settings query's status, because the store's folder is only ever hydrated as a side effect of `loadApiKeys`: a null value alone could not tell "not configured" from "not loaded yet" from "load failed". Without this, a corrupt settings file would have left Posterframe and Settings contradicting each other.

`missing` and `unreadable` share one message, worded to be true either way; the detail goes to `logger` only. `retry: false`, because an absent or denied folder will not appear within a retry window and the shared default spent roughly 7s of backoff before the user was told anything.

Session picks are now exposed separately from the default with a reset control. Previously `session || default` left no route back to the configured folder for the rest of the session.

Also removed a `refetch()` that was a no-op: `setCurrentFolder` changed the query key, so the refetch targeted the old one.

## B4, B5 - Posterframe page

Shows which folder is in use, warns with the path when it cannot be read, and clears a selection the resolved listing no longer contains. Rendering a preview from a folder the page is simultaneously warning about was exactly the mixed message this fix removes.

## B6 - Sprout upload dialog

Takes the folder hook's reason instead of re-deriving it from truthiness, which is what made a missing folder report as empty. A font check that *throws* is now distinguished from a font that is genuinely absent, and no longer retries.

## B7, B8 - Settings

`BackgroundsSection` flags a saved path it cannot read, without touching the stored value: folders come back when a drive is remounted, so auto-clearing would destroy working configuration.

`loadApiKeys` rethrows on a read or parse failure, mirroring what `saveApiKeys` already did for #155 P5-b. An absent file still resolves `{}`, so a first run stays quiet. `SettingsPage` banners the failure and **disables saving in every section**: each section writes `{...apiKeys, ...newKeys}` over the `{}` fallback, so a single save would overwrite a merely unparseable file and destroy the Sprout key and Trello token still sitting in it.

## Testing evidence

Red before green, in separate commits:

| Commit | State |
|---|---|
| `ad84ee3` | tests only, 56 failing |
| `59944bc` | implementation, 2687 passing |
| `900f6c6` | review fixes, 2692 passing |

The red commit is checkoutable: the suite fails there, so the sequence does not rest on my say-so.

- **Unit and component:** 2692 pass, 178 files. Clean-tree baseline was 2644, so 48 net new.
- **E2E:** 12 pass via `bun run test:e2e:posterframe`. A new `projects` entry was required in `playwright.config.ts`; without it a spec matching no existing `testMatch` silently never runs.
- **Build:** clean.
- **Lint:** 0 errors, 19 warnings, matching the clean-tree baseline exactly.
- **`tsc --noEmit`** fails on a stale `jest` types reference in tsconfig. Pre-existing and identical on `master`; not touched here.

Four files stubbed `listDirectory` as a bare array and would have misclassified inside the tests without failing loudly. All updated.

## Adversarial review round

A review agent was run against the full diff before this PR opened. Verdict: NEEDS CHANGES. Findings and resolutions:

- **Blocker.** `logger.error` sat in the render body, so any unrelated re-render logged the same failure again. Moved to an effect.
- **Substantive.** Settings and Posterframe described the same condition differently: `directoryExists` returns false when the probe throws, so Settings asserted "no longer exists" for a folder that exists but is forbidden. That repeats the misattribution this PR removes, so the copy is now "Bucket cannot read this folder", true for absence and denial alike. This changed a string agreed during specification; recorded as an amendment on #166.
- **Substantive.** `b2_9` and `b6_6` claimed to prove `retry: false` but could not fail, because the test client already disabled retries. Both now use a retrying client. Verified by removing the production override and confirming `b2_9` fails.
- **Substantive.** An e2e comment claimed B6 was covered by `SetPosterFrameDialog`'s `b4_*` tests. Those belong to #141 and assert the older strings. Added `b6_1` and `b6_3` render tests and corrected the comment.
- **Minor.** B6.2, B6.4 and B6.5 lacked direct assertions. Added exact-message tests plus one proving no font reason is claimed while that check is in flight.

## Notes for review

- **B6 has no end-to-end coverage.** `usePosterFrameForUpload` is consumed by Baker's `AddVideoDialog` and `SetPosterFrameDialog` and by Trello's `useCardPosterFrame`, not by `/upload/sprout`, so reaching it in a browser means driving a drive scan, project selection and dialog open with the Baker scan fixtures. B6 is covered at hook and render level instead, and by hand. Documented in the spec file rather than left implicit. Happy to add the Baker journey if you want it.
- **`available` now includes `backgrounds.length > 0`.** Previously `unavailableReason === null && fontAvailable === true` could in principle be true with no backgrounds. No test regressed, but it is a behaviour tightening worth a look.
- **The `settings` retry strategy retries a read or parse failure once after 500ms** (`query-utils.ts:179-184`), so the banner is intentionally about half a second late. Two tests wait past it rather than change the policy, which felt out of scope. Say the word if you would rather it were immediate, as the folder query now is.
- **`directoryExists` returns false on a thrown probe**, collapsing "absent" and "unprobeable" in Settings. Deliberate, and the copy no longer overstates it, but Settings genuinely knows less than Posterframe here.
- **IPC is mocked in e2e**, so nothing automated proves Tauri's real `readDir` rejects with `os error 2`, nor that a TCC denial behaves as modelled. `docs/posterframe-background-verification.md` covers those by hand, following the boundary `sprout-folders.fixture.ts` already documents.
- **No version bump.** Version changes look to be their own commits in this repo (`2b5bb42`), so I left it alone.

## Follow-ups filed from the accompanying audit

Not fixed here, deliberately:

- #167 `appDataDir()` joined by concatenation, so settings land *beside* the app data directory. Needs a migration, which does not belong in a diagnostic fix. A second instance found at `Upload/api.ts:225`.
- #168 Stale stored paths rendered as current across Baker and Trello, and propagated into Trello cards as authoritative "Location".
- #169 Default Sprout upload folder never validated against the live account.
