### PR TITLE
ci: run the Rust tests, and gate them on macOS instead of Linux (#185)

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -58,27 +58,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up cargo cache
-        uses: actions/cache@v5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -90,14 +69,15 @@ jobs:
       - name: Run unit tests
         run: bun run test:run
 
-      # deb only: this runs on Linux and no Linux artifact is released, so the
-      # AppImage bundle added a network dependency without an output. See ci.yml.
-      - name: Build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          PKG_CONFIG_ALLOW_CROSS: 1
-        run: bun run build:tauri -- --bundles deb
+      # No Rust step here on purpose. This workflow fires on a push to master,
+      # and ci.yml runs on every push to master with no path filter, so its
+      # rust-test job already compiles and tests this exact commit - on macOS,
+      # which is the platform actually shipped. Repeating it here would gate the
+      # same commit twice, and the Linux build it replaced never compiled the
+      # cfg(target_os = "macos") code at all (issue #185).
+      #
+      # Dropping it also lets this job shed the apt packages, Rust toolchain and
+      # cargo cache it only needed in order to build.
 
   e2e-tests:
     needs: [check-version-bump, test]

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -90,12 +90,14 @@ jobs:
       - name: Run unit tests
         run: bun run test:run
 
+      # deb only: this runs on Linux and no Linux artifact is released, so the
+      # AppImage bundle added a network dependency without an output. See ci.yml.
       - name: Build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           PKG_CONFIG_ALLOW_CROSS: 1
-        run: bun run build:tauri
+        run: bun run build:tauri -- --bundles deb
 
   e2e-tests:
     needs: [check-version-bump, test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,17 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Only the deb bundle. Nothing Linux is ever released - publish.yml ships
+      # macOS DMGs alone - so this job exists to prove the code compiles and the
+      # bundle config resolves. Building the AppImage as well downloaded four
+      # files at bundle time, two of them from a mutable upstream `master`, and
+      # an outage there failed every branch at once (issue #185). deb bundling
+      # is pure Rust and touches the network not at all.
       - name: Build
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: bun run build:tauri
+        run: bun run build:tauri -- --bundles deb
 
   # macOS build is expensive (10x Linux cost) - only run on release branch pushes
   # For PRs, the Linux build validates the code compiles correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,22 @@ jobs:
       - name: Run unit tests
         run: bun run test:run
 
-  build:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+  # Gates Rust on macOS, the only platform shipped (publish.yml releases DMGs
+  # and nothing else). This replaced a Linux release build, which was blind to
+  # the code it claimed to guard: 19 blocks are behind cfg(target_os = "macos"),
+  # including utils/macos_copyfile.rs, the native copyfile(3) transfer path that
+  # BuildProject depends on. None of it compiled on Linux, so a break there
+  # reached the release branch unnoticed (issue #185).
+  #
+  # macOS minutes bill ~10x, so this deliberately runs the tests and no bundle.
+  # Full DMG bundling stays on release pushes in build-macos below.
+  rust-test:
+    runs-on: macos-14 # Apple Silicon, matching the aarch64 target publish.yml ships
+    timeout-minutes: 30
     needs: [lint, test]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -77,7 +81,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            src-tauri/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -87,20 +91,20 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      # Only the deb bundle. Nothing Linux is ever released - publish.yml ships
-      # macOS DMGs alone - so this job exists to prove the code compiles and the
-      # bundle config resolves. Building the AppImage as well downloaded four
-      # files at bundle time, two of them from a mutable upstream `master`, and
-      # an outage there failed every branch at once (issue #185). deb bundling
-      # is pure Rust and touches the network not at all.
-      - name: Build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: bun run build:tauri -- --bundles deb
+      # Required, not incidental: tauri::generate_context! embeds frontendDist
+      # at compile time, so cargo fails with "the frontendDist configuration is
+      # set to ../dist but this path doesn't exist" if the frontend was never
+      # built. It also keeps a production `vite build` in CI - the e2e job runs
+      # the dev server, so nothing else would catch a production-only break.
+      - name: Build frontend
+        run: bun run build
+
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test
 
   # macOS build is expensive (10x Linux cost) - only run on release branch pushes
-  # For PRs, the Linux build validates the code compiles correctly
+  # For PRs, rust-test above compiles the same macOS code paths without bundling
   build-macos:
     runs-on: macos-latest
     timeout-minutes: 30

--- a/.github/workflows/update-rust-packages.yml
+++ b/.github/workflows/update-rust-packages.yml
@@ -15,17 +15,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+  # Kept, unlike the Linux build in auto-release-pr.yml, because this is the
+  # only thing guarding a Rust dependency bump on a renovate branch before a PR
+  # exists. Moved to macOS because that is where a dependency bump is most
+  # likely to break: libc is a macOS-only dependency, objc2 carries a macOS
+  # profile override, and 19 blocks sit behind cfg(target_os = "macos") - none
+  # of which a Linux build ever compiled (issue #185).
+  rust-test:
+    runs-on: macos-14 # Apple Silicon, matching the aarch64 target publish.yml ships
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -39,7 +40,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            src-tauri/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -51,7 +52,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      # deb only: this runs on Linux and no Linux artifact is released, so the
-      # AppImage bundle added a network dependency without an output. See ci.yml.
-      - name: Build
-        run: bun run build:tauri -- --bundles deb
+      # tauri::generate_context! embeds frontendDist at compile time, so cargo
+      # cannot compile at all unless dist/ exists. See ci.yml.
+      - name: Build frontend
+        run: bun run build
+
+      - name: Run Rust tests
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/update-rust-packages.yml
+++ b/.github/workflows/update-rust-packages.yml
@@ -51,5 +51,7 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # deb only: this runs on Linux and no Linux artifact is released, so the
+      # AppImage bundle added a network dependency without an output. See ci.yml.
       - name: Build
-        run: bun run build:tauri
+        run: bun run build:tauri -- --bundles deb


### PR DESCRIPTION
Fixes #185. Two problems in one place, so one PR: the `build` check had been red on every branch since yesterday, and separately it was guarding the wrong platform while the Rust tests ran nowhere at all.

> **Scope grew after review was requested.** This started as the AppImage fix alone. It now also adds the Rust tests and moves the gate to macOS, because investigating the first problem turned up the second and they touch the same job.

## 1. The red check was an upstream outage

`tauri.conf.json` sets `bundle.targets: "all"`, so Linux builds produced deb, rpm **and** AppImage. The AppImage bundler downloads four files at bundle time - `AppRun`, `linuxdeploy`, and two plugin scripts pulled from a mutable upstream `master` branch. When those returned 503, every branch failed at once.

Verified as not a code defect before changing anything: **re-running `master`'s own previously-green build job, against unchanged code, failed identically** with `failed to bundle project: http status: 503`.

## 2. The gate was blind to the code we ship

`publish.yml` releases **macOS only**. Meanwhile 19 blocks are behind `cfg(target_os = "macos")`, including `utils/macos_copyfile.rs` - the native `copyfile(3)`/`clonefile` transfer path BuildProject depends on - plus paths in `plugins.rs`, `premiere.rs` and `system.rs`. **None of it compiled on Linux.** The gate could pass green while the shipped app was broken, with the break surfacing only on a push to `release`.

## 3. The Rust tests ran on no job at all

`lint` is eslint plus prettier, `test` is vitest. All 220 Rust tests were unguarded - a regression reached `master` as long as it still compiled.

## The change

The Linux `build` job is replaced by `rust-test` on `macos-14`:

| | before | after |
| --- | --- | --- |
| platform | ubuntu-24.04 | macos-14 (aarch64, as shipped) |
| Rust tests | none | 220, including 4 macOS-only |
| `cfg(macos)` code | never compiled | compiled |
| output | deb + rpm + AppImage, all discarded | none |
| network at bundle time | 4 downloads | none |

Tests but no bundle, deliberately - macOS minutes bill ~10x, and full DMG bundling already happens in `build-macos` on release pushes.

**The frontend build step is required, not incidental.** `tauri::generate_context!` embeds `frontendDist` at compile time, so cargo fails outright if `dist/` was never built. I verified this rather than assumed it, by removing `dist/` locally:

```
error: proc macro panicked
   = help: message: The `frontendDist` configuration is set to `"../dist"` but this path doesn't exist
```

It also keeps a production `vite build` in CI, which would otherwise have been lost along with the Linux job - the e2e job runs `vite dev`, so nothing else would catch a production-only break.

`auto-release-pr.yml` and `update-rust-packages.yml` still build on Linux, now deb-only, which fixes their outage exposure.

## Verification

The AppImage fix was confirmed from the log of this PR's earlier run, not from a green tick - a tick alone would not distinguish "fixed" from "the outage ended". The build step contained no `Bundling …AppImage` and none of the four `Downloading …` lines, while still compiling Rust and bundling the deb. That commit also confirmed `createUpdaterArtifacts` still works without AppImage (`Finished 1 updater signature`).

The new `rust-test` job is verified by this PR's current run; I will confirm the test count below rather than assert it now. Locally the same 220 tests pass on macOS.

## Every Linux tauri build is now gone

Following review feedback, the same treatment was applied to the remaining two, differently because the cases differ:

- **`auto-release-pr.yml`** - Rust build removed outright. It fires on a push to master, which `ci.yml` already gates via `rust-test` on the same commit. The job sheds its apt packages, Rust toolchain and cargo cache too.
- **`update-rust-packages.yml`** - kept but moved to macOS. It guards a Rust dependency bump on a `renovate/**` branch before a PR exists, so nothing else covers it, and `libc`/`objc2` make a macOS bump exactly the kind that breaks there.

Neither can execute on this PR, so both are validated by `actionlint` (clean, and mutation-tested to confirm it would flag a bad runner label) plus being step-for-step identical to the `rust-test` job proven green here.

Still open from #185: a dead `if: matrix.platform == 'ubuntu-22.04'` step in `publish.yml`.
