### PR TITLE
fix(ui): cap dialog height and let it scroll its own content

### DIFF
--- a/src/shared/ui/alert-dialog.tsx
+++ b/src/shared/ui/alert-dialog.tsx
@@ -33,7 +33,10 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        // Same cap as DialogContent, for the same reason -- and it matters more
+        // here: an alert dialog exists for its Cancel/Confirm buttons, and those
+        // are the first thing an uncapped overflow puts out of reach. See #157.
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid max-h-[85vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-6 shadow-lg duration-200 sm:rounded-lg',
         className
       )}
       {...props}

--- a/src/shared/ui/dialog.test.tsx
+++ b/src/shared/ui/dialog.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogTitle
+} from './alert-dialog'
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from './dialog'
+
+/**
+ * These assert the overflow contract of the two dialog primitives, which #157
+ * showed is load-bearing rather than cosmetic: with no cap and no scroll
+ * container, a dialog taller than the viewport ran off both edges and its own
+ * footer buttons became unreachable.
+ *
+ * jsdom has no layout engine, so these pin the CSS contract rather than measured
+ * geometry. The geometry was verified in a real browser: uncapped, a 733px
+ * dialog in a 591px viewport sat at top -71 / bottom 662 with
+ * `overflow-y: visible` and nothing scrollable; capped, the same dialog fits and
+ * its Cancel and Upload buttons scroll into reach.
+ */
+const tallContent = <div style={{ height: 4000 }}>tall</div>
+
+describe('DialogContent overflow contract', () => {
+  it('caps its height so it cannot outgrow the viewport', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Tall dialog</DialogTitle>
+          {tallContent}
+        </DialogContent>
+      </Dialog>
+    )
+
+    expect(screen.getByRole('dialog').className).toContain('max-h-[85vh]')
+  })
+
+  it('scrolls its own content, so nothing is unreachable', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Tall dialog</DialogTitle>
+          {tallContent}
+          <DialogFooter>
+            <button>Confirm</button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+
+    expect(screen.getByRole('dialog').className).toContain('overflow-y-auto')
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument()
+  })
+
+  it('lets a consumer override the cap', () => {
+    // Three dialogs already set their own cap. tailwind-merge must drop the
+    // default rather than emit both, or the winner depends on CSS source order.
+    render(
+      <Dialog open>
+        <DialogContent className="max-h-[60vh]">
+          <DialogTitle>Custom cap</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    )
+
+    const className = screen.getByRole('dialog').className
+    expect(className).toContain('max-h-[60vh]')
+    expect(className).not.toContain('max-h-[85vh]')
+  })
+})
+
+describe('AlertDialogContent overflow contract', () => {
+  it('caps and scrolls, so its confirm button stays reachable', () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogTitle>Delete everything?</AlertDialogTitle>
+          {tallContent}
+          <AlertDialogFooter>
+            <AlertDialogAction>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    )
+
+    const className = screen.getByRole('alertdialog').className
+    expect(className).toContain('max-h-[85vh]')
+    expect(className).toContain('overflow-y-auto')
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -35,7 +35,15 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        // `max-h-[85vh] overflow-y-auto` is load-bearing, not cosmetic. Without
+        // a cap the -50% translate grows the dialog symmetrically, so it runs
+        // off the top and bottom at the same rate, and nothing scrolls: the
+        // body is `fixed` and Radix's modal mode applies RemoveScroll, leaving
+        // the overflow -- including the footer buttons -- simply unreachable.
+        // See #157. Consumers may still override via className (tailwind-merge),
+        // and a dialog wanting a pinned header/footer can add `flex flex-col`
+        // plus `flex-1 overflow-y-auto` on its body, as ViewExampleDialog does.
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid max-h-[85vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-6 shadow-lg duration-200 sm:rounded-lg',
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #157.

## Reproduced first

`UploadDialog` in the running app, 591px-tall viewport — measured, not inferred:

```json
{ "dialogHeight": 733, "top": -71, "bottom": 662,
  "maxHeight": "none", "overflowY": "visible", "scrollable": false,
  "clippedTop": true, "clippedBottom": true }
```

Its title and close X were cut off the top, its Cancel and Upload buttons off the bottom, with no scrollbar anywhere to reach either. Exactly the symmetric overflow the issue describes: centred by a `-50%` translate, so it runs off both edges at the same rate, and nothing scrolls because the element is `fixed`, the body behind it doesn't scroll, and Radix's modal mode applies `RemoveScroll`.

## The fix

`max-h-[85vh] overflow-y-auto` on `DialogContent`. Verified in the same browser afterwards:

| | before | after |
|---|---|---|
| `max-height` | `none` | `374px` (85vh) |
| `overflow-y` | `visible` | `auto` |
| scrollable | false | true |
| clipped top / bottom | true / true | false / false |
| Cancel + Upload | unreachable | reachable after scroll |

I took the simpler of the two options the issue offers (whole dialog scrolls, rather than `grid-rows-[auto_minmax(0,1fr)_auto]` with a pinned header and footer). `grid-rows` assumes exactly three children, and the 13 consumers here don't have a consistent child count, so it's unsafe as a shared default. A dialog that wants a pinned footer can still opt in per-dialog with `flex flex-col` plus `flex-1 overflow-y-auto`, which `ViewExampleDialog` already does.

## AlertDialogContent too

`AlertDialogContent` carried a character-for-character identical class string and the same defect. Left alone, "tall dialogs clip their buttons" would only be half fixed — and it arguably matters more there, since an alert dialog exists for its Cancel/Confirm buttons and those are precisely what an uncapped overflow puts out of reach.

## Acceptance criteria

- [x] A dialog taller than the viewport scrolls internally; no content unreachable
- [x] Existing short dialogs visually unchanged — verified at a 903px viewport where the cap (768px) exceeds the dialog's natural height: same 733px height as before, `scrollable: false`, and `offsetWidth - clientWidth - borders = 0`, so no scrollbar gutter appears
- [x] Regression test
- [~] `AddVideoDialog` specifically at 768px — see below

On the `AddVideoDialog` criterion: I could not drive that surface in a browser, because reaching it needs a Baker drive scan through the Tauri backend. It renders a bare `<DialogContent>` with no className override, so it inherits exactly what I measured, and its content is taller than the dialog I tested — but I'm flagging that I verified the primitive rather than that surface directly. Worth a look when you next have the real app open on a laptop screen.

## Known trade-off

The close X is absolutely positioned inside what is now the scroll container, so it scrolls out of view on a tall dialog (measured: `top: -308` when scrolled to the bottom). Esc, the overlay and the dialog's own Cancel button all still close it, and this is strictly better than before, where the X was *permanently* unreachable on a tall dialog. Pinning it would require wrapping children in an inner scroller, which `ViewExampleDialog` forbids — it sets `flex flex-col` on `DialogContent` and relies on its children being direct flex children.

## Left deliberately alone

Three dialogs (`BatchUpdateConfirmationDialog`, `AddCardDialog`, `ViewExampleDialog`) already worked around this locally with their own `max-h-[80vh] overflow-y-auto`. Those overrides still win through tailwind-merge. Harmonising them to 85vh would be a cosmetic change to Baker and Trello surfaces I can't reach in a browser to verify, so I left them.

## Tests

`src/shared/ui/dialog.test.tsx`. jsdom has no layout engine, so these pin the CSS contract rather than measured geometry — the real geometry is the browser measurements above. Reverting the fix fails 3 of the 4; the fourth pins that a consumer's own cap overrides the default, which three dialogs depend on.

Full suite: 2779 passed, 28.4s.