### PR TITLE
fix(storage): join app data paths and migrate misplaced settings files

### DIFF
--- a/src/features/Upload/__contracts__/api.appDataPath.test.ts
+++ b/src/features/Upload/__contracts__/api.appDataPath.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Folder index and poster-frame font paths are joined, not concatenated
+ * (issue #167).
+ *
+ * folderIndexPath built `${await appDataDir()}${FOLDER_INDEX_FILE}`, so the
+ * 122 KB index landed beside the app data directory. The font path hardcoded a
+ * separator after fontDir(). Both now go through join, and the index migrates.
+ *
+ * Behaviour IDs refer to issue #167.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appDataDirMock, fontDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock, readTextFileMock, writeTextFileMock } =
+  vi.hoisted(() => ({
+    appDataDirMock: vi.fn(),
+    fontDirMock: vi.fn(),
+    joinMock: vi.fn(),
+    existsMock: vi.fn(),
+    statMock: vi.fn(),
+    renameMock: vi.fn(),
+    removeMock: vi.fn(),
+    mkdirMock: vi.fn(),
+    readTextFileMock: vi.fn(),
+    writeTextFileMock: vi.fn()
+  }))
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: appDataDirMock,
+  fontDir: fontDirMock,
+  join: joinMock
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: existsMock,
+  stat: statMock,
+  rename: renameMock,
+  remove: removeMock,
+  mkdir: mkdirMock,
+  readDir: vi.fn(),
+  readFile: vi.fn(),
+  readTextFile: readTextFileMock,
+  writeFile: vi.fn(),
+  writeTextFile: writeTextFileMock
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn(), save: vi.fn() }))
+
+const DIR = '/mock/app/data'
+const CORRECT = '/mock/app/data/sprout-folder-index.json'
+const MISPLACED = '/mock/app/datasprout-folder-index.json'
+const FONTS = '/mock/fonts'
+const FONT_PATH = '/mock/fonts/Cabrito.otf'
+
+const INDEX = JSON.stringify({ folders: [{ id: 'f1', name: 'Marketing' }] })
+
+function present(...paths: string[]) {
+  existsMock.mockImplementation((p: string) => Promise.resolve(paths.includes(p)))
+}
+
+async function freshSession() {
+  vi.resetModules()
+  return import('../api')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  appDataDirMock.mockResolvedValue(DIR)
+  fontDirMock.mockResolvedValue(FONTS)
+  joinMock.mockImplementation((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
+  statMock.mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false })
+  renameMock.mockResolvedValue(undefined)
+  removeMock.mockResolvedValue(undefined)
+  mkdirMock.mockResolvedValue(undefined)
+  writeTextFileMock.mockResolvedValue(undefined)
+  readTextFileMock.mockResolvedValue(INDEX)
+})
+
+describe('folder index path (#167 B1, B2)', () => {
+  it('b1_2_joins_the_directory_and_filename_as_separate_arguments', async () => {
+    present(DIR, CORRECT)
+    const { readFolderIndex } = await freshSession()
+
+    await readFolderIndex()
+
+    expect(joinMock).toHaveBeenCalledWith(DIR, 'sprout-folder-index.json')
+  })
+
+  it('b1_2_writes_inside_the_directory_rather_than_beside_it', async () => {
+    present(DIR)
+    const { writeFolderIndex } = await freshSession()
+
+    await writeFolderIndex({ folders: [] })
+
+    const [target] = writeTextFileMock.mock.calls[0]
+    expect(target).toBe(CORRECT)
+    expect(target).not.toBe(MISPLACED)
+  })
+
+  it('b2_2_migrates_a_misplaced_index_and_returns_it_rather_than_null', async () => {
+    present(DIR, MISPLACED)
+    const { readFolderIndex } = await freshSession()
+
+    const index = await readFolderIndex()
+
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+    expect(index).toEqual({ folders: [{ id: 'f1', name: 'Marketing' }] })
+  })
+})
+
+describe('folder index failure handling (#167 B5)', () => {
+  it('b5_5_returns_null_rather_than_throwing_when_the_migration_fails', async () => {
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValue(new Error('EACCES'))
+    readTextFileMock.mockRejectedValue(new Error('unreadable'))
+    const { readFolderIndex } = await freshSession()
+
+    await expect(readFolderIndex()).resolves.toBeNull()
+    // Asserted so this cannot pass against the unfixed code, which never
+    // attempts a move and returns null for unrelated reasons.
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+  })
+
+  it('b5_5_writeFolderIndex_still_rejects_on_a_genuine_write_failure', async () => {
+    present(DIR)
+    writeTextFileMock.mockRejectedValue(new Error('disk full'))
+    const { writeFolderIndex } = await freshSession()
+
+    await expect(writeFolderIndex({ folders: [] })).rejects.toThrow(/disk full/)
+  })
+})
+
+describe('poster frame font path (#167 B1)', () => {
+  it('b1_3_joins_the_font_directory_and_filename_as_separate_arguments', async () => {
+    present(FONT_PATH)
+    const { posterFrameFontAvailable } = await freshSession()
+
+    const available = await posterFrameFontAvailable()
+
+    expect(joinMock).toHaveBeenCalledWith(FONTS, 'Cabrito.otf')
+    expect(existsMock).toHaveBeenCalledWith(FONT_PATH)
+    expect(available).toBe(true)
+  })
+
+  it('b1_4_exposes_one_font_path_helper_so_loadFont_cannot_diverge', async () => {
+    const api = await freshSession()
+
+    // loadFont lives in internal/ and cannot import @tauri-apps itself
+    // (upload.contract.test.ts), so it must consume this export.
+    await expect(api.posterFrameFontPath()).resolves.toBe(FONT_PATH)
+  })
+})

--- a/src/features/Upload/__contracts__/api.appDataPath.test.ts
+++ b/src/features/Upload/__contracts__/api.appDataPath.test.ts
@@ -152,6 +152,28 @@ describe('folder index failure handling (#167 B5)', () => {
     expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
   })
 
+  it('b5_5_writeFolderIndex_still_rejects_when_the_write_fails_after_a_failed_move', async () => {
+    // The clause that matters: the migration failed, so the write targets the
+    // misplaced path -- and a failure there must still reach the caller.
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValue(new Error('EACCES'))
+    writeTextFileMock.mockRejectedValue(new Error('disk full'))
+    const { writeFolderIndex } = await freshSession()
+
+    await expect(writeFolderIndex({ folders: [] })).rejects.toThrow(/disk full/)
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+  })
+
+  it('b5_2_writes_to_the_misplaced_path_when_the_move_failed', async () => {
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValue(new Error('EACCES'))
+    const { writeFolderIndex } = await freshSession()
+
+    await writeFolderIndex({ folders: [] })
+
+    expect(writeTextFileMock.mock.calls[0][0]).toBe(MISPLACED)
+  })
+
   it('b5_5_writeFolderIndex_still_rejects_on_a_genuine_write_failure', async () => {
     present(DIR)
     writeTextFileMock.mockRejectedValue(new Error('disk full'))
@@ -179,5 +201,24 @@ describe('poster frame font path (#167 B1)', () => {
     // loadFont lives in internal/ and cannot import @tauri-apps itself
     // (upload.contract.test.ts), so it must consume this export.
     await expect(api.posterFrameFontPath()).resolves.toBe(FONT_PATH)
+  })
+
+  it('b1_4_loadFont_probes_and_reads_exactly_the_path_the_helper_returns', async () => {
+    vi.resetModules()
+    const fileExists = vi.fn().mockResolvedValue(false)
+    const posterFrameFontPath = vi.fn().mockResolvedValue(FONT_PATH)
+    vi.doMock('../api', () => ({
+      fileExists,
+      posterFrameFontPath,
+      readFileAsBytes: vi.fn()
+    }))
+
+    const { loadFont } = await import('../internal/loadFont')
+    await loadFont()
+
+    // Asserting the same value flows through is what stops the two paths
+    // drifting apart, which is how they diverged before (#167).
+    expect(posterFrameFontPath).toHaveBeenCalled()
+    expect(fileExists).toHaveBeenCalledWith(FONT_PATH)
   })
 })

--- a/src/features/Upload/__contracts__/api.appDataPath.test.ts
+++ b/src/features/Upload/__contracts__/api.appDataPath.test.ts
@@ -10,19 +10,29 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appDataDirMock, fontDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock, readTextFileMock, writeTextFileMock } =
-  vi.hoisted(() => ({
-    appDataDirMock: vi.fn(),
-    fontDirMock: vi.fn(),
-    joinMock: vi.fn(),
-    existsMock: vi.fn(),
-    statMock: vi.fn(),
-    renameMock: vi.fn(),
-    removeMock: vi.fn(),
-    mkdirMock: vi.fn(),
-    readTextFileMock: vi.fn(),
-    writeTextFileMock: vi.fn()
-  }))
+const {
+  appDataDirMock,
+  fontDirMock,
+  joinMock,
+  existsMock,
+  statMock,
+  renameMock,
+  removeMock,
+  mkdirMock,
+  readTextFileMock,
+  writeTextFileMock
+} = vi.hoisted(() => ({
+  appDataDirMock: vi.fn(),
+  fontDirMock: vi.fn(),
+  joinMock: vi.fn(),
+  existsMock: vi.fn(),
+  statMock: vi.fn(),
+  renameMock: vi.fn(),
+  removeMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  readTextFileMock: vi.fn(),
+  writeTextFileMock: vi.fn()
+}))
 
 vi.mock('@tauri-apps/api/path', () => ({
   appDataDir: appDataDirMock,
@@ -55,8 +65,15 @@ const FONT_PATH = '/mock/fonts/Cabrito.otf'
 
 const INDEX = JSON.stringify({ folders: [{ id: 'f1', name: 'Marketing' }] })
 
+/**
+ * A fake filesystem that actually moves things, so a migrated index is
+ * readable at its new path rather than vanishing.
+ */
+const files = new Set<string>()
+
 function present(...paths: string[]) {
-  existsMock.mockImplementation((p: string) => Promise.resolve(paths.includes(p)))
+  files.clear()
+  paths.forEach((p) => files.add(p))
 }
 
 async function freshSession() {
@@ -72,9 +89,20 @@ beforeEach(() => {
     Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
   )
   statMock.mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false })
-  renameMock.mockResolvedValue(undefined)
-  removeMock.mockResolvedValue(undefined)
-  mkdirMock.mockResolvedValue(undefined)
+  existsMock.mockImplementation((p: string) => Promise.resolve(files.has(p)))
+  renameMock.mockImplementation((from: string, to: string) => {
+    files.delete(from)
+    files.add(to)
+    return Promise.resolve(undefined)
+  })
+  removeMock.mockImplementation((p: string) => {
+    files.delete(p)
+    return Promise.resolve(undefined)
+  })
+  mkdirMock.mockImplementation((p: string) => {
+    files.add(p)
+    return Promise.resolve(undefined)
+  })
   writeTextFileMock.mockResolvedValue(undefined)
   readTextFileMock.mockResolvedValue(INDEX)
 })

--- a/src/features/Upload/__contracts__/api.backgroundFolder.test.ts
+++ b/src/features/Upload/__contracts__/api.backgroundFolder.test.ts
@@ -25,8 +25,12 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn(), save: vi.fn() }))
 vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn().mockResolvedValue('/appdata/'),
-  fontDir: vi.fn().mockResolvedValue('/fonts')
+  // Neither returns a trailing separator in reality (issue #167).
+  appDataDir: vi.fn().mockResolvedValue('/appdata'),
+  fontDir: vi.fn().mockResolvedValue('/fonts'),
+  join: vi.fn((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
 }))
 
 const FOLDER = '/backgrounds'

--- a/src/features/Upload/__contracts__/api.contract.test.ts
+++ b/src/features/Upload/__contracts__/api.contract.test.ts
@@ -23,9 +23,22 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
   exists: vi.fn(),
   readDir: vi.fn(),
   readFile: vi.fn(),
-  writeFile: vi.fn()
+  writeFile: vi.fn(),
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  stat: vi.fn().mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false }),
+  rename: vi.fn(),
+  remove: vi.fn(),
+  mkdir: vi.fn()
 }))
-vi.mock('@tauri-apps/api/path', () => ({ fontDir: vi.fn() }))
+vi.mock('@tauri-apps/api/path', () => ({
+  fontDir: vi.fn(),
+  // No trailing separator, and join must exist: api.ts now joins paths rather
+  // than concatenating them (issue #167). Plain functions, so `mockReset` in
+  // vitest.config.ts cannot wipe them between tests.
+  appDataDir: async () => '/appdata',
+  join: async (...parts: string[]) => parts.join('/').replace(/\/{2,}/g, '/')
+}))
 
 import { getFolders, uploadVideo } from '../api'
 import { __resetBudget } from '../internal/sproutRateBudget'

--- a/src/features/Upload/__contracts__/upload.contract.test.ts
+++ b/src/features/Upload/__contracts__/upload.contract.test.ts
@@ -29,7 +29,7 @@ vi.mock('../api', () => ({
   // Tagged result since issue #166: a bare array would be read as a missing
   // `status` and misclassify inside the test rather than failing loudly.
   listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
-  getFontDir: vi.fn().mockResolvedValue('/fonts'),
+  posterFrameFontPath: vi.fn().mockResolvedValue('/fonts/Cabrito.otf'),
   fileExists: vi.fn().mockResolvedValue(false),
   posterFrameFontAvailable: vi.fn().mockResolvedValue(false),
   setSproutPosterFrame: vi.fn().mockResolvedValue(undefined),

--- a/src/features/Upload/api.ts
+++ b/src/features/Upload/api.ts
@@ -16,9 +16,10 @@ import {
   writeFile,
   writeTextFile
 } from '@tauri-apps/plugin-fs'
-import { appDataDir, fontDir } from '@tauri-apps/api/path'
+import { fontDir, join } from '@tauri-apps/api/path'
 
 import { isRateLimited } from '@shared/lib'
+import { resolveAppDataFile } from '@shared/utils'
 import type {
   GetFoldersResponse,
   SproutUploadResponse,
@@ -230,12 +231,22 @@ export async function listDirectory(folderPath: string): Promise<BackgroundFolde
   }
 }
 
-export async function getFontDir(): Promise<string> {
-  return fontDir()
-}
+/** Poster frame title font, shipped alongside the app. */
+const POSTER_FRAME_FONT = 'Cabrito.otf'
 
 export async function fileExists(path: string): Promise<boolean> {
   return exists(path)
+}
+
+/**
+ * Full path to the poster frame font.
+ *
+ * The single source of the path: loadFont lives in internal/ and may not
+ * import @tauri-apps itself, so routing it through here is what stops the two
+ * from drifting apart (issue #167).
+ */
+export async function posterFrameFontPath(): Promise<string> {
+  return join(await fontDir(), POSTER_FRAME_FONT)
 }
 
 /**
@@ -244,8 +255,7 @@ export async function fileExists(path: string): Promise<boolean> {
  * poster frame option on this.
  */
 export async function posterFrameFontAvailable(): Promise<boolean> {
-  const dir = await fontDir()
-  return exists(`${dir}/Cabrito.otf`)
+  return exists(await posterFrameFontPath())
 }
 
 // --- Saved folder index (issue #155, search) ---
@@ -254,7 +264,9 @@ export async function posterFrameFontAvailable(): Promise<boolean> {
 const FOLDER_INDEX_FILE = 'sprout-folder-index.json'
 
 async function folderIndexPath(): Promise<string> {
-  return `${await appDataDir()}${FOLDER_INDEX_FILE}`
+  // Joined rather than concatenated, relocating any copy an earlier build left
+  // beside the app data directory (issue #167).
+  return resolveAppDataFile(FOLDER_INDEX_FILE)
 }
 
 /**

--- a/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
+++ b/src/features/Upload/hooks/usePosterFrameForUpload.test.ts
@@ -19,7 +19,7 @@ import { usePosterFrameForUpload } from './usePosterFrameForUpload'
 vi.mock('../api', () => ({
   listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
   readFileAsBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
-  getFontDir: vi.fn().mockResolvedValue('/fonts'),
+  posterFrameFontPath: vi.fn().mockResolvedValue('/fonts/Cabrito.otf'),
   fileExists: vi.fn().mockResolvedValue(true),
   posterFrameFontAvailable: vi.fn().mockResolvedValue(true),
   setSproutPosterFrame: vi.fn().mockResolvedValue(undefined),

--- a/src/features/Upload/internal/loadFont.ts
+++ b/src/features/Upload/internal/loadFont.ts
@@ -1,6 +1,6 @@
 import { Font, parse } from 'opentype.js'
 
-import { fileExists, getFontDir, readFileAsBytes } from '../api'
+import { fileExists, posterFrameFontPath, readFileAsBytes } from '../api'
 
 let parsedFont: Font | null = null
 
@@ -15,8 +15,7 @@ export async function loadFont(): Promise<Font | null> {
     return parsedFont
   }
   // Load the font from the Tauri font directory
-  const fontPath = await getFontDir()
-  const path = `${fontPath}/Cabrito.otf`
+  const path = await posterFrameFontPath()
 
   // Check if the font file exists return null if not
   const found = await fileExists(path)

--- a/src/shared/utils/appDataPath.test.ts
+++ b/src/shared/utils/appDataPath.test.ts
@@ -10,16 +10,23 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appDataDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock } =
-  vi.hoisted(() => ({
-    appDataDirMock: vi.fn(),
-    joinMock: vi.fn(),
-    existsMock: vi.fn(),
-    statMock: vi.fn(),
-    renameMock: vi.fn(),
-    removeMock: vi.fn(),
-    mkdirMock: vi.fn()
-  }))
+const {
+  appDataDirMock,
+  joinMock,
+  existsMock,
+  statMock,
+  renameMock,
+  removeMock,
+  mkdirMock
+} = vi.hoisted(() => ({
+  appDataDirMock: vi.fn(),
+  joinMock: vi.fn(),
+  existsMock: vi.fn(),
+  statMock: vi.fn(),
+  renameMock: vi.fn(),
+  removeMock: vi.fn(),
+  mkdirMock: vi.fn()
+}))
 
 vi.mock('@tauri-apps/api/path', () => ({
   appDataDir: appDataDirMock,

--- a/src/shared/utils/appDataPath.test.ts
+++ b/src/shared/utils/appDataPath.test.ts
@@ -1,0 +1,283 @@
+/**
+ * App data path resolution and the misplaced-file migration (issue #167).
+ *
+ * `appDataDir()` returns no trailing separator, so `${dir}${file}` put
+ * api_keys.json and sprout-folder-index.json *beside* the app data directory
+ * rather than inside it. These tests cover the corrected join and the migration
+ * that relocates what the old expression already wrote.
+ *
+ * Behaviour IDs refer to issue #167.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appDataDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock } =
+  vi.hoisted(() => ({
+    appDataDirMock: vi.fn(),
+    joinMock: vi.fn(),
+    existsMock: vi.fn(),
+    statMock: vi.fn(),
+    renameMock: vi.fn(),
+    removeMock: vi.fn(),
+    mkdirMock: vi.fn()
+  }))
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: appDataDirMock,
+  join: joinMock
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: existsMock,
+  stat: statMock,
+  rename: renameMock,
+  remove: removeMock,
+  mkdir: mkdirMock,
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  BaseDirectory: {}
+}))
+
+const DIR = '/mock/app/data'
+const KEYS = 'api_keys.json'
+const CORRECT = '/mock/app/data/api_keys.json'
+const MISPLACED = '/mock/app/dataapi_keys.json'
+const LEGACY_TXT = 'api_key.txt'
+const MISPLACED_LEGACY = '/mock/app/dataapi_key.txt'
+
+/** Stands in for the real join: concatenates segments, collapsing separators. */
+function realisticJoin(...parts: string[]) {
+  return Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+}
+
+/** Makes exists() answer true only for the listed paths. */
+function present(...paths: string[]) {
+  existsMock.mockImplementation((p: string) => Promise.resolve(paths.includes(p)))
+}
+
+/** Re-imports the module so its per-session memo starts empty. */
+async function freshSession() {
+  vi.resetModules()
+  return import('./appDataPath')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  appDataDirMock.mockResolvedValue(DIR)
+  joinMock.mockImplementation(realisticJoin)
+  statMock.mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false })
+  renameMock.mockResolvedValue(undefined)
+  removeMock.mockResolvedValue(undefined)
+  mkdirMock.mockResolvedValue(undefined)
+  present(DIR)
+})
+
+describe('resolveAppDataFile - path construction (#167 B1)', () => {
+  it('b1_1_joins_the_directory_and_filename_as_separate_arguments', async () => {
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(joinMock).toHaveBeenCalledWith(DIR, KEYS)
+    expect(result).toBe(CORRECT)
+  })
+
+  it('b1_1_returns_joins_value_verbatim_rather_than_building_the_path_itself', async () => {
+    // If the code concatenated instead of using join's answer, this sentinel
+    // would not survive.
+    joinMock.mockResolvedValue('/sentinel/from/join')
+    present(DIR)
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).resolves.toBe('/sentinel/from/join')
+  })
+})
+
+describe('resolveAppDataFile - migration happy path (#167 B2)', () => {
+  it('b2_1_moves_a_misplaced_file_into_the_directory_and_returns_the_correct_path', async () => {
+    present(DIR, MISPLACED)
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+    expect(result).toBe(CORRECT)
+  })
+
+  it('b2_3_creates_the_app_data_directory_before_moving_when_it_does_not_exist', async () => {
+    present(MISPLACED) // directory itself absent
+    const { resolveAppDataFile } = await freshSession()
+
+    await resolveAppDataFile(KEYS)
+
+    expect(mkdirMock).toHaveBeenCalledWith(DIR, { recursive: true })
+    const mkdirOrder = mkdirMock.mock.invocationCallOrder[0]
+    const renameOrder = renameMock.mock.invocationCallOrder[0]
+    expect(mkdirOrder).toBeLessThan(renameOrder)
+  })
+})
+
+describe('resolveAppDataFile - guards on what is migrated (#167 B3)', () => {
+  it('b3_1_does_nothing_when_appDataDir_returns_a_trailing_separator', async () => {
+    // The misplaced path can only be computed by reproducing the bug. With a
+    // trailing separator that expression IS the correct path, so migrating it
+    // would delete the user's real file.
+    appDataDirMock.mockResolvedValue('/mock/app/data/')
+    present('/mock/app/data/', CORRECT)
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(result).toBe(CORRECT)
+    expect(renameMock).not.toHaveBeenCalled()
+    expect(removeMock).not.toHaveBeenCalled()
+  })
+
+  it('b3_2_leaves_a_directory_at_the_misplaced_path_untouched', async () => {
+    present(DIR, MISPLACED)
+    statMock.mockResolvedValue({ isFile: false, isDirectory: true, isSymlink: false })
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(result).toBe(CORRECT)
+    expect(renameMock).not.toHaveBeenCalled()
+    expect(removeMock).not.toHaveBeenCalled()
+  })
+
+  it('b3_3_deletes_the_misplaced_copy_and_never_writes_over_the_correct_one', async () => {
+    present(DIR, MISPLACED, CORRECT)
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(renameMock).not.toHaveBeenCalled()
+    expect(removeMock).toHaveBeenCalledWith(MISPLACED)
+    expect(result).toBe(CORRECT)
+  })
+})
+
+describe('resolveAppDataFile - idempotence and concurrency (#167 B4)', () => {
+  it('b4_1_attempts_no_move_or_delete_when_nothing_is_misplaced', async () => {
+    present(DIR, CORRECT)
+    const { resolveAppDataFile } = await freshSession()
+
+    await resolveAppDataFile(KEYS)
+
+    expect(renameMock).not.toHaveBeenCalled()
+    expect(removeMock).not.toHaveBeenCalled()
+  })
+
+  it('b4_2_does_not_probe_again_once_the_migration_has_run_this_session', async () => {
+    present(DIR, MISPLACED)
+    const { resolveAppDataFile } = await freshSession()
+
+    await resolveAppDataFile(KEYS)
+    const probesAfterFirst = existsMock.mock.calls.length
+    await resolveAppDataFile(KEYS)
+
+    expect(existsMock.mock.calls.length).toBe(probesAfterFirst)
+  })
+
+  it('b4_3_moves_once_when_two_callers_resolve_concurrently', async () => {
+    present(DIR, MISPLACED)
+    const { resolveAppDataFile } = await freshSession()
+
+    const [a, b] = await Promise.all([resolveAppDataFile(KEYS), resolveAppDataFile(KEYS)])
+
+    expect(renameMock).toHaveBeenCalledTimes(1)
+    expect(a).toBe(CORRECT)
+    expect(b).toBe(CORRECT)
+  })
+
+  it('b4_4_a_second_session_leaves_the_same_state_as_the_first', async () => {
+    present(DIR, MISPLACED)
+    const first = await freshSession()
+    await first.resolveAppDataFile(KEYS)
+    expect(renameMock).toHaveBeenCalledTimes(1)
+
+    // Second launch: the file is now where it belongs.
+    present(DIR, CORRECT)
+    const second = await freshSession()
+    const result = await second.resolveAppDataFile(KEYS)
+
+    expect(renameMock).toHaveBeenCalledTimes(1)
+    expect(result).toBe(CORRECT)
+  })
+})
+
+describe('resolveAppDataFile - failure (#167 B5)', () => {
+  it('b5_1_falls_back_to_the_misplaced_path_when_the_move_rejects', async () => {
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValue(new Error('EACCES: permission denied'))
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).resolves.toBe(MISPLACED)
+  })
+
+  it('b5_3_retries_the_move_on_a_later_call_in_the_same_session', async () => {
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValueOnce(new Error('device busy'))
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).resolves.toBe(MISPLACED)
+    await expect(resolveAppDataFile(KEYS)).resolves.toBe(CORRECT)
+    expect(renameMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('b5_4_uses_the_correct_path_when_the_existence_probe_itself_rejects', async () => {
+    existsMock.mockRejectedValue(new Error('probe denied'))
+    const { resolveAppDataFile } = await freshSession()
+
+    // An unanswerable probe is not evidence that a misplaced file exists.
+    await expect(resolveAppDataFile(KEYS)).resolves.toBe(CORRECT)
+    expect(renameMock).not.toHaveBeenCalled()
+  })
+
+  it('b5_1_never_throws_when_the_filesystem_is_uncooperative', async () => {
+    present(DIR, MISPLACED)
+    statMock.mockRejectedValue(new Error('stat failed'))
+    renameMock.mockRejectedValue(new Error('rename failed'))
+    removeMock.mockRejectedValue(new Error('remove failed'))
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).resolves.toEqual(expect.any(String))
+  })
+})
+
+describe('removeMisplacedResidue - api_key.txt (#167 B6)', () => {
+  it('b6_1_deletes_the_misplaced_legacy_file', async () => {
+    present(DIR, MISPLACED_LEGACY)
+    const { removeMisplacedResidue } = await freshSession()
+
+    await removeMisplacedResidue(LEGACY_TXT)
+
+    expect(removeMock).toHaveBeenCalledWith(MISPLACED_LEGACY)
+  })
+
+  it('b6_2_does_not_throw_when_the_deletion_rejects', async () => {
+    present(DIR, MISPLACED_LEGACY)
+    removeMock.mockRejectedValue(new Error('EPERM'))
+    const { removeMisplacedResidue } = await freshSession()
+
+    await expect(removeMisplacedResidue(LEGACY_TXT)).resolves.toBeUndefined()
+  })
+
+  it('b6_3_deletes_nothing_when_the_legacy_file_is_absent', async () => {
+    present(DIR)
+    const { removeMisplacedResidue } = await freshSession()
+
+    await removeMisplacedResidue(LEGACY_TXT)
+
+    expect(removeMock).not.toHaveBeenCalled()
+  })
+
+  it('b6_4_leaves_the_path_alone_when_it_is_not_a_regular_file', async () => {
+    present(DIR, MISPLACED_LEGACY)
+    statMock.mockResolvedValue({ isFile: false, isDirectory: true, isSymlink: false })
+    const { removeMisplacedResidue } = await freshSession()
+
+    await removeMisplacedResidue(LEGACY_TXT)
+
+    expect(removeMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/utils/appDataPath.test.ts
+++ b/src/shared/utils/appDataPath.test.ts
@@ -110,6 +110,19 @@ describe('resolveAppDataFile - migration happy path (#167 B2)', () => {
     expect(result).toBe(CORRECT)
   })
 
+  it('b2_5_creates_the_app_data_directory_even_when_nothing_needs_migrating', async () => {
+    // Nothing else creates it: rag.rs makes it on demand, and the old
+    // concatenation worked precisely because it wrote into the always-present
+    // parent. Joining correctly without this breaks saves on a fresh install.
+    present() // neither the directory nor any stray file
+    const { resolveAppDataFile } = await freshSession()
+
+    const result = await resolveAppDataFile(KEYS)
+
+    expect(mkdirMock).toHaveBeenCalledWith(DIR, { recursive: true })
+    expect(result).toBe(CORRECT)
+  })
+
   it('b2_3_creates_the_app_data_directory_before_moving_when_it_does_not_exist', async () => {
     present(MISPLACED) // directory itself absent
     const { resolveAppDataFile } = await freshSession()
@@ -197,17 +210,27 @@ describe('resolveAppDataFile - idempotence and concurrency (#167 B4)', () => {
   })
 
   it('b4_4_a_second_session_leaves_the_same_state_as_the_first', async () => {
-    present(DIR, MISPLACED)
+    // The second session must inherit what the first actually did, not a
+    // hand-set state, or this proves nothing about idempotence.
+    const disk = new Set([DIR, MISPLACED])
+    existsMock.mockImplementation((p: string) => Promise.resolve(disk.has(p)))
+    renameMock.mockImplementation((from: string, to: string) => {
+      disk.delete(from)
+      disk.add(to)
+      return Promise.resolve(undefined)
+    })
+
     const first = await freshSession()
     await first.resolveAppDataFile(KEYS)
-    expect(renameMock).toHaveBeenCalledTimes(1)
+    const afterFirst = [...disk].sort()
 
-    // Second launch: the file is now where it belongs.
-    present(DIR, CORRECT)
     const second = await freshSession()
     const result = await second.resolveAppDataFile(KEYS)
 
     expect(renameMock).toHaveBeenCalledTimes(1)
+    expect([...disk].sort()).toEqual(afterFirst)
+    expect(disk.has(CORRECT)).toBe(true)
+    expect(disk.has(MISPLACED)).toBe(false)
     expect(result).toBe(CORRECT)
   })
 })
@@ -237,6 +260,28 @@ describe('resolveAppDataFile - failure (#167 B5)', () => {
 
     // An unanswerable probe is not evidence that a misplaced file exists.
     await expect(resolveAppDataFile(KEYS)).resolves.toBe(CORRECT)
+    expect(renameMock).not.toHaveBeenCalled()
+  })
+
+  it('b5_6_propagates_a_failure_to_resolve_the_app_data_directory', async () => {
+    // There is no honest path to return without a directory, and #166
+    // established that a failed settings read must be loud rather than empty.
+    appDataDirMock.mockRejectedValue(new Error('no app data dir'))
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).rejects.toThrow(/no app data dir/)
+  })
+
+  it('b5_7_does_not_redirect_to_the_misplaced_path_when_join_rejects', async () => {
+    // join is an IPC round trip and can fail. Treating that as a failed move
+    // would send reads and writes beside the directory with no evidence a
+    // misplaced file exists. join is what produces the correct path, so there
+    // is nothing to fall back to and the failure propagates.
+    present(DIR, CORRECT)
+    joinMock.mockRejectedValue(new Error('ipc dropped'))
+    const { resolveAppDataFile } = await freshSession()
+
+    await expect(resolveAppDataFile(KEYS)).rejects.toThrow(/ipc dropped/)
     expect(renameMock).not.toHaveBeenCalled()
   })
 

--- a/src/shared/utils/appDataPath.ts
+++ b/src/shared/utils/appDataPath.ts
@@ -52,10 +52,47 @@ function misplacedSibling(dir: string, filename: string): string {
   return `${dir}${filename}`
 }
 
-async function migrateAndResolve(filename: string): Promise<string> {
-  const dir = await appDataDir()
+/**
+ * Signals that a stray file was found and could not be moved -- the one
+ * failure that justifies falling back to the old location.
+ *
+ * Distinguished from every other failure because the fallback is only correct
+ * when a misplaced file is known to exist. A rejecting join or probe is not
+ * evidence of one, and must not silently redirect reads and writes back beside
+ * the directory.
+ */
+class MigrationFailed extends Error {
+  constructor(
+    readonly misplaced: string,
+    readonly reason: unknown
+  ) {
+    super(`Could not move ${misplaced}`)
+    this.name = 'MigrationFailed'
+  }
+}
+
+/**
+ * Creates the app data directory if it is missing.
+ *
+ * Nothing else does: the only other creation is on demand in rag.rs, and the
+ * concatenation this issue fixes worked precisely because it wrote into the
+ * always-present parent. Without this, joining the path correctly would break
+ * saves for anyone whose directory has never been created.
+ */
+async function ensureDirectory(dir: string): Promise<void> {
+  try {
+    if (!(await exists(dir))) await mkdir(dir, { recursive: true })
+  } catch (error) {
+    // The write that follows reports this far more usefully than we can.
+    logger.error(`Could not ensure ${dir} exists:`, error)
+  }
+}
+
+async function migrateAndResolve(dir: string, filename: string): Promise<string> {
   const correct = await join(dir, filename)
   const misplaced = misplacedSibling(dir, filename)
+
+  await ensureDirectory(dir)
 
   // Nothing to migrate, and moving it would destroy the real file.
   if (misplaced === correct) return correct
@@ -87,15 +124,13 @@ async function migrateAndResolve(filename: string): Promise<string> {
   }
 
   try {
-    if (!(await exists(dir))) await mkdir(dir, { recursive: true })
     await rename(misplaced, correct)
     logger.info(`Moved ${misplaced} to ${correct}`)
     return correct
   } catch (error) {
     // Keep working against the old location so reads and writes agree. The
     // next call retries.
-    logger.error(`Could not move ${misplaced} to ${correct}:`, error)
-    throw error
+    throw new MigrationFailed(misplaced, error)
   }
 }
 
@@ -103,19 +138,31 @@ async function migrateAndResolve(filename: string): Promise<string> {
  * Path to a file inside the app data directory, relocating any copy an earlier
  * build left beside the directory.
  *
- * Never rejects. If the move fails, the misplaced path is returned so the app
- * keeps working exactly as it did before, and the move is retried on the next
- * call.
+ * Filesystem failures never reject: if the move fails, the misplaced path is
+ * returned so the app keeps working exactly as it did before, and the move is
+ * retried on the next call.
+ *
+ * A failure to resolve the app data directory itself does reject. There is no
+ * honest path to hand back without one, and #166 established that a settings
+ * read which cannot be performed must say so rather than report emptiness.
  */
 export async function resolveAppDataFile(filename: string): Promise<string> {
   const cached = resolved.get(filename)
   if (cached) return cached
 
-  const attempt = migrateAndResolve(filename).catch(async (error) => {
-    resolved.delete(filename)
-    logger.error(`Falling back to the pre-migration path for ${filename}:`, error)
-    return misplacedSibling(await appDataDir(), filename)
-  })
+  const attempt = appDataDir()
+    .then((dir) => migrateAndResolve(dir, filename))
+    .catch((error) => {
+      // Evicted whichever way this settles, so a transient failure cannot pin
+      // the session to the old location or cache a rejection.
+      resolved.delete(filename)
+
+      if (error instanceof MigrationFailed) {
+        logger.error(`Could not move ${error.misplaced}, using it as-is:`, error.reason)
+        return error.misplaced
+      }
+      throw error
+    })
 
   resolved.set(filename, attempt)
   return attempt

--- a/src/shared/utils/appDataPath.ts
+++ b/src/shared/utils/appDataPath.ts
@@ -1,0 +1,154 @@
+/**
+ * Resolving files inside the app data directory, and relocating the ones an
+ * earlier build put beside it (issue #167).
+ *
+ * `appDataDir()` returns no trailing separator, so `${dir}${file}` produced
+ * `…/com.bucket-app.devapi_keys.json` -- a sibling of the app data directory
+ * rather than a child. Reads and writes shared that expression, so the app
+ * worked and the fault stayed invisible; correcting the join without moving
+ * the files would have orphaned every user's settings.
+ *
+ * Resolution is lazy and per file: whoever asks for the path first performs
+ * the move. That keeps the migration in the modules that own these files, and
+ * means it always precedes the startup prefetch that reads api_keys.json.
+ */
+import { appDataDir, join } from '@tauri-apps/api/path'
+import { exists, mkdir, remove, rename, stat } from '@tauri-apps/plugin-fs'
+
+import { logger } from './logger'
+
+/**
+ * Resolved paths, memoised for the session so the probe runs once.
+ *
+ * Holds the in-flight promise as well as the settled value, so concurrent
+ * callers -- the startup prefetch racing an open Settings page -- share one
+ * migration rather than each attempting the move.
+ *
+ * A failed migration is deliberately evicted rather than cached: a disk busy
+ * for a moment at boot must not pin the whole session to the old location.
+ */
+const resolved = new Map<string, Promise<string>>()
+const sweptResidue = new Map<string, Promise<void>>()
+
+/** Whether the path is a regular file we may move or delete. */
+async function isRegularFile(path: string): Promise<boolean> {
+  try {
+    const info = await stat(path)
+    return info.isFile
+  } catch (error) {
+    // Unreadable metadata is not permission to touch it.
+    logger.error(`Could not stat ${path}:`, error)
+    return false
+  }
+}
+
+/**
+ * The path the buggy expression produced. Computing it means reproducing the
+ * bug on purpose, which is safe only alongside the identity check in
+ * resolveAppDataFile: were appDataDir to gain a trailing separator, this would
+ * *be* the correct path.
+ */
+function misplacedSibling(dir: string, filename: string): string {
+  return `${dir}${filename}`
+}
+
+async function migrateAndResolve(filename: string): Promise<string> {
+  const dir = await appDataDir()
+  const correct = await join(dir, filename)
+  const misplaced = misplacedSibling(dir, filename)
+
+  // Nothing to migrate, and moving it would destroy the real file.
+  if (misplaced === correct) return correct
+
+  let strayExists: boolean
+  try {
+    strayExists = await exists(misplaced)
+  } catch (error) {
+    // A probe that cannot run is not evidence that a stray file exists.
+    logger.error(`Could not probe ${misplaced}:`, error)
+    return correct
+  }
+  if (!strayExists) return correct
+
+  // A directory here belongs to something else -- an app whose identifier
+  // extends ours would create one -- so only regular files are ours to move.
+  if (!(await isRegularFile(misplaced))) return correct
+
+  // rename replaces its destination, so the destination is checked first.
+  try {
+    if (await exists(correct)) {
+      await remove(misplaced)
+      logger.info(`Removed superseded ${misplaced}; ${correct} already exists`)
+      return correct
+    }
+  } catch (error) {
+    logger.error(`Could not resolve ${misplaced} against ${correct}:`, error)
+    return correct
+  }
+
+  try {
+    if (!(await exists(dir))) await mkdir(dir, { recursive: true })
+    await rename(misplaced, correct)
+    logger.info(`Moved ${misplaced} to ${correct}`)
+    return correct
+  } catch (error) {
+    // Keep working against the old location so reads and writes agree. The
+    // next call retries.
+    logger.error(`Could not move ${misplaced} to ${correct}:`, error)
+    throw error
+  }
+}
+
+/**
+ * Path to a file inside the app data directory, relocating any copy an earlier
+ * build left beside the directory.
+ *
+ * Never rejects. If the move fails, the misplaced path is returned so the app
+ * keeps working exactly as it did before, and the move is retried on the next
+ * call.
+ */
+export async function resolveAppDataFile(filename: string): Promise<string> {
+  const cached = resolved.get(filename)
+  if (cached) return cached
+
+  const attempt = migrateAndResolve(filename).catch(async (error) => {
+    resolved.delete(filename)
+    logger.error(`Falling back to the pre-migration path for ${filename}:`, error)
+    return misplacedSibling(await appDataDir(), filename)
+  })
+
+  resolved.set(filename, attempt)
+  return attempt
+}
+
+/**
+ * Deletes a misplaced file nothing reads any more (api_key.txt, superseded by
+ * api_keys.json). Runs once per session whether or not its live counterpart
+ * needed moving, since otherwise it would survive on every machine past its
+ * first upgrade.
+ *
+ * Never rejects: this is housekeeping, and it must not fail the caller's own
+ * migration.
+ */
+export async function removeMisplacedResidue(filename: string): Promise<void> {
+  const cached = sweptResidue.get(filename)
+  if (cached) return cached
+
+  const attempt = (async () => {
+    try {
+      const dir = await appDataDir()
+      const misplaced = misplacedSibling(dir, filename)
+      if (misplaced === (await join(dir, filename))) return
+      if (!(await exists(misplaced))) return
+      if (!(await isRegularFile(misplaced))) return
+
+      await remove(misplaced)
+      logger.info(`Removed orphaned ${misplaced}`)
+    } catch (error) {
+      logger.error(`Could not remove orphaned ${filename}:`, error)
+    }
+  })()
+
+  sweptResidue.set(filename, attempt)
+  return attempt
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -11,6 +11,12 @@ export { logger } from './logger'
 /** Create a namespaced logger instance for module-specific logging */
 export { createNamespacedLogger } from './logger'
 
+// App data paths (issue #167)
+/** Resolve a file inside the app data directory, relocating misplaced copies */
+export { resolveAppDataFile } from './appDataPath'
+/** Delete a misplaced file that nothing reads any more */
+export { removeMisplacedResidue } from './appDataPath'
+
 // Storage (API keys persistence)
 /** Persist API keys (Sprout Video, Trello) to secure local storage */
 export { saveApiKeys } from './storage'

--- a/src/shared/utils/storage.appDataPath.test.ts
+++ b/src/shared/utils/storage.appDataPath.test.ts
@@ -1,0 +1,166 @@
+/**
+ * api_keys.json reaches the migrated path (issue #167).
+ *
+ * appDataPath.test.ts covers the resolver in isolation. These tests drive it
+ * through the exported functions users actually reach, since getFilePath is
+ * module-private, and cover the residue sweep that storage.ts triggers.
+ *
+ * Behaviour IDs refer to issue #167.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appDataDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock, readTextFileMock, writeTextFileMock } =
+  vi.hoisted(() => ({
+    appDataDirMock: vi.fn(),
+    joinMock: vi.fn(),
+    existsMock: vi.fn(),
+    statMock: vi.fn(),
+    renameMock: vi.fn(),
+    removeMock: vi.fn(),
+    mkdirMock: vi.fn(),
+    readTextFileMock: vi.fn(),
+    writeTextFileMock: vi.fn()
+  }))
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: appDataDirMock,
+  join: joinMock
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: existsMock,
+  stat: statMock,
+  rename: renameMock,
+  remove: removeMock,
+  mkdir: mkdirMock,
+  readTextFile: readTextFileMock,
+  writeTextFile: writeTextFileMock,
+  BaseDirectory: {}
+}))
+
+vi.mock('@shared/store/useAppStore', () => ({
+  appStore: {
+    getState: vi.fn(() => ({
+      setSproutVideoApiKey: vi.fn(),
+      setTrelloApiKey: vi.fn(),
+      setTrelloApiToken: vi.fn(),
+      setTrelloBoardId: vi.fn(),
+      setDefaultBackgroundFolder: vi.fn(),
+      setOllamaUrl: vi.fn()
+    }))
+  }
+}))
+
+const DIR = '/mock/app/data'
+const CORRECT = '/mock/app/data/api_keys.json'
+const MISPLACED = '/mock/app/dataapi_keys.json'
+const MISPLACED_LEGACY = '/mock/app/dataapi_key.txt'
+
+const STORED = JSON.stringify({ sproutVideo: 'stored-key', trello: 'stored-trello' })
+
+function present(...paths: string[]) {
+  existsMock.mockImplementation((p: string) => Promise.resolve(paths.includes(p)))
+}
+
+async function freshSession() {
+  vi.resetModules()
+  return import('./storage')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  appDataDirMock.mockResolvedValue(DIR)
+  joinMock.mockImplementation((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
+  statMock.mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false })
+  renameMock.mockResolvedValue(undefined)
+  removeMock.mockResolvedValue(undefined)
+  mkdirMock.mockResolvedValue(undefined)
+  writeTextFileMock.mockResolvedValue(undefined)
+  readTextFileMock.mockResolvedValue(STORED)
+})
+
+describe('loadApiKeys after migration (#167 B2)', () => {
+  it('b2_1_returns_the_migrated_files_contents_rather_than_an_empty_object', async () => {
+    present(DIR, MISPLACED)
+    const { loadApiKeys } = await freshSession()
+
+    const keys = await loadApiKeys()
+
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+    expect(keys).toEqual({ sproutVideo: 'stored-key', trello: 'stored-trello' })
+  })
+
+  it('b2_1_reads_from_the_correct_path_once_migrated', async () => {
+    present(DIR, MISPLACED)
+    const { loadApiKeys } = await freshSession()
+
+    await loadApiKeys()
+
+    expect(readTextFileMock).toHaveBeenCalledWith(CORRECT)
+  })
+})
+
+describe('saveApiKeys path targeting (#167 B2, B5)', () => {
+  it('b2_4_writes_to_the_correct_path_after_a_migration', async () => {
+    present(DIR, MISPLACED)
+    const { saveApiKeys } = await freshSession()
+
+    await saveApiKeys({ sproutVideo: 'new-key' })
+
+    const [target] = writeTextFileMock.mock.calls[0]
+    expect(target).toBe(CORRECT)
+  })
+
+  it('b2_4_writes_inside_the_directory_when_nothing_needs_migrating', async () => {
+    present(DIR)
+    const { saveApiKeys } = await freshSession()
+
+    await saveApiKeys({ sproutVideo: 'new-key' })
+
+    const [target] = writeTextFileMock.mock.calls[0]
+    expect(target).toBe(CORRECT)
+    // The bug this issue fixes: the file landing beside the directory.
+    expect(target).not.toBe(MISPLACED)
+  })
+
+  it('b5_2_writes_to_the_misplaced_path_when_the_move_failed_so_read_and_write_agree', async () => {
+    present(DIR, MISPLACED)
+    renameMock.mockRejectedValue(new Error('EACCES'))
+    const { saveApiKeys, loadApiKeys } = await freshSession()
+
+    await saveApiKeys({ sproutVideo: 'new-key' })
+    await loadApiKeys()
+
+    // The fallback must be a fallback: the move is attempted first, and only
+    // its failure sends the write back to the old location. Without this the
+    // test would pass against the unfixed code, which never tries to move.
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+    expect(writeTextFileMock.mock.calls[0][0]).toBe(MISPLACED)
+    expect(readTextFileMock).toHaveBeenCalledWith(MISPLACED)
+  })
+})
+
+describe('legacy api_key.txt sweep (#167 B6)', () => {
+  it('b6_1_deletes_it_even_when_api_keys_json_needed_no_migration', async () => {
+    present(DIR, CORRECT, MISPLACED_LEGACY)
+    const { loadApiKeys } = await freshSession()
+
+    await loadApiKeys()
+
+    expect(removeMock).toHaveBeenCalledWith(MISPLACED_LEGACY)
+  })
+
+  it('b6_2_still_completes_the_api_keys_migration_when_the_sweep_fails', async () => {
+    present(DIR, MISPLACED, MISPLACED_LEGACY)
+    removeMock.mockRejectedValue(new Error('EPERM'))
+    const { loadApiKeys } = await freshSession()
+
+    await expect(loadApiKeys()).resolves.toEqual({
+      sproutVideo: 'stored-key',
+      trello: 'stored-trello'
+    })
+    expect(renameMock).toHaveBeenCalledWith(MISPLACED, CORRECT)
+  })
+})

--- a/src/shared/utils/storage.appDataPath.test.ts
+++ b/src/shared/utils/storage.appDataPath.test.ts
@@ -9,18 +9,27 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appDataDirMock, joinMock, existsMock, statMock, renameMock, removeMock, mkdirMock, readTextFileMock, writeTextFileMock } =
-  vi.hoisted(() => ({
-    appDataDirMock: vi.fn(),
-    joinMock: vi.fn(),
-    existsMock: vi.fn(),
-    statMock: vi.fn(),
-    renameMock: vi.fn(),
-    removeMock: vi.fn(),
-    mkdirMock: vi.fn(),
-    readTextFileMock: vi.fn(),
-    writeTextFileMock: vi.fn()
-  }))
+const {
+  appDataDirMock,
+  joinMock,
+  existsMock,
+  statMock,
+  renameMock,
+  removeMock,
+  mkdirMock,
+  readTextFileMock,
+  writeTextFileMock
+} = vi.hoisted(() => ({
+  appDataDirMock: vi.fn(),
+  joinMock: vi.fn(),
+  existsMock: vi.fn(),
+  statMock: vi.fn(),
+  renameMock: vi.fn(),
+  removeMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  readTextFileMock: vi.fn(),
+  writeTextFileMock: vi.fn()
+}))
 
 vi.mock('@tauri-apps/api/path', () => ({
   appDataDir: appDataDirMock,
@@ -58,8 +67,15 @@ const MISPLACED_LEGACY = '/mock/app/dataapi_key.txt'
 
 const STORED = JSON.stringify({ sproutVideo: 'stored-key', trello: 'stored-trello' })
 
+/**
+ * A fake filesystem that actually moves things, so a migrated file is readable
+ * at its new path rather than vanishing.
+ */
+const files = new Set<string>()
+
 function present(...paths: string[]) {
-  existsMock.mockImplementation((p: string) => Promise.resolve(paths.includes(p)))
+  files.clear()
+  paths.forEach((p) => files.add(p))
 }
 
 async function freshSession() {
@@ -74,9 +90,20 @@ beforeEach(() => {
     Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
   )
   statMock.mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false })
-  renameMock.mockResolvedValue(undefined)
-  removeMock.mockResolvedValue(undefined)
-  mkdirMock.mockResolvedValue(undefined)
+  existsMock.mockImplementation((p: string) => Promise.resolve(files.has(p)))
+  renameMock.mockImplementation((from: string, to: string) => {
+    files.delete(from)
+    files.add(to)
+    return Promise.resolve(undefined)
+  })
+  removeMock.mockImplementation((p: string) => {
+    files.delete(p)
+    return Promise.resolve(undefined)
+  })
+  mkdirMock.mockImplementation((p: string) => {
+    files.add(p)
+    return Promise.resolve(undefined)
+  })
   writeTextFileMock.mockResolvedValue(undefined)
   readTextFileMock.mockResolvedValue(STORED)
 })

--- a/src/shared/utils/storage.appDataPath.test.ts
+++ b/src/shared/utils/storage.appDataPath.test.ts
@@ -140,6 +140,19 @@ describe('saveApiKeys path targeting (#167 B2, B5)', () => {
     expect(target).toBe(CORRECT)
   })
 
+  it('b2_5_creates_the_directory_before_writing_on_a_fresh_install', async () => {
+    present() // no app data directory at all
+    const { saveApiKeys } = await freshSession()
+
+    await expect(saveApiKeys({ sproutVideo: 'new-key' })).resolves.toBeUndefined()
+
+    expect(mkdirMock).toHaveBeenCalledWith(DIR, { recursive: true })
+    expect(mkdirMock.mock.invocationCallOrder[0]).toBeLessThan(
+      writeTextFileMock.mock.invocationCallOrder[0]
+    )
+    expect(writeTextFileMock.mock.calls[0][0]).toBe(CORRECT)
+  })
+
   it('b2_4_writes_inside_the_directory_when_nothing_needs_migrating', async () => {
     present(DIR)
     const { saveApiKeys } = await freshSession()

--- a/src/shared/utils/storage.saveApiKeys.test.ts
+++ b/src/shared/utils/storage.saveApiKeys.test.ts
@@ -7,11 +7,14 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { writeTextFileMock, readTextFileMock, existsMock } = vi.hoisted(() => ({
-  writeTextFileMock: vi.fn(),
-  readTextFileMock: vi.fn(),
-  existsMock: vi.fn()
-}))
+const { writeTextFileMock, readTextFileMock, existsMock, appDataDirMock, joinMock } =
+  vi.hoisted(() => ({
+    writeTextFileMock: vi.fn(),
+    readTextFileMock: vi.fn(),
+    existsMock: vi.fn(),
+    appDataDirMock: vi.fn(),
+    joinMock: vi.fn()
+  }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
   writeTextFile: writeTextFileMock,
@@ -24,17 +27,22 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
   BaseDirectory: {}
 }))
 vi.mock('@tauri-apps/api/path', () => ({
-  // No trailing separator, matching the real API (issue #167).
-  appDataDir: vi.fn().mockResolvedValue('/tmp/bucket'),
-  join: vi.fn((...parts: string[]) =>
-    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
-  )
+  appDataDir: appDataDirMock,
+  join: joinMock
 }))
 
 import { saveApiKeys } from './storage'
 
 beforeEach(() => {
   writeTextFileMock.mockReset().mockResolvedValue(undefined)
+  // vitest.config.ts sets mockReset, so implementations declared in the mock
+  // factory are wiped between tests and must be restored here.
+  // No trailing separator, matching the real API (issue #167).
+  appDataDirMock.mockResolvedValue('/tmp/bucket')
+  joinMock.mockImplementation((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
+  existsMock.mockResolvedValue(false)
 })
 
 describe('saveApiKeys', () => {

--- a/src/shared/utils/storage.saveApiKeys.test.ts
+++ b/src/shared/utils/storage.saveApiKeys.test.ts
@@ -17,10 +17,18 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
   writeTextFile: writeTextFileMock,
   readTextFile: readTextFileMock,
   exists: existsMock,
+  stat: vi.fn().mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false }),
+  rename: vi.fn(),
+  remove: vi.fn(),
+  mkdir: vi.fn(),
   BaseDirectory: {}
 }))
 vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn().mockResolvedValue('/tmp/bucket/')
+  // No trailing separator, matching the real API (issue #167).
+  appDataDir: vi.fn().mockResolvedValue('/tmp/bucket'),
+  join: vi.fn((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
 }))
 
 import { saveApiKeys } from './storage'

--- a/src/shared/utils/storage.ts
+++ b/src/shared/utils/storage.ts
@@ -1,7 +1,7 @@
 import { appStore } from '@shared/store'
-import { appDataDir } from '@tauri-apps/api/path'
 import { exists, readTextFile, writeTextFile } from '@tauri-apps/plugin-fs'
 
+import { removeMisplacedResidue, resolveAppDataFile } from './appDataPath'
 import { logger } from './logger'
 
 const setSproutVideoApiKey = (state: string) =>
@@ -29,14 +29,22 @@ export interface ApiKeys {
 
 const API_KEYS_FILE = 'api_keys.json' // New file for storing API keys as JSON
 
+/** Superseded by api_keys.json and read by nothing; swept up on the way past
+ *  (issue #167). */
+const LEGACY_API_KEY_FILE = 'api_key.txt'
+
 // default background folder state
 const setDefaultBackgroundFolder = (path: string) =>
   appStore.getState().setDefaultBackgroundFolder(path)
 
 // Get full path for storing API keys.
+//
+// Joined rather than concatenated, and any copy an earlier build left beside
+// the app data directory is relocated first (issue #167).
 const getFilePath = async () => {
-  const dir = await appDataDir()
-  return `${dir}${API_KEYS_FILE}`
+  const path = await resolveAppDataFile(API_KEYS_FILE)
+  await removeMisplacedResidue(LEGACY_API_KEY_FILE)
+  return path
 }
 
 // Save API keys to a local file as JSON.

--- a/tests/contract/e2e-mock-protocol.contract.test.ts
+++ b/tests/contract/e2e-mock-protocol.contract.test.ts
@@ -83,34 +83,116 @@ describe('e2e mock protocol — B2.2 mock speaks the current protocol', () => {
 
 describe('e2e mock protocol — #167 every fixture joins paths for real', () => {
   /**
-   * A substring check would pass against `return null` or a constant. Three of
+   * A source grep would pass against `return null` or a constant. Three of
    * these fixtures answered every `plugin:path|*` command with one hardcoded
    * directory, which would have collapsed api_keys.json and the folder index
-   * onto a single path. So the handler is executed, not merely located.
+   * onto a single path -- so each fixture's init script is executed against a
+   * fake window and its handler actually invoked. That also proves the handler
+   * is reachable given the fixture's if-ordering, not merely present.
    */
-  const FIXTURES = [
-    'tauri-e2e-mocks.ts',
-    'sprout-folders.fixture.ts',
-    'posterframe-backgrounds.fixture.ts',
-    'mocks.fixture.ts'
+  type Invoke = (cmd: string, args?: unknown) => Promise<unknown>
+
+  /** Runs a fixture's setup, capturing the invoke it installs on window. */
+  async function captureInvoke(
+    setup: (page: never) => Promise<void>
+  ): Promise<Invoke> {
+    const win: Record<string, unknown> = {}
+    const page = {
+      addInitScript: async (fn: (arg?: unknown) => void, arg?: unknown) => {
+        const originalWindow = globalThis.window
+        // The init script closes over `window`, so stand one in for it.
+        Object.defineProperty(globalThis, 'window', {
+          value: win,
+          configurable: true,
+          writable: true
+        })
+        try {
+          fn(arg)
+        } finally {
+          Object.defineProperty(globalThis, 'window', {
+            value: originalWindow,
+            configurable: true,
+            writable: true
+          })
+        }
+      },
+      route: async () => {},
+      on: () => {},
+      goto: async () => {},
+      evaluate: async () => {},
+      waitForLoadState: async () => {}
+    }
+
+    await setup(page as never)
+
+    const internals = win.__TAURI_INTERNALS__ as { invoke?: Invoke } | undefined
+    if (!internals?.invoke) {
+      throw new Error('fixture installed no __TAURI_INTERNALS__.invoke')
+    }
+    return internals.invoke
+  }
+
+  const FIXTURES: Array<[string, () => Promise<(page: never) => Promise<void>>]> = [
+    [
+      'tauri-e2e-mocks.ts',
+      async () => {
+        const mod = await import('../e2e/fixtures/tauri-e2e-mocks')
+        return (page: never) => mod.createTauriMock(page).setup()
+      }
+    ],
+    [
+      'sprout-folders.fixture.ts',
+      async () => {
+        const mod = await import('../e2e/fixtures/sprout-folders.fixture')
+        return (page: never) => mod.setupSproutMocks(page, { folders: [] })
+      }
+    ],
+    [
+      'posterframe-backgrounds.fixture.ts',
+      async () => {
+        const mod = await import('../e2e/fixtures/posterframe-backgrounds.fixture')
+        return (page: never) => mod.installBackgroundMocks(page)
+      }
+    ],
+    [
+      'mocks.fixture.ts',
+      async () => (await import('../e2e/fixtures/mocks.fixture')).setupTauriMocks
+    ]
   ]
 
-  it.each(FIXTURES)('%s answers plugin:path|join by concatenating its segments', (file) => {
-    const source = fs.readFileSync(path.join(E2E_DIR, 'fixtures', file), 'utf-8')
+  it.each(FIXTURES)(
+    '%s answers plugin:path|join by concatenating its segments',
+    async (file, load) => {
+      const invoke = await captureInvoke(await load())
+
+      const joined = await invoke('plugin:path|join', {
+        paths: ['/data/dir', 'api_keys.json']
+      })
+
+      expect(
+        joined,
+        `tests/e2e/fixtures/${file} does not join paths — the app joins the ` +
+          'app data directory to a filename (#167), and a constant or absent ' +
+          'answer silently merges every settings file onto one path'
+      ).toBe('/data/dir/api_keys.json')
+    }
+  )
+
+  it.each(FIXTURES)('%s resolves the app data directory without a trailing separator', async (file, load) => {
+    const invoke = await captureInvoke(await load())
+
+    const dir = (await invoke('plugin:path|resolve_directory', { directory: 13 })) as string
 
     expect(
-      source.includes("'plugin:path|join'"),
-      `tests/e2e/fixtures/${file} has no plugin:path|join handler — the app ` +
-        'joins the app data directory to a filename (#167), and an unhandled ' +
-        'or constant answer silently merges every settings file onto one path'
+      typeof dir === 'string' && dir.length > 0,
+      `tests/e2e/fixtures/${file} returns no app data directory — appDataDir() ` +
+        'resolves through resolve_directory, not a per-directory command'
     ).toBe(true)
-
-    // The handler must read the paths argument rather than return a constant.
     expect(
-      /plugin:path\|join'[\s\S]{0,320}paths/.test(source),
-      `tests/e2e/fixtures/${file} answers plugin:path|join without reading ` +
-        'the `paths` argument, so it returns a constant rather than a join'
-    ).toBe(true)
+      dir.endsWith('/'),
+      `tests/e2e/fixtures/${file} returns a trailing separator, which the real ` +
+        'appDataDir never does — that fiction is what hid #167'
+    ).toBe(false)
   })
 })
 

--- a/tests/contract/e2e-mock-protocol.contract.test.ts
+++ b/tests/contract/e2e-mock-protocol.contract.test.ts
@@ -81,6 +81,39 @@ describe('e2e mock protocol — B2.2 mock speaks the current protocol', () => {
   })
 })
 
+describe('e2e mock protocol — #167 every fixture joins paths for real', () => {
+  /**
+   * A substring check would pass against `return null` or a constant. Three of
+   * these fixtures answered every `plugin:path|*` command with one hardcoded
+   * directory, which would have collapsed api_keys.json and the folder index
+   * onto a single path. So the handler is executed, not merely located.
+   */
+  const FIXTURES = [
+    'tauri-e2e-mocks.ts',
+    'sprout-folders.fixture.ts',
+    'posterframe-backgrounds.fixture.ts',
+    'mocks.fixture.ts'
+  ]
+
+  it.each(FIXTURES)('%s answers plugin:path|join by concatenating its segments', (file) => {
+    const source = fs.readFileSync(path.join(E2E_DIR, 'fixtures', file), 'utf-8')
+
+    expect(
+      source.includes("'plugin:path|join'"),
+      `tests/e2e/fixtures/${file} has no plugin:path|join handler — the app ` +
+        'joins the app data directory to a filename (#167), and an unhandled ' +
+        'or constant answer silently merges every settings file onto one path'
+    ).toBe(true)
+
+    // The handler must read the paths argument rather than return a constant.
+    expect(
+      /plugin:path\|join'[\s\S]{0,320}paths/.test(source),
+      `tests/e2e/fixtures/${file} answers plugin:path|join without reading ` +
+        'the `paths` argument, so it returns a constant rather than a join'
+    ).toBe(true)
+  })
+})
+
 describe('e2e mock protocol — B2.3 no legacy residue in the e2e specs', () => {
   const specFiles = collectTsFiles(E2E_DIR)
 

--- a/tests/e2e/fixtures/mocks.fixture.ts
+++ b/tests/e2e/fixtures/mocks.fixture.ts
@@ -160,6 +160,16 @@ export async function setupTauriMocks(page: Page): Promise<void> {
         switch (cmd) {
           case 'get_version':
             return '0.9.3'
+          // Tauri v2 invokes this directly rather than nested under 'tauri'.
+          // It must genuinely concatenate, or every file the app joins onto
+          // the app data directory collapses onto one path (issue #167).
+          case 'plugin:path|join': {
+            const parts = ((args as { paths?: string[] })?.paths ?? []) as string[]
+            return parts.join('/').replace(/\/{2,}/g, '/')
+          }
+          case 'plugin:path|app_data_dir':
+            // No trailing separator, matching the real API.
+            return '/tmp/bucket-test/data'
           case 'check_auth':
             return { authenticated: true, user: 'test@example.com' }
           case 'get_preferences':
@@ -172,6 +182,12 @@ export async function setupTauriMocks(page: Page): Promise<void> {
             if (args && typeof args === 'object' && 'cmd' in args) {
               const innerCmd = (args as { cmd: string }).cmd
               switch (innerCmd) {
+                // Must genuinely concatenate, or every file the app joins onto
+                // the app data directory collapses onto one path (issue #167).
+                case 'plugin:path|join': {
+                  const parts = ((args as { paths?: string[] }).paths ?? []) as string[]
+                  return parts.join('/').replace(/\/{2,}/g, '/')
+                }
                 case 'plugin:path|app_data_dir':
                 case 'plugin:path|resolve_directory':
                   return '/tmp/bucket-test/data'

--- a/tests/e2e/fixtures/mocks.fixture.ts
+++ b/tests/e2e/fixtures/mocks.fixture.ts
@@ -167,7 +167,10 @@ export async function setupTauriMocks(page: Page): Promise<void> {
             const parts = ((args as { paths?: string[] })?.paths ?? []) as string[]
             return parts.join('/').replace(/\/{2,}/g, '/')
           }
-          case 'plugin:path|app_data_dir':
+          // appDataDir()/fontDir() resolve through resolve_directory with a
+          // directory enum, not through per-directory commands. Without this
+          // the call fell through to `default` and returned null.
+          case 'plugin:path|resolve_directory':
             // No trailing separator, matching the real API.
             return '/tmp/bucket-test/data'
           case 'check_auth':

--- a/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
+++ b/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
@@ -93,6 +93,9 @@ export async function installBackgroundMocks(
     win.__backgroundListings__ = []
     win.__nextListenerId__ = 1
 
+    /** No trailing separator, matching the real appDataDir (issue #167). */
+    const APP_DATA_DIR = '/tmp/bucket-e2e'
+
     const settings: Record<string, string> = { sproutVideo: 'e2e-sprout-key' }
     if (cfg.configured) settings.defaultBackgroundFolder = cfg.folder
 
@@ -116,6 +119,11 @@ export async function installBackgroundMocks(
         // The Cabrito font probe goes through the same exists() call.
         if (path.toLowerCase().includes('cabrito')) return cfg.fontInstalled
         if (path === cfg.folder) return cfg.scenario !== 'missing'
+        // A path beside the app data directory rather than inside it is the
+        // pre-#167 layout. E2E runs start already migrated.
+        if (path.startsWith(APP_DATA_DIR) && !path.startsWith(`${APP_DATA_DIR}/`)) {
+          return false
+        }
         return true
       }
 
@@ -226,13 +234,24 @@ export async function installBackgroundMocks(
       if (cmd === 'get_username') return 'E2E User'
       if (cmd === 'get_version') return '0.0.0-e2e'
 
+      // join must genuinely concatenate. The catch-all below would break the
+      // cabrito probe above by returning a constant (issue #167).
+      if (cmd === 'plugin:path|join') {
+        const parts = (payload.paths as string[]) ?? []
+        return parts.join('/').replace(/\/{2,}/g, '/')
+      }
+
       if (cmd === 'tauri' && payload && typeof payload === 'object') {
         const inner = (payload as { cmd?: string }).cmd
-        if (inner?.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+        if (inner === 'plugin:path|join') {
+          const parts = ((payload as { paths?: string[] }).paths as string[]) ?? []
+          return parts.join('/').replace(/\/{2,}/g, '/')
+        }
+        if (inner?.startsWith('plugin:path|')) return APP_DATA_DIR
         return null
       }
 
-      if (cmd.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+      if (cmd.startsWith('plugin:path|')) return APP_DATA_DIR
       if (cmd.startsWith('plugin:')) return null
 
       return null

--- a/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
+++ b/tests/e2e/fixtures/posterframe-backgrounds.fixture.ts
@@ -120,8 +120,14 @@ export async function installBackgroundMocks(
         if (path.toLowerCase().includes('cabrito')) return cfg.fontInstalled
         if (path === cfg.folder) return cfg.scenario !== 'missing'
         // A path beside the app data directory rather than inside it is the
-        // pre-#167 layout. E2E runs start already migrated.
-        if (path.startsWith(APP_DATA_DIR) && !path.startsWith(`${APP_DATA_DIR}/`)) {
+        // pre-#167 layout. E2E runs start already migrated. The directory
+        // itself must still report as present, or every run takes the mkdir
+        // branch.
+        if (
+          path !== APP_DATA_DIR &&
+          path.startsWith(APP_DATA_DIR) &&
+          !path.startsWith(`${APP_DATA_DIR}/`)
+        ) {
           return false
         }
         return true

--- a/tests/e2e/fixtures/sprout-folders.fixture.ts
+++ b/tests/e2e/fixtures/sprout-folders.fixture.ts
@@ -95,6 +95,9 @@ export async function setupSproutMocks(
     const installedAt = Date.now()
     win.__sproutFolderCalls__ = []
 
+    /** No trailing separator, matching the real appDataDir (issue #167). */
+    const APP_DATA_DIR = '/tmp/bucket-e2e'
+
     // plugin:fs|read_text_file returns BYTES, which the plugin then decodes.
     // Returning a string here yields garbage after Uint8Array.from().
     const apiKeysBytes = Array.from(
@@ -130,6 +133,11 @@ export async function setupSproutMocks(
       // Settings live in api_keys.json, read through the fs plugin.
       if (cmd === 'plugin:fs|exists') {
         const path = String((payload.path as string) ?? '')
+        // A path beside the app data directory rather than inside it is the
+        // pre-#167 layout. E2E runs start already migrated.
+        if (path.startsWith(APP_DATA_DIR) && !path.startsWith(`${APP_DATA_DIR}/`)) {
+          return false
+        }
         // No saved index at start, so tests exercise building one.
         return !path.includes('sprout-folder-index')
       }
@@ -142,13 +150,25 @@ export async function setupSproutMocks(
       if (cmd === 'plugin:fs|write_text_file') return null
       if (cmd === 'plugin:fs|read_dir') return []
 
+      // join must genuinely concatenate. Answering it with the catch-all
+      // constant below would collapse api_keys.json and the folder index onto
+      // one path (issue #167).
+      if (cmd === 'plugin:path|join') {
+        const parts = (payload.paths as string[]) ?? []
+        return parts.join('/').replace(/\/{2,}/g, '/')
+      }
+
       if (cmd === 'tauri' && payload && typeof payload === 'object') {
         const inner = (payload as { cmd?: string }).cmd
-        if (inner?.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+        if (inner === 'plugin:path|join') {
+          const parts = ((payload as { paths?: string[] }).paths as string[]) ?? []
+          return parts.join('/').replace(/\/{2,}/g, '/')
+        }
+        if (inner?.startsWith('plugin:path|')) return APP_DATA_DIR
         return null
       }
 
-      if (cmd.startsWith('plugin:path|')) return '/tmp/bucket-e2e/'
+      if (cmd.startsWith('plugin:path|')) return APP_DATA_DIR
       if (cmd.startsWith('plugin:')) return null
 
       return null

--- a/tests/e2e/fixtures/sprout-folders.fixture.ts
+++ b/tests/e2e/fixtures/sprout-folders.fixture.ts
@@ -134,8 +134,14 @@ export async function setupSproutMocks(
       if (cmd === 'plugin:fs|exists') {
         const path = String((payload.path as string) ?? '')
         // A path beside the app data directory rather than inside it is the
-        // pre-#167 layout. E2E runs start already migrated.
-        if (path.startsWith(APP_DATA_DIR) && !path.startsWith(`${APP_DATA_DIR}/`)) {
+        // pre-#167 layout. E2E runs start already migrated. The directory
+        // itself must still report as present, or every run takes the mkdir
+        // branch.
+        if (
+          path !== APP_DATA_DIR &&
+          path.startsWith(APP_DATA_DIR) &&
+          !path.startsWith(`${APP_DATA_DIR}/`)
+        ) {
           return false
         }
         // No saved index at start, so tests exercise building one.

--- a/tests/e2e/fixtures/tauri-e2e-mocks.ts
+++ b/tests/e2e/fixtures/tauri-e2e-mocks.ts
@@ -495,6 +495,14 @@ export class TauriE2EMock {
             return '/mock/app/data'
           }
 
+          // Must genuinely concatenate: the app joins the app data directory
+          // to a filename, and a constant answer would collapse every settings
+          // file onto one path (issue #167).
+          if (cmd === 'plugin:path|join') {
+            const parts = (args?.paths as string[]) ?? []
+            return parts.join('/').replace(/\/{2,}/g, '/')
+          }
+
           if (
             cmd === 'plugin:path|app_data_dir' ||
             cmd === 'plugin:path|app_config_dir' ||
@@ -503,7 +511,8 @@ export class TauriE2EMock {
             cmd === 'plugin:path|app_log_dir'
           ) {
             console.log('[E2E Mock] Mocking', cmd)
-            return '/mock/app/data/'
+            // No trailing separator, matching the real API (issue #167).
+            return '/mock/app/data'
           }
 
           if (

--- a/tests/integration/us06-sprout-upload.test.ts
+++ b/tests/integration/us06-sprout-upload.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../src/features/Upload/api', () => ({
   // Tagged result since issue #166: a bare array would be read as a missing
   // `status` and misclassify inside the test rather than failing loudly.
   listDirectory: vi.fn().mockResolvedValue({ status: 'ok', files: [] }),
-  getFontDir: vi.fn().mockResolvedValue('/mock/fonts'),
+  posterFrameFontPath: vi.fn().mockResolvedValue('/mock/fonts/Cabrito.otf'),
   fileExists: vi.fn().mockResolvedValue(false),
   openFolder: vi.fn().mockResolvedValue(undefined)
 }))

--- a/tests/setup/vitest-setup.ts
+++ b/tests/setup/vitest-setup.ts
@@ -190,15 +190,17 @@ const mockTauriApis = () => {
   // None of the directory getters returns a trailing separator, matching the
   // real API. A file-level vi.mock replaces this factory wholesale, so any
   // test file declaring its own must supply `join` too (issue #167).
+  // Plain functions rather than vi.fn: vitest.config.ts sets `mockReset`, so a
+  // vi.fn's implementation is wiped before every test after the first, leaving
+  // appDataDir() returning undefined. Files that need to assert on these calls
+  // declare their own factory, which replaces this one wholesale.
   vi.mock('@tauri-apps/api/path', () => ({
-    appDataDir: vi.fn().mockResolvedValue('/mock/app/data'),
-    appConfigDir: vi.fn().mockResolvedValue('/mock/app/config'),
-    appCacheDir: vi.fn().mockResolvedValue('/mock/app/cache'),
-    appLocalDataDir: vi.fn().mockResolvedValue('/mock/app/local-data'),
-    fontDir: vi.fn().mockResolvedValue('/mock/fonts'),
-    join: vi.fn((...parts: string[]) =>
-      Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
-    )
+    appDataDir: async () => '/mock/app/data',
+    appConfigDir: async () => '/mock/app/config',
+    appCacheDir: async () => '/mock/app/cache',
+    appLocalDataDir: async () => '/mock/app/local-data',
+    fontDir: async () => '/mock/fonts',
+    join: async (...parts: string[]) => parts.join('/').replace(/\/{2,}/g, '/')
   }))
 
   // Mock window API for useWindowState and useSystemTheme hooks

--- a/tests/setup/vitest-setup.ts
+++ b/tests/setup/vitest-setup.ts
@@ -186,11 +186,19 @@ const mockTauriApis = () => {
   }))
 
   // Mock Tauri path APIs (used by storage utilities)
+  //
+  // None of the directory getters returns a trailing separator, matching the
+  // real API. A file-level vi.mock replaces this factory wholesale, so any
+  // test file declaring its own must supply `join` too (issue #167).
   vi.mock('@tauri-apps/api/path', () => ({
     appDataDir: vi.fn().mockResolvedValue('/mock/app/data'),
     appConfigDir: vi.fn().mockResolvedValue('/mock/app/config'),
     appCacheDir: vi.fn().mockResolvedValue('/mock/app/cache'),
-    appLocalDataDir: vi.fn().mockResolvedValue('/mock/app/local-data')
+    appLocalDataDir: vi.fn().mockResolvedValue('/mock/app/local-data'),
+    fontDir: vi.fn().mockResolvedValue('/mock/fonts'),
+    join: vi.fn((...parts: string[]) =>
+      Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+    )
   }))
 
   // Mock window API for useWindowState and useSystemTheme hooks

--- a/tests/unit/utils/storage.test.ts
+++ b/tests/unit/utils/storage.test.ts
@@ -13,13 +13,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock Tauri APIs
 vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn()
+  appDataDir: vi.fn(),
+  // Without this the join throws, the migration falls back, and the assertions
+  // below pass against the concatenated path this issue fixes (#167).
+  join: vi.fn((...parts: string[]) =>
+    Promise.resolve(parts.join('/').replace(/\/{2,}/g, '/'))
+  )
 }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
   exists: vi.fn(),
   readTextFile: vi.fn(),
-  writeTextFile: vi.fn()
+  writeTextFile: vi.fn(),
+  stat: vi.fn().mockResolvedValue({ isFile: true, isDirectory: false, isSymlink: false }),
+  rename: vi.fn(),
+  remove: vi.fn(),
+  mkdir: vi.fn()
 }))
 
 // Mock app store
@@ -37,8 +46,10 @@ vi.mock('@shared/store/useAppStore', () => ({
 }))
 
 describe('storage utility', () => {
-  const mockAppDataDir = '/mock/app/data/dir/'
-  const mockFilePath = `${mockAppDataDir}api_keys.json`
+  // No trailing separator: the real appDataDir never returns one, and the
+  // trailing slash here is what hid #167 from this suite.
+  const mockAppDataDir = '/mock/app/data/dir'
+  const mockFilePath = `${mockAppDataDir}/api_keys.json`
 
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
Closes #167.

`appDataDir()` returns no trailing separator, so `${dir}${file}` wrote `api_keys.json` and `sprout-folder-index.json` *beside* the app data directory rather than inside it. Reads and writes shared the expression, so the app worked and the fault stayed invisible — but correcting the join alone would have orphaned every user's settings. `tauri.conf.json:5` uses the same identifier for release builds, so this is not dev-only.

## B1 — Path construction

`join()` from `@tauri-apps/api/path` at three sites: `getFilePath()`, `folderIndexPath()`, and a new `posterFrameFontPath()` that both `posterFrameFontAvailable()` and `internal/loadFont.ts` consume. `loadFont` cannot call `join` itself — `upload.contract.test.ts:470-478` forbids `@tauri-apps` imports outside `api.ts` — so routing it through the export is what stops the two paths drifting apart. `getFontDir()` lost its last caller and is removed.

No capability change needed: `core:path:default` already includes `allow-join`, and `fs:write-all` scoped `**` grants `rename`/`remove`/`mkdir`.

## B2–B4 — Migration

New `shared/utils/appDataPath.ts` resolves a file inside the directory and relocates any copy left beside it. Lazy and memoised per file, so it precedes the startup `prefetchApiKeys()` and concurrent callers share one move (the startup prefetch racing an open Settings page is a real case, not a synthetic one).

Guards before anything is moved:
- **Identity** — the misplaced path can only be computed by reproducing the bug. If `appDataDir()` ever returned a trailing separator that expression *is* the correct path, and the collision rule would delete the user's real file. Every IPC-level E2E fixture returned a trailing slash, so this was live, not hypothetical.
- **File type** — regular files only. A directory there belongs to something else (an app whose identifier extends ours would create one), which settles ownership completely.
- **Collision** — the correct-location file wins untouched; the stray is deleted. `rename` replaces its destination, so the destination is probed first.

`api_key.txt`, superseded and read by nothing, is swept once per session whether or not `api_keys.json` needed moving — scoping it to the migration event would leave it forever on any machine past its first upgrade.

## B5 — Failure

Filesystem failures never throw: a failed move falls back to the misplaced path so reads and writes agree, and retries on the next call rather than pinning the session. An unanswerable existence probe resolves to the correct path — it is not evidence a stray file exists.

## Testing

Red → green, in separate commits. `7c9ec5b` commits the failing tests alone: **13 failed, 1 passed, plus 19 uncollected** (the resolver module did not exist). The single pass was a deliberate regression guard.

Final state:
| Gate | Result |
|---|---|
| Unit (`test:run`) | 183 files, **2748 passed** |
| E2E chromium (CI's spec gate) | **57 passed** |
| E2E sprout-folders + posterframe-backgrounds + smoke | **35 passed** |
| `eslint src` | 0 errors (19 pre-existing warnings) |
| `prettier src -c` | clean |
| `vite build` | clean |

Prettier status of every touched file under `tests/` is byte-identical to master; the 72 pre-existing failures there are outside `bun run prettier`'s scope and untouched.

## Adversarial review round

A review of the complete diff against the issue's behaviours returned **NEEDS CHANGES** with 12 findings. Two were shipping-blockers:

1. **`mkdir` sat inside the rename branch**, so the directory was only ensured when something needed migrating. Nothing else creates it — `rag.rs` makes it on demand — and the old concatenation worked precisely because it wrote into the always-present *parent*. On this machine the directory is dated eight months after the settings file, i.e. the app ran that whole time with no app data directory. Joining correctly without this would have broken saves for exactly those users. **Fixed**, with B2.5 added.
2. **`resolveAppDataFile` rejected when `appDataDir()` failed**, because the fallback re-invoked the same failing call — its "never rejects" contract was false. **Fixed**: it now propagates deliberately (there is no honest path to return without a directory) and the contract says so. B5.6 added.

Also fixed: a rejecting `join` was treated as a failed move and would have redirected to the misplaced path (B5.7, typed sentinel); the contract test was still a source grep despite claiming otherwise (it now executes each fixture's init script and invokes the handler); `appDataDir` resolves via `plugin:path|resolve_directory`, not `plugin:path|app_data_dir`, so `mocks.fixture.ts` was returning `null`; `api.contract.test.ts` was missed by the mock sweep; B5.5's test asserted its clause under a no-migration precondition; B1.4 asserted the export rather than `loadFont`'s use of it; B4.4 stipulated the second session's state instead of inheriting it; a stale `getFontDir` mock survived.

One finding rejected: the review reported `e2e-mock-protocol.contract.test.ts` as newly failing prettier. It fails on master too — verified file by file.

Decisions recorded as an amendment comment on #167 rather than applied silently.

## Notes for review

- **Test infrastructure was the real story.** Four E2E fixtures gain a genuine `plugin:path|join` handler; three of them answered every `plugin:path|*` command with one hardcoded constant, which would have collapsed `api_keys.json` and the folder index onto a single path and broken the `cabrito` and `sprout-folder-index` substring probes those fixtures depend on. No path mock returns a trailing separator any more — that fiction is what hid this from a suite of 2737 passing tests.
- **Path mocks are now plain functions, not `vi.fn()`.** `vitest.config.ts` sets `mockReset`, which wipes a factory-declared implementation before every test after the first. `storage.saveApiKeys.test.ts` failed for exactly this reason once the code actually depended on `appDataDir()` returning something.
- **Release builds log nothing.** `logger.ts:37-51` is an all-`noop` outside development, so the migration leaves no trace in production. Accepted deliberately (agreed on the issue): the on-disk state is the trace, and a failure is absorbed by the fallback. Changing app-wide logging policy is out of scope.
- **`join` is an IPC round trip**, not a string operation, on every settings read and write. Negligible, but a real change.
- **Two concurrent app instances** can still race the collision check, since dev and release share one identifier. Acknowledged rather than locked against.
- **Out of scope**: eight other hardcoded-`/` sites in Baker, Trello, build-project and Posterframe, where paths come from dialogs or user config rather than Tauri directory APIs. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
