### PR TITLE
feat(kavanagh): tail structure, sting identity and the overall verdict (#180 stage 3)

### DIFF
--- a/src-tauri/src/kavanagh/check.rs
+++ b/src-tauri/src/kavanagh/check.rs
@@ -1,0 +1,254 @@
+//! One whole run: probe, tail, sting, watermark, verdict (D9).
+//!
+//! The order is forced by a circular dependency and is the reason this module
+//! exists rather than the work living in `watermark`. The watermark is not
+//! expected over the closing dip - checking it there reports a gap on every
+//! correct render - but the dip is found by the tail analysis. So the tail runs
+//! first and hands the watermark pass the point to stop at.
+//!
+//! When no dip is found, both problems are reported rather than one hiding the
+//! other: the watermark span falls back to a fixed window and the report says
+//! it was approximated (B5.10). An operator should learn everything wrong with
+//! a render in one run, not fix one fault to discover the next.
+
+use serde::Serialize;
+use tokio::sync::watch;
+
+use super::error::KavanaghError;
+use super::ffmpeg::{run_capture, run_frames};
+use super::parsing::{parse_signalstats, LumaSample, VideoProbe};
+use super::sting::{assess, default_threshold, StingOutcome, StingReference, StingReport};
+use super::tail::{analyse_tail, TailAnalysis};
+use super::thresholds::{
+    resolve_match_confidence, STING_COMPARISON_HEIGHT, STING_COMPARISON_WIDTH, STING_SAMPLE_FPS,
+    STING_SETTLED_OFFSET_SECONDS, TAIL_WINDOW_SECONDS,
+};
+use super::verdict::{overall, Verdict};
+use super::watermark::{
+    analyse_with_probe, probe_video, AnalysisRequest, Phase, WatermarkReport,
+};
+
+/// Everything one run concluded, with each check's own result intact (B7.2).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckReport {
+    pub verdict: Verdict,
+    pub watermark: WatermarkReport,
+    pub tail: TailAnalysis,
+    /// `None` when no white peak was found, so no sting could be located.
+    pub sting: Option<StingReport>,
+    /// One sentence per fault, ready to render.
+    ///
+    /// Written here rather than in the frontend because every one of them
+    /// carries a measurement - "the dip to white takes 0.25s, expected 0.40s
+    /// (0.32-0.48s)" - and the numbers, their formatting and the tolerances
+    /// they are quoted against all live on this side. Duplicating that in
+    /// TypeScript would be two places to keep in step for no gain.
+    pub problem_messages: Vec<String>,
+    /// Caveats about the run as a whole, as opposed to either check.
+    pub notes: Vec<String>,
+}
+
+/// Runs both checks over one video and reduces them to a verdict.
+pub fn run_check(
+    request: &AnalysisRequest,
+    cancel: &watch::Receiver<bool>,
+    progress: &mut dyn FnMut(Phase, f64, &str),
+) -> Result<CheckReport, KavanaghError> {
+    // First, before any process is spawned, for the same reason as in
+    // `watermark::analyse`: a rejected threshold must not arrive disguised as a
+    // file error (B13.3).
+    resolve_match_confidence(request.match_threshold)
+        .map_err(|message| KavanaghError::Threshold { message })?;
+
+    progress(Phase::Probe, 2.0, "Reading the video");
+    let probe = probe_video(request, cancel)?;
+
+    progress(Phase::Tail, 6.0, "Checking the closing transition");
+    let samples = tail_luma(request, &probe, cancel)?;
+    let tail = analyse_tail(&samples, probe.end_seconds(), probe.duration_seconds);
+
+    let sting = match tail.peak_at_seconds {
+        Some(peak_at) => {
+            progress(Phase::Tail, 14.0, "Checking the closing sting");
+            let frames = sting_frames(request, peak_at, cancel)?;
+            let references = prepare_sting_references(request, cancel);
+            Some(assess(&frames, &references, default_threshold()))
+        }
+        None => None,
+    };
+
+    let mut notes = Vec::new();
+    if tail.peak_at_seconds.is_none() {
+        notes.push(format!(
+            "No dip to white was found, so the watermark was checked over the first {:.0}s less the closing {:.0}s rather than up to a measured dip. The span is approximate.",
+            probe.duration_seconds, TAIL_WINDOW_SECONDS
+        ));
+    }
+
+    // The watermark pass starts where the dip does, so it is not asked to find a
+    // mark that is already dissolving (B4.6).
+    let watermark_request = AnalysisRequest {
+        dip_start_seconds: tail.dip_start_seconds(),
+        ..request.clone()
+    };
+
+    let watermark = analyse_with_probe(&watermark_request, &probe, cancel, progress)?;
+    let verdict = overall(watermark.outcome, &tail, sting.as_ref());
+
+    // Both checks contribute, whichever one decided the verdict (B7.2).
+    let mut problem_messages: Vec<String> =
+        tail.problems.iter().map(|problem| problem.message()).collect();
+    if let Some(report) = sting.as_ref() {
+        if report.outcome != StingOutcome::Matched {
+            problem_messages.push(report.message());
+        }
+    }
+
+    Ok(CheckReport {
+        verdict,
+        watermark,
+        tail,
+        sting,
+        problem_messages,
+        notes,
+    })
+}
+
+/// Streams per-frame luma statistics over the closing window.
+///
+/// `-copyts` is load-bearing: with a plain `-ss` the printed `pts_time` restarts
+/// at zero from the seek point, and every structural measurement is made
+/// against absolute time. Verified against real output rather than assumed.
+fn tail_luma(
+    request: &AnalysisRequest,
+    probe: &VideoProbe,
+    cancel: &watch::Receiver<bool>,
+) -> Result<Vec<LumaSample>, KavanaghError> {
+    let start = (probe.end_seconds() - TAIL_WINDOW_SECONDS).max(0.0);
+
+    let args = vec![
+        "-v".to_string(),
+        "error".to_string(),
+        "-copyts".to_string(),
+        "-ss".to_string(),
+        format!("{:.3}", start),
+        "-i".to_string(),
+        request.video_path.clone(),
+        "-vf".to_string(),
+        "signalstats,metadata=print:file=-".to_string(),
+        "-f".to_string(),
+        "null".to_string(),
+        "-".to_string(),
+    ];
+
+    let (stdout, run) = run_capture(&request.ffmpeg, &args, cancel).map_err(super::watermark::run_error)?;
+
+    if !run.exit_ok {
+        return Err(KavanaghError::Ffmpeg {
+            message: "ffmpeg could not read the closing section of this video.".to_string(),
+            stderr: run.stderr_tail,
+        });
+    }
+
+    Ok(parse_signalstats(&String::from_utf8_lossy(&stdout)))
+}
+
+/// Extracts the settled sting frames, greyscale at the comparison size.
+///
+/// Sampling starts half a second after the peak because the still's opening
+/// half second is underneath the fade from white; matching there would compare
+/// a part-white frame against the reference JPG (A6).
+fn sting_frames(
+    request: &AnalysisRequest,
+    peak_at: f64,
+    cancel: &watch::Receiver<bool>,
+) -> Result<Vec<Vec<u8>>, KavanaghError> {
+    let from = peak_at + STING_SETTLED_OFFSET_SECONDS;
+    let frame_size = (STING_COMPARISON_WIDTH * STING_COMPARISON_HEIGHT) as usize;
+
+    let args = vec![
+        "-v".to_string(),
+        "error".to_string(),
+        "-ss".to_string(),
+        format!("{:.3}", from),
+        "-i".to_string(),
+        request.video_path.clone(),
+        "-vf".to_string(),
+        format!(
+            "fps={},scale={}:{},format=gray",
+            STING_SAMPLE_FPS, STING_COMPARISON_WIDTH, STING_COMPARISON_HEIGHT
+        ),
+        "-f".to_string(),
+        "rawvideo".to_string(),
+        "-pix_fmt".to_string(),
+        "gray".to_string(),
+        "-".to_string(),
+    ];
+
+    let mut frames: Vec<Vec<u8>> = Vec::new();
+    let run = run_frames(&request.ffmpeg, &args, frame_size, cancel, |_, frame| {
+        frames.push(frame.to_vec());
+    })
+    .map_err(super::watermark::run_error)?;
+
+    if !run.exit_ok && frames.is_empty() {
+        return Err(KavanaghError::Ffmpeg {
+            message: "ffmpeg could not read the closing sting from this video.".to_string(),
+            stderr: run.stderr_tail,
+        });
+    }
+
+    Ok(frames)
+}
+
+/// Decodes every sting reference to greyscale at the comparison size.
+///
+/// A reference that cannot be read is skipped rather than failing the run, as
+/// in the watermark pool: one corrupt file in a folder should not make the
+/// whole check unavailable. An empty result is reported as an unavailable pool
+/// by the sting check itself (B6.4), which is why this returns no error.
+fn prepare_sting_references(
+    request: &AnalysisRequest,
+    cancel: &watch::Receiver<bool>,
+) -> Vec<StingReference> {
+    let expected = (STING_COMPARISON_WIDTH * STING_COMPARISON_HEIGHT) as usize;
+    let mut references = Vec::new();
+
+    for path in &request.sting_reference_files {
+        let args = vec![
+            "-v".to_string(),
+            "error".to_string(),
+            "-i".to_string(),
+            path.clone(),
+            "-vf".to_string(),
+            format!(
+                "scale={}:{},format=gray",
+                STING_COMPARISON_WIDTH, STING_COMPARISON_HEIGHT
+            ),
+            "-frames:v".to_string(),
+            "1".to_string(),
+            "-f".to_string(),
+            "rawvideo".to_string(),
+            "-pix_fmt".to_string(),
+            "gray".to_string(),
+            "-".to_string(),
+        ];
+
+        let Ok((pixels, run)) = run_capture(&request.ffmpeg, &args, cancel) else {
+            continue;
+        };
+
+        if !run.exit_ok || pixels.len() < expected {
+            continue;
+        }
+
+        references.push(StingReference {
+            path: path.clone(),
+            pixels,
+        });
+    }
+
+    references
+}
+

--- a/src-tauri/src/kavanagh/commands.rs
+++ b/src-tauri/src/kavanagh/commands.rs
@@ -1,4 +1,4 @@
-//! Tauri commands for the watermark check (issue #180, stage 2).
+//! Tauri commands for a Kavanagh run (issue #180, stages 2-3).
 //!
 //! Progress and cancellation reuse what BuildProject already established rather
 //! than inventing a third mechanism: `OperationRegistry` hands out an operation id
@@ -23,7 +23,7 @@ use super::check::{run_check, CheckReport};
 use super::discovery::{probe_binary_path, resolve_ffmpeg_tools, FfmpegAvailability};
 use super::error::KavanaghError;
 use super::evidence::{save_evidence, EvidenceItem};
-use super::watermark::{analyse, AnalysisRequest, Phase, WatermarkReport};
+use super::watermark::{AnalysisRequest, Phase};
 
 /// Which run, if any, is in flight.
 ///
@@ -110,97 +110,6 @@ pub struct KavanaghProgressEvent {
 
 /// The event name the frontend listens on.
 pub const KAVANAGH_PROGRESS_EVENT: &str = "kavanagh-progress";
-
-/// Runs the watermark check over one video.
-#[tauri::command]
-pub async fn kavanagh_run_watermark_check(
-    app: AppHandle,
-    registry: State<'_, OperationRegistry>,
-    runs: State<'_, KavanaghRunState>,
-    request: WatermarkCheckRequest,
-) -> Result<WatermarkReport, KavanaghError> {
-    let (ffmpeg, ffprobe) =
-        match resolve_ffmpeg_tools(request.ffmpeg_directory.as_deref(), probe_binary_path) {
-            FfmpegAvailability::Ready { ffmpeg, ffprobe } => (ffmpeg, ffprobe),
-            // Discovery already knows exactly which binary is missing and where it
-            // looked, so the run refuses with that rather than letting a spawn fail.
-            other => {
-                return Err(KavanaghError::Unavailable {
-                    message: describe_unavailable(&other),
-                })
-            }
-        };
-
-    if request.reference_files.is_empty() {
-        return Err(KavanaghError::ReferencePool {
-            message: "There are no watermark reference images to compare against.".to_string(),
-        });
-    }
-
-    let (operation_id, cancel_receiver) = registry.register().await;
-
-    // Claimed after registering so the id in the rejection message and the id the
-    // cancel command uses are the same one.
-    if let Err(busy) = runs.begin(operation_id.clone()) {
-        registry.complete(&operation_id).await;
-        return Err(busy);
-    }
-
-    let analysis = AnalysisRequest {
-        video_path: request.video_path.clone(),
-        ffmpeg,
-        ffprobe,
-        reference_files: request.reference_files.clone(),
-        sting_reference_files: Vec::new(),
-        match_threshold: request.match_threshold,
-        // The watermark-only entry point never measures a dip, so the span falls
-        // back to the tail-window approximation, which the report says out loud.
-        // `kavanagh_run_check` is the one that fills this in (B4.6, B5.10).
-        dip_start_seconds: None,
-    };
-
-    let emit_app = app.clone();
-    let emit_id = operation_id.clone();
-
-    // Blocking: the whole analysis is process spawning and pixel arithmetic, and
-    // running it on the async runtime's worker would stall every other command.
-    let result = tokio::task::spawn_blocking(move || {
-        analyse(
-            &analysis,
-            &cancel_receiver,
-            &mut |phase, percentage, detail| {
-                let _ = emit_app.emit(
-                    KAVANAGH_PROGRESS_EVENT,
-                    KavanaghProgressEvent {
-                        operation_id: emit_id.clone(),
-                        phase,
-                        percentage,
-                        detail: detail.to_string(),
-                    },
-                );
-            },
-        )
-    })
-    .await;
-
-    // Released before returning, on every path: leaving the slot claimed after a
-    // panic would need an app restart to run QC again.
-    runs.finish();
-    registry.complete(&operation_id).await;
-
-    match result {
-        Ok(Ok(report)) => Ok(report),
-        Ok(Err(error)) => {
-            // Logged as well as returned: a QC failure the operator screenshots is
-            // much easier to diagnose against a log line naming the same cause.
-            log::warn!("[QC] watermark check failed: {}", error.message());
-            Err(error)
-        }
-        Err(join_error) => Err(KavanaghError::Io {
-            message: format!("The quality control run did not finish: {}", join_error),
-        }),
-    }
-}
 
 /// Runs both checks over one video and returns a single verdict (D9, B7).
 ///

--- a/src-tauri/src/kavanagh/commands.rs
+++ b/src-tauri/src/kavanagh/commands.rs
@@ -19,6 +19,7 @@ use tauri::{AppHandle, Emitter, State};
 // app uses. Nothing in `build_project/transfer.rs` is touched.
 use crate::build_project::OperationRegistry;
 
+use super::check::{run_check, CheckReport};
 use super::discovery::{probe_binary_path, resolve_ffmpeg_tools, FfmpegAvailability};
 use super::error::KavanaghError;
 use super::evidence::{save_evidence, EvidenceItem};
@@ -86,6 +87,10 @@ pub struct WatermarkCheckRequest {
     pub video_path: String,
     /// The watermark pool's files, as listed by the frontend's pool resolution.
     pub reference_files: Vec<String>,
+    /// The sting pool's files. Defaulted so the watermark-only command, which
+    /// has no use for them, does not have to send an empty array.
+    #[serde(default)]
+    pub sting_reference_files: Vec<String>,
     /// The Settings ffmpeg directory, when one is configured.
     pub ffmpeg_directory: Option<String>,
     /// An advanced override; omitted means the calibrated default (B13.1).
@@ -146,10 +151,11 @@ pub async fn kavanagh_run_watermark_check(
         ffmpeg,
         ffprobe,
         reference_files: request.reference_files.clone(),
+        sting_reference_files: Vec::new(),
         match_threshold: request.match_threshold,
-        // Stage 2 has no tail analysis, so the dip start is never known and the
-        // span falls back to the tail-window approximation, which the report says
-        // out loud. Stage 3 fills this in (B4.6, B5.10).
+        // The watermark-only entry point never measures a dip, so the span falls
+        // back to the tail-window approximation, which the report says out loud.
+        // `kavanagh_run_check` is the one that fills this in (B4.6, B5.10).
         dip_start_seconds: None,
     };
 
@@ -193,6 +199,99 @@ pub async fn kavanagh_run_watermark_check(
         Err(join_error) => Err(KavanaghError::Io {
             message: format!("The quality control run did not finish: {}", join_error),
         }),
+    }
+}
+
+/// Runs both checks over one video and returns a single verdict (D9, B7).
+///
+/// The tail is measured first so the watermark pass knows where to stop, which
+/// is why this is one command rather than the frontend calling two and stitching
+/// the results together.
+#[tauri::command]
+pub async fn kavanagh_run_check(
+    app: AppHandle,
+    registry: State<'_, OperationRegistry>,
+    runs: State<'_, KavanaghRunState>,
+    request: WatermarkCheckRequest,
+) -> Result<CheckReport, KavanaghError> {
+    let (ffmpeg, ffprobe) =
+        match resolve_ffmpeg_tools(request.ffmpeg_directory.as_deref(), probe_binary_path) {
+            FfmpegAvailability::Ready { ffmpeg, ffprobe } => (ffmpeg, ffprobe),
+            other => {
+                return Err(KavanaghError::Unavailable {
+                    message: describe_unavailable(&other),
+                })
+            }
+        };
+
+    if request.reference_files.is_empty() {
+        return Err(KavanaghError::ReferencePool {
+            message: "There are no watermark reference images to compare against.".to_string(),
+        });
+    }
+
+    // An empty sting pool is deliberately not refused here: the sting check
+    // reports it as an unavailable pool and the tail is still worth measuring,
+    // which is what B6.4 asks for.
+
+    let (operation_id, cancel_receiver) = registry.register().await;
+
+    if let Err(busy) = runs.begin(operation_id.clone()) {
+        registry.complete(&operation_id).await;
+        return Err(busy);
+    }
+
+    let analysis = AnalysisRequest {
+        video_path: request.video_path.clone(),
+        ffmpeg,
+        ffprobe,
+        reference_files: request.reference_files.clone(),
+        sting_reference_files: request.sting_reference_files.clone(),
+        match_threshold: request.match_threshold,
+        // Measured by the run itself rather than supplied.
+        dip_start_seconds: None,
+    };
+
+    let mut emit = progress_emitter(app.clone(), operation_id.clone());
+
+    let result = tokio::task::spawn_blocking(move || {
+        run_check(&analysis, &cancel_receiver, &mut emit)
+    })
+    .await;
+
+    runs.finish();
+    registry.complete(&operation_id).await;
+
+    match result {
+        Ok(Ok(report)) => Ok(report),
+        Ok(Err(error)) => {
+            log::warn!("[Kavanagh] check failed: {}", error.message());
+            Err(error)
+        }
+        Err(join_error) => Err(KavanaghError::Io {
+            message: format!("The quality control run did not finish: {}", join_error),
+        }),
+    }
+}
+
+/// Builds the progress closure both entry points hand to the analysis.
+///
+/// Owned rather than borrowed because the analysis runs on a blocking thread and
+/// outlives the command's stack frame.
+fn progress_emitter(
+    app: AppHandle,
+    operation_id: String,
+) -> impl FnMut(Phase, f64, &str) + Send + 'static {
+    move |phase, percentage, detail| {
+        let _ = app.emit(
+            KAVANAGH_PROGRESS_EVENT,
+            KavanaghProgressEvent {
+                operation_id: operation_id.clone(),
+                phase,
+                percentage,
+                detail: detail.to_string(),
+            },
+        );
     }
 }
 

--- a/src-tauri/src/kavanagh/integration_tests.rs
+++ b/src-tauri/src/kavanagh/integration_tests.rs
@@ -197,6 +197,7 @@ fn run(
             video_path: video.to_string_lossy().to_string(),
             ffmpeg: ffmpeg.to_string(),
             ffprobe: ffprobe.to_string(),
+            sting_reference_files: Vec::new(),
             reference_files: references
                 .iter()
                 .map(|p| p.to_string_lossy().to_string())
@@ -458,6 +459,7 @@ fn b11_1_reports_phases_with_a_percentage_that_never_goes_backwards() {
             ffmpeg: ffmpeg.clone(),
             ffprobe: ffprobe.clone(),
             reference_files: vec![right.to_string_lossy().to_string()],
+            sting_reference_files: Vec::new(),
             match_threshold: None,
             dip_start_seconds: None,
         },
@@ -527,6 +529,7 @@ fn b13_3_refuses_an_out_of_range_threshold_before_spawning_anything() {
             ffmpeg,
             ffprobe,
             reference_files: vec![],
+            sting_reference_files: Vec::new(),
             match_threshold: Some(4.2),
             dip_start_seconds: None,
         },

--- a/src-tauri/src/kavanagh/integration_tests.rs
+++ b/src-tauri/src/kavanagh/integration_tests.rs
@@ -18,7 +18,9 @@ use super::discovery::{probe_binary_path, resolve_ffmpeg_tools, FfmpegAvailabili
 use super::error::KavanaghError;
 use super::ffmpeg::{run_frames, RunError};
 use super::geometry::Corner;
-use super::watermark::{analyse, AnalysisRequest, Phase, WatermarkOutcome, WatermarkReport};
+use super::watermark::{
+    analyse_with_probe, probe_video, AnalysisRequest, Phase, WatermarkOutcome, WatermarkReport,
+};
 
 /// The toolchain, or `None` when this machine has no ffmpeg.
 fn tools() -> Option<(String, String)> {
@@ -192,8 +194,7 @@ fn run(
 ) -> Result<WatermarkReport, KavanaghError> {
     let (_tx, cancel) = watch::channel(false);
 
-    analyse(
-        &AnalysisRequest {
+    let request = AnalysisRequest {
             video_path: video.to_string_lossy().to_string(),
             ffmpeg: ffmpeg.to_string(),
             ffprobe: ffprobe.to_string(),
@@ -204,10 +205,13 @@ fn run(
                 .collect(),
             match_threshold: None,
             dip_start_seconds: None,
-        },
-        &cancel,
-        &mut |_, _, _| {},
-    )
+    };
+
+    // Probed here rather than calling a wrapper that probes: these fixtures are
+    // watermark test cards with no closing tail, so they are checked through the
+    // watermark half directly. `check::run_check` covers the whole run.
+    let probe = probe_video(&request, &cancel)?;
+    analyse_with_probe(&request, &probe, &cancel, &mut |_, _, _| {})
 }
 
 #[test]
@@ -453,7 +457,9 @@ fn b11_1_reports_phases_with_a_percentage_that_never_goes_backwards() {
     let (_tx, cancel) = watch::channel(false);
     let mut seen: Vec<(Phase, f64)> = Vec::new();
 
-    analyse(
+    // The whole run, not just the watermark half: this is the one test that
+    // asserts what an operator actually sees a run do (B11.1).
+    crate::kavanagh::check::run_check(
         &AnalysisRequest {
             video_path: video.to_string_lossy().to_string(),
             ffmpeg: ffmpeg.clone(),
@@ -469,6 +475,10 @@ fn b11_1_reports_phases_with_a_percentage_that_never_goes_backwards() {
     .expect("the run completes");
 
     assert!(seen.iter().any(|(phase, _)| *phase == Phase::Probe));
+    assert!(
+        seen.iter().any(|(phase, _)| *phase == Phase::Tail),
+        "the tail is analysed before the watermark, so its phase must be reported"
+    );
     assert!(seen.iter().any(|(phase, _)| *phase == Phase::Watermark));
     assert!(
         seen.iter().any(|(phase, _)| *phase == Phase::Refine),
@@ -521,7 +531,7 @@ fn b13_3_refuses_an_out_of_range_threshold_before_spawning_anything() {
     let (ffmpeg, ffprobe) = require_ffmpeg!();
     let (_tx, cancel) = watch::channel(false);
 
-    let result = analyse(
+    let result = crate::kavanagh::check::run_check(
         &AnalysisRequest {
             // Deliberately not a real file: validation must happen first, so this
             // never gets as far as being opened.

--- a/src-tauri/src/kavanagh/mod.rs
+++ b/src-tauri/src/kavanagh/mod.rs
@@ -32,7 +32,7 @@ pub mod watermark;
 mod integration_tests;
 
 pub use commands::{
-    kavanagh_cancel_run, kavanagh_run_check, kavanagh_run_watermark_check, kavanagh_save_evidence,
+    kavanagh_cancel_run, kavanagh_run_check, kavanagh_save_evidence,
     KavanaghRunState,
 };
 pub use discovery::kavanagh_detect_ffmpeg;

--- a/src-tauri/src/kavanagh/mod.rs
+++ b/src-tauri/src/kavanagh/mod.rs
@@ -12,6 +12,7 @@
 //! feature outgrew one file, following the precedent of `baker/` and
 //! `build_project/` rather than accumulating a second `kavanagh_*.rs` beside it.
 
+pub mod check;
 pub mod commands;
 pub mod discovery;
 pub mod error;
@@ -21,11 +22,17 @@ pub mod geometry;
 pub mod matching;
 pub mod parsing;
 pub mod sampling;
+pub mod sting;
+pub mod tail;
 pub mod thresholds;
+pub mod verdict;
 pub mod watermark;
 
 #[cfg(test)]
 mod integration_tests;
 
-pub use commands::{kavanagh_cancel_run, kavanagh_run_watermark_check, kavanagh_save_evidence, KavanaghRunState};
+pub use commands::{
+    kavanagh_cancel_run, kavanagh_run_check, kavanagh_run_watermark_check, kavanagh_save_evidence,
+    KavanaghRunState,
+};
 pub use discovery::kavanagh_detect_ffmpeg;

--- a/src-tauri/src/kavanagh/parsing.rs
+++ b/src-tauri/src/kavanagh/parsing.rs
@@ -90,6 +90,115 @@ pub struct VideoProbe {
     pub width: u32,
     pub height: u32,
     pub duration_seconds: f64,
+    /// Frames in the stream, when ffprobe could count them.
+    pub frame_count: Option<u64>,
+    /// Frames per second, parsed from the `num/den` ffprobe prints.
+    pub frame_rate: Option<f64>,
+}
+
+impl VideoProbe {
+    /// Where the video actually ends, preferring `nb_frames / fps` over the
+    /// container's duration field (A7).
+    ///
+    /// Not pedantry. One measured render reports a container duration of
+    /// 166.633991s while its true end is 166.620s - 8331 frames at 50fps. The
+    /// tail is measured backwards from the end, so a 14ms error is a systematic
+    /// bias applied to every structural measurement: it puts a peak that is
+    /// exactly at T-5.000s at T-5.014s instead. Falls back to the container
+    /// value when either field is missing, which is the pre-A7 behaviour.
+    pub fn end_seconds(&self) -> f64 {
+        match (self.frame_count, self.frame_rate) {
+            (Some(frames), Some(fps)) if frames > 0 && fps > 0.0 => frames as f64 / fps,
+            _ => self.duration_seconds,
+        }
+    }
+}
+
+/// One frame's luma statistics, as `signalstats` reported them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LumaSample {
+    pub at_seconds: f64,
+    /// Mean luma over the frame.
+    pub yavg: f64,
+    /// Darkest pixel in the frame.
+    pub ymin: f64,
+}
+
+/// Parses a `signalstats,metadata=print` stream into per-frame luma samples.
+///
+/// The filter prints a frame header and then one `key=value` line per metadata
+/// entry, so values are accumulated until the next header closes the frame:
+///
+/// ```text
+/// frame:0    pts:0       pts_time:0
+/// lavfi.signalstats.YAVG=16.5
+/// lavfi.signalstats.YMIN=0
+/// ```
+///
+/// A frame missing either statistic is dropped rather than defaulted. Zero is a
+/// meaningful luma, so defaulting would invent a black frame, and a run of
+/// invented black frames is exactly the shape of a dip to white's approach.
+pub fn parse_signalstats(stdout: &str) -> Vec<LumaSample> {
+    let mut samples = Vec::new();
+    let mut at: Option<f64> = None;
+    let mut yavg: Option<f64> = None;
+    let mut ymin: Option<f64> = None;
+
+    // Closes the frame currently being accumulated, if it is complete.
+    fn flush(
+        samples: &mut Vec<LumaSample>,
+        at: Option<f64>,
+        yavg: Option<f64>,
+        ymin: Option<f64>,
+    ) {
+        if let (Some(at_seconds), Some(yavg), Some(ymin)) = (at, yavg, ymin) {
+            samples.push(LumaSample {
+                at_seconds,
+                yavg,
+                ymin,
+            });
+        }
+    }
+
+    for line in stdout.lines() {
+        let line = line.trim();
+
+        if let Some(rest) = line.strip_prefix("frame:") {
+            flush(&mut samples, at, yavg, ymin);
+            at = rest
+                .split_whitespace()
+                .find_map(|token| token.strip_prefix("pts_time:"))
+                .and_then(|value| value.parse::<f64>().ok());
+            yavg = None;
+            ymin = None;
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+
+        match key.trim() {
+            "lavfi.signalstats.YAVG" => yavg = value.trim().parse().ok(),
+            "lavfi.signalstats.YMIN" => ymin = value.trim().parse().ok(),
+            _ => {}
+        }
+    }
+
+    flush(&mut samples, at, yavg, ymin);
+    samples
+}
+
+/// Parses the `num/den` form ffprobe prints for a frame rate.
+///
+/// `0/0` appears for streams with no meaningful rate and must not become a
+/// division by zero or an fps of zero.
+fn parse_frame_rate(value: &str) -> Option<f64> {
+    let (num, den) = value.split_once('/')?;
+    let num: f64 = num.trim().parse().ok()?;
+    let den: f64 = den.trim().parse().ok()?;
+
+    (den > 0.0 && num > 0.0).then_some(num / den)
 }
 
 /// Why a file cannot be analysed, in the operator's terms.
@@ -127,6 +236,8 @@ pub fn parse_probe_output(stdout: &str) -> Result<VideoProbe, ProbeProblem> {
     let mut width: Option<u32> = None;
     let mut height: Option<u32> = None;
     let mut duration: Option<f64> = None;
+    let mut frame_count: Option<u64> = None;
+    let mut frame_rate: Option<f64> = None;
 
     for line in stdout.lines() {
         let Some((key, value)) = line.split_once('=') else {
@@ -141,6 +252,12 @@ pub fn parse_probe_output(stdout: &str) -> Result<VideoProbe, ProbeProblem> {
             // it must not become 0.0 - a zero duration would silently check
             // nothing and report a pass.
             "duration" => duration = value.parse().ok().filter(|d: &f64| *d > 0.0),
+            // Both optional: a stream that cannot report them still gets checked,
+            // just with the container duration as the end (see end_seconds).
+            "nb_frames" => frame_count = value.parse().ok().filter(|f: &u64| *f > 0),
+            "r_frame_rate" | "avg_frame_rate" => {
+                frame_rate = frame_rate.or_else(|| parse_frame_rate(value))
+            }
             _ => {}
         }
     }
@@ -157,6 +274,8 @@ pub fn parse_probe_output(stdout: &str) -> Result<VideoProbe, ProbeProblem> {
             width: w,
             height: h,
             duration_seconds: d,
+            frame_count,
+            frame_rate,
         }),
         (_, _, None) => Err(ProbeProblem::MissingDuration),
         _ => Err(ProbeProblem::UnreadableDimensions),
@@ -236,7 +355,9 @@ frame=3 fps=0.0 q=-0.0 Lsize=N/A time=00:00:05.00";
             Ok(VideoProbe {
                 width: 1080,
                 height: 1920,
-                duration_seconds: 144.0
+                duration_seconds: 144.0,
+                frame_count: None,
+                frame_rate: None
             })
         );
     }
@@ -294,5 +415,110 @@ frame=3 fps=0.0 q=-0.0 Lsize=N/A time=00:00:05.00";
             parse_probe_output(stdout),
             Err(ProbeProblem::UnreadableDimensions)
         );
+    }
+
+    #[test]
+    fn reads_luma_statistics_per_frame_from_real_metadata_output() {
+        // Verbatim from `signalstats,metadata=print:file=-`, with the entries
+        // this does not read left in: the parser must skip them rather than be
+        // confused by them.
+        let stdout = "\
+frame:0    pts:179200  pts_time:14
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YLOW=41
+lavfi.signalstats.YAVG=125.865
+lavfi.signalstats.YHIGH=209
+frame:1    pts:179712  pts_time:14.04
+lavfi.signalstats.YMIN=235
+lavfi.signalstats.YAVG=235
+";
+
+        assert_eq!(
+            parse_signalstats(stdout),
+            vec![
+                LumaSample {
+                    at_seconds: 14.0,
+                    yavg: 125.865,
+                    ymin: 8.0
+                },
+                LumaSample {
+                    at_seconds: 14.04,
+                    yavg: 235.0,
+                    ymin: 235.0
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn drops_a_frame_missing_a_statistic_rather_than_calling_it_black() {
+        // Defaulting to 0 would invent a black frame, and a run of invented
+        // black frames is the shape of a dip's approach.
+        let stdout = "\
+frame:0    pts:0  pts_time:1
+lavfi.signalstats.YMIN=8
+frame:1    pts:1  pts_time:2
+lavfi.signalstats.YMIN=9
+lavfi.signalstats.YAVG=100
+";
+
+        assert_eq!(
+            parse_signalstats(stdout),
+            vec![LumaSample {
+                at_seconds: 2.0,
+                yavg: 100.0,
+                ymin: 9.0
+            }]
+        );
+    }
+
+    #[test]
+    fn a7_prefers_the_frame_count_over_the_containers_duration() {
+        // The measured case: a container claiming 166.633991s where 8331 frames
+        // at 50fps put the true end at 166.62s. The tail is measured backwards
+        // from the end, so the 14ms difference is a bias on every structural
+        // measurement - it moves a peak that is exactly at T-5.000s to T-5.014s.
+        let probe = VideoProbe {
+            width: 3840,
+            height: 2160,
+            duration_seconds: 166.633991,
+            frame_count: Some(8331),
+            frame_rate: Some(50.0),
+        };
+
+        assert!((probe.end_seconds() - 166.62).abs() < 1e-9);
+    }
+
+    #[test]
+    fn falls_back_to_the_container_duration_when_frames_cannot_be_counted() {
+        let probe = VideoProbe {
+            width: 1920,
+            height: 1080,
+            duration_seconds: 144.0,
+            frame_count: None,
+            frame_rate: Some(25.0),
+        };
+
+        assert_eq!(probe.end_seconds(), 144.0);
+    }
+
+    #[test]
+    fn reads_the_frame_rate_ffprobe_prints_as_a_fraction() {
+        let stdout =
+            "width=1920\nheight=1080\nnb_frames=8331\nr_frame_rate=50/1\nduration=166.633991\n";
+        let probe = parse_probe_output(stdout).expect("a probe");
+
+        assert_eq!(probe.frame_rate, Some(50.0));
+        assert_eq!(probe.frame_count, Some(8331));
+    }
+
+    #[test]
+    fn a_zero_frame_rate_is_not_a_frame_rate() {
+        // `0/0` is what ffprobe prints for a stream with no meaningful rate.
+        let stdout = "width=1920\nheight=1080\nr_frame_rate=0/0\nduration=10.0\n";
+        let probe = parse_probe_output(stdout).expect("a probe");
+
+        assert_eq!(probe.frame_rate, None);
+        assert_eq!(probe.end_seconds(), 10.0);
     }
 }

--- a/src-tauri/src/kavanagh/sting.rs
+++ b/src-tauri/src/kavanagh/sting.rs
@@ -1,0 +1,407 @@
+//! Sting identity and the freeze check (B6).
+//!
+//! The sting is a static JPG held on screen, which makes both halves of this
+//! unusually strong. Identity can be near-exact rather than heuristic, because
+//! the reference *is* the asset in the edit and nothing is composited over it.
+//! And because a still is held, the frames across the hold must be identical to
+//! one another, which catches faults identity alone cannot see: motion left
+//! underneath, a stray cut inside the hold, a wrong layer left visible.
+//!
+//! Both fold into one verdict (D7), with three states rather than two: a
+//! structurally correct tail whose logo matches nothing is a **warning**, not a
+//! failure, because it usually means a new variant needs adding to the folder
+//! (D8).
+
+use serde::Serialize;
+
+use super::matching::weighted_ncc;
+use super::thresholds::{STING_FREEZE_MAX_MAD, STING_MATCH_CONFIDENCE};
+
+/// One reference image from the `stings/` pool, greyscale at the comparison
+/// scale.
+#[derive(Debug, Clone)]
+pub struct StingReference {
+    /// Absolute path, so the report can name which asset matched.
+    pub path: String,
+    pub pixels: Vec<u8>,
+}
+
+/// What the sting check concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StingOutcome {
+    /// A reference in the pool matched across every settled frame.
+    Matched,
+    /// Structurally a held still, but nothing in the pool matches it (D8).
+    Unrecognised,
+    /// The frames across the hold are not identical, so it is not a held still.
+    NotFrozen,
+    /// Nothing to compare against; the pool was empty or unreadable (B6.4).
+    PoolUnavailable,
+}
+
+/// Everything the sting check measured.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StingReport {
+    pub outcome: StingOutcome,
+    /// The reference that matched across all frames, when one did.
+    pub matched_reference: Option<String>,
+    /// The closest reference, whether or not it passed.
+    ///
+    /// Populated even on a miss: knowing the nearest asset is what separates a
+    /// wrong-resolution variant from a completely different logo.
+    pub best_reference: Option<String>,
+    /// The best reference's weakest score across the settled frames.
+    pub best_confidence: f32,
+    /// Mean absolute luma difference across the hold; ~0 for a held still.
+    pub freeze_mad: Option<f64>,
+    pub frames_compared: usize,
+    pub threshold: f32,
+}
+
+impl StingReport {
+    /// A sentence for the report, naming the measurement behind the verdict.
+    pub fn message(&self) -> String {
+        match self.outcome {
+            StingOutcome::Matched => match &self.matched_reference {
+                Some(reference) => format!(
+                    "The closing sting matches {} at {:.3}.",
+                    file_name(reference),
+                    self.best_confidence
+                ),
+                None => "The closing sting matches a reference.".to_string(),
+            },
+            StingOutcome::Unrecognised => match &self.best_reference {
+                Some(reference) => format!(
+                    "The tail is a held still, but it matches nothing in the stings folder - closest was {} at {:.3}, below {:.2}. If this is a new sting, add it to the folder.",
+                    file_name(reference),
+                    self.best_confidence,
+                    self.threshold
+                ),
+                None => "The tail is a held still, but it matches nothing in the stings folder."
+                    .to_string(),
+            },
+            StingOutcome::NotFrozen => format!(
+                "The closing frames are not held steady (mean difference {:.2}), so this is not a static sting.",
+                self.freeze_mad.unwrap_or_default()
+            ),
+            StingOutcome::PoolUnavailable => {
+                "No sting references are available, so the closing logo could not be identified."
+                    .to_string()
+            }
+        }
+    }
+
+    /// Whether this outcome should fail a run, as opposed to warn on it (D8).
+    pub fn is_failure(&self) -> bool {
+        matches!(self.outcome, StingOutcome::NotFrozen)
+    }
+}
+
+/// Trims a path to its file name for display.
+fn file_name(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+
+/// Mean absolute difference between consecutive frames, in luma units.
+///
+/// Consecutive rather than all-pairs: a drift across the hold shows up either
+/// way, and a stray cut in the middle shows up more sharply between neighbours.
+/// `None` when there are fewer than two frames, since one frame cannot be shown
+/// to be held.
+pub fn freeze_mad(frames: &[Vec<u8>]) -> Option<f64> {
+    if frames.len() < 2 {
+        return None;
+    }
+
+    let mut total = 0.0f64;
+    let mut pairs = 0usize;
+
+    for window in frames.windows(2) {
+        let (a, b) = (&window[0], &window[1]);
+        let n = a.len().min(b.len());
+        if n == 0 {
+            continue;
+        }
+
+        let sum: f64 = (0..n)
+            .map(|i| (f64::from(a[i]) - f64::from(b[i])).abs())
+            .sum();
+
+        total += sum / n as f64;
+        pairs += 1;
+    }
+
+    (pairs > 0).then(|| total / pairs as f64)
+}
+
+/// Correlates two greyscale images, in `[-1, 1]`.
+///
+/// Uniform weights over the shared correlation routine rather than a second
+/// implementation of the same statistic - the weighting exists for the
+/// watermark's alpha mask and simply is not needed here.
+pub fn luma_ncc(a: &[u8], b: &[u8]) -> f32 {
+    let n = a.len().min(b.len());
+    if n == 0 {
+        return 0.0;
+    }
+
+    let left: Vec<f32> = a[..n].iter().map(|v| f32::from(*v)).collect();
+    let right: Vec<f32> = b[..n].iter().map(|v| f32::from(*v)).collect();
+    let weights = vec![1.0f32; n];
+
+    weighted_ncc(&left, &right, &weights)
+}
+
+/// The best reference across every settled frame, and its weakest score.
+///
+/// A reference identifies the sting only if it matches **every** sampled frame,
+/// so the score carried is its worst, not its best. Scoring on the best frame
+/// would let a tail that is only briefly right pass on one lucky sample (B6.7);
+/// the sting is a held still, so if a reference is the sting it matches all of
+/// them.
+pub fn identify<'a>(
+    frames: &[Vec<u8>],
+    references: &'a [StingReference],
+) -> Option<(&'a StingReference, f32)> {
+    if frames.is_empty() {
+        return None;
+    }
+
+    references
+        .iter()
+        .map(|reference| {
+            let weakest = frames
+                .iter()
+                .map(|frame| luma_ncc(frame, &reference.pixels))
+                .fold(f32::INFINITY, f32::min);
+            (reference, weakest)
+        })
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+}
+
+/// Judges the settled sting frames: held still first, then which sting it is.
+///
+/// Freeze is checked before identity deliberately. A tail that is not a held
+/// still is wrong whatever it happens to correlate with, and reporting "matches
+/// the 2019 sting" about moving footage would be actively misleading.
+pub fn assess(frames: &[Vec<u8>], references: &[StingReference], threshold: f32) -> StingReport {
+    let mad = freeze_mad(frames);
+    let frames_compared = frames.len();
+
+    if let Some(measured) = mad {
+        if measured > STING_FREEZE_MAX_MAD {
+            return StingReport {
+                outcome: StingOutcome::NotFrozen,
+                matched_reference: None,
+                best_reference: None,
+                best_confidence: 0.0,
+                freeze_mad: mad,
+                frames_compared,
+                threshold,
+            };
+        }
+    }
+
+    let best = identify(frames, references);
+
+    match best {
+        None => StingReport {
+            outcome: StingOutcome::PoolUnavailable,
+            matched_reference: None,
+            best_reference: None,
+            best_confidence: 0.0,
+            freeze_mad: mad,
+            frames_compared,
+            threshold,
+        },
+        Some((reference, confidence)) if confidence >= threshold => StingReport {
+            outcome: StingOutcome::Matched,
+            matched_reference: Some(reference.path.clone()),
+            best_reference: Some(reference.path.clone()),
+            best_confidence: confidence,
+            freeze_mad: mad,
+            frames_compared,
+            threshold,
+        },
+        Some((reference, confidence)) => StingReport {
+            outcome: StingOutcome::Unrecognised,
+            matched_reference: None,
+            best_reference: Some(reference.path.clone()),
+            best_confidence: confidence,
+            freeze_mad: mad,
+            frames_compared,
+            threshold,
+        },
+    }
+}
+
+/// The calibrated sting threshold, for callers with no override to apply.
+pub fn default_threshold() -> f32 {
+    STING_MATCH_CONFIDENCE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const W: usize = 64;
+    const H: usize = 36;
+
+    /// A "logo": a filled block on a flat field, at a given position.
+    fn logo(offset_x: usize, value: u8) -> Vec<u8> {
+        let mut pixels = vec![30u8; W * H];
+        for y in 8..H - 8 {
+            for x in (8 + offset_x)..(28 + offset_x).min(W) {
+                pixels[y * W + x] = value;
+            }
+        }
+        pixels
+    }
+
+    /// The same image with a little encode noise on it.
+    fn with_noise(base: &[u8], amplitude: i16) -> Vec<u8> {
+        base.iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let wobble = if i % 2 == 0 { amplitude } else { -amplitude };
+                (i16::from(*v) + wobble).clamp(0, 255) as u8
+            })
+            .collect()
+    }
+
+    fn reference(path: &str, pixels: Vec<u8>) -> StingReference {
+        StingReference {
+            path: path.to_string(),
+            pixels,
+        }
+    }
+
+    #[test]
+    fn b6_1_passes_naming_the_reference_that_matched() {
+        let sting = logo(0, 200);
+        let frames = vec![sting.clone(), sting.clone(), sting.clone()];
+        let pool = vec![reference("/refs/stings/current.jpg", sting)];
+
+        let report = assess(&frames, &pool, default_threshold());
+
+        assert_eq!(report.outcome, StingOutcome::Matched);
+        assert_eq!(
+            report.matched_reference.as_deref(),
+            Some("/refs/stings/current.jpg")
+        );
+        assert!(report.message().contains("current.jpg"));
+    }
+
+    #[test]
+    fn b6_2_an_unmatched_logo_warns_rather_than_fails() {
+        let frames = vec![logo(0, 200), logo(0, 200)];
+        let pool = vec![reference("/refs/stings/other.jpg", logo(30, 200))];
+
+        let report = assess(&frames, &pool, default_threshold());
+
+        assert_eq!(report.outcome, StingOutcome::Unrecognised);
+        assert!(
+            !report.is_failure(),
+            "an unrecognised sting is housekeeping, not a broken video (D8)"
+        );
+        // The nearest asset is named, so the operator knows what to compare.
+        assert_eq!(
+            report.best_reference.as_deref(),
+            Some("/refs/stings/other.jpg")
+        );
+    }
+
+    #[test]
+    fn b6_3_any_reference_in_the_pool_may_match() {
+        let third = logo(20, 210);
+        let frames = vec![third.clone(), third.clone()];
+        let pool = vec![
+            reference("/refs/stings/a.jpg", logo(0, 200)),
+            reference("/refs/stings/b.jpg", logo(10, 120)),
+            reference("/refs/stings/c.jpg", third),
+        ];
+
+        let report = assess(&frames, &pool, default_threshold());
+
+        assert_eq!(report.outcome, StingOutcome::Matched);
+        assert_eq!(report.matched_reference.as_deref(), Some("/refs/stings/c.jpg"));
+    }
+
+    #[test]
+    fn b6_4_an_empty_pool_is_reported_distinctly_and_still_measures_the_hold() {
+        let sting = logo(0, 200);
+        let frames = vec![sting.clone(), sting];
+
+        let report = assess(&frames, &[], default_threshold());
+
+        assert_eq!(report.outcome, StingOutcome::PoolUnavailable);
+        assert!(
+            report.freeze_mad.is_some(),
+            "the structural half must still be measured when identity cannot be (B6.4)"
+        );
+        assert!(!report.is_failure());
+    }
+
+    #[test]
+    fn b6_5_frames_that_differ_materially_are_not_a_held_still() {
+        let frames = vec![logo(0, 200), logo(25, 200), logo(0, 200)];
+        let pool = vec![reference("/refs/stings/current.jpg", logo(0, 200))];
+
+        let report = assess(&frames, &pool, default_threshold());
+
+        assert_eq!(report.outcome, StingOutcome::NotFrozen);
+        assert!(report.is_failure());
+        assert!(report.message().contains("not held steady"));
+    }
+
+    #[test]
+    fn b6_6_encode_noise_does_not_break_the_freeze_check() {
+        let sting = logo(0, 200);
+        let frames = vec![
+            with_noise(&sting, 1),
+            with_noise(&sting, -1),
+            with_noise(&sting, 1),
+        ];
+        let pool = vec![reference("/refs/stings/current.jpg", sting)];
+
+        let report = assess(&frames, &pool, default_threshold());
+
+        assert_eq!(
+            report.outcome,
+            StingOutcome::Matched,
+            "a held JPG re-encoded per frame is still held (mad {:?})",
+            report.freeze_mad
+        );
+    }
+
+    #[test]
+    fn b6_7_a_reference_must_match_every_frame_not_just_one() {
+        let sting = logo(0, 200);
+        // One frame is the sting, the other is something else entirely.
+        let frames = vec![sting.clone(), logo(30, 90)];
+        let pool = vec![reference("/refs/stings/current.jpg", sting)];
+
+        let (_, weakest) = identify(&frames, &pool).expect("a candidate");
+
+        assert!(
+            weakest < default_threshold(),
+            "identity must be carried by the worst frame, not the best: got {}",
+            weakest
+        );
+    }
+
+    #[test]
+    fn a_single_frame_cannot_be_shown_to_be_held() {
+        assert_eq!(freeze_mad(&[vec![1, 2, 3]]), None);
+    }
+
+    #[test]
+    fn identical_frames_measure_no_movement_at_all() {
+        let frame = logo(0, 200);
+        let mad = freeze_mad(&[frame.clone(), frame]).expect("a measurement");
+
+        assert!(mad.abs() < f64::EPSILON, "expected 0.0, got {}", mad);
+    }
+}

--- a/src-tauri/src/kavanagh/tail.rs
+++ b/src-tauri/src/kavanagh/tail.rs
@@ -1,0 +1,761 @@
+//! Closing tail structure: the dip to white and the sting that follows (B5).
+//!
+//! The tail is a consequence of two Premiere preferences rather than a hand
+//! edit, so it is checked against a derived model rather than an observed one.
+//! See `thresholds` for the derivation; the short version is a 1.00s transition
+//! applied Center at Cut, so white is reached at the cut, and a 5.00s still
+//! image begins there.
+//!
+//! Everything here is pure: it takes the luma samples `signalstats` produced and
+//! returns what they imply. That keeps the structural rules testable without
+//! ffmpeg, which matters because these are the rules most likely to be argued
+//! with when a render fails.
+
+use serde::Serialize;
+
+use super::parsing::LumaSample;
+use super::thresholds::{
+    RAMP_NOMINAL_SECONDS, RAMP_RISE_HIGH_FRACTION, RAMP_RISE_LOW_FRACTION, RAMP_TOLERANCE_SECONDS,
+    STING_NOMINAL_SECONDS, STING_TOLERANCE_SECONDS, TAIL_WINDOW_SECONDS,
+    TRAILING_TOLERANCE_SECONDS, WHITE_PEAK_YAVG_MIN, WHITE_PEAK_YMIN_MIN,
+};
+
+/// Fraction of the settled sting's brightness a frame must keep to count as
+/// still showing the sting.
+///
+/// Relative rather than an absolute luma floor, so it adapts to a sting that is
+/// darker than the ones measured. Black export padding sits near zero and is
+/// nowhere near half of any sting's mean.
+const ON_STING_FRACTION: f64 = 0.5;
+
+/// How far back the ramp's baseline is measured from.
+///
+/// Bounded rather than "the darkest frame in the window", which was the first
+/// implementation and is wrong on real footage: a dark shot anywhere in the
+/// preceding 12s drags the baseline down, which drags the 10% target below the
+/// level the dip actually started from. The crossing search then walks back
+/// past the ramp entirely and measures from some earlier cut, reporting a
+/// multi-second ramp on a correct render. Three ramps' worth of look-back is
+/// comfortably longer than any legitimate transition and short enough to stay
+/// inside the shot the dip begins from.
+const RAMP_BASELINE_WINDOW_SECONDS: f64 = 1.5;
+
+/// What is wrong with a tail, in the operator's terms.
+///
+/// Each variant carries what was measured, because a tolerance failure is only
+/// actionable next to the number that failed it: "ramp 0.25s, expected 0.40s"
+/// is a diagnosis, "the ramp is wrong" is an argument.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TailProblem {
+    /// Shorter than the search window, so there is no tail to analyse (B5.9).
+    VideoTooShort { duration_seconds: f64 },
+    /// No frame in the window reached white (B5.5).
+    NoWhitePeak,
+    /// A hard cut rather than a dissolve (B5.7).
+    RampTooShort { measured_seconds: f64 },
+    /// A longer transition than the 1.00s default, i.e. preset drift.
+    RampTooLong { measured_seconds: f64 },
+    /// Less content after the peak than a 5.00s still (B5.6).
+    StingTooShort { measured_seconds: f64 },
+    /// More content after the peak than a 5.00s still.
+    StingTooLong { measured_seconds: f64 },
+    /// Content continues past the sting beyond the trailing tolerance (B5.8).
+    DoesNotEndOnSting { trailing_seconds: f64 },
+}
+
+impl TailProblem {
+    /// One sentence naming the fault and the measurement behind it.
+    pub fn message(&self) -> String {
+        match self {
+            TailProblem::VideoTooShort { duration_seconds } => format!(
+                "This video is {:.1}s long, shorter than the {:.0}s closing section the check reads, so its tail cannot be analysed.",
+                duration_seconds, TAIL_WINDOW_SECONDS
+            ),
+            TailProblem::NoWhitePeak => {
+                "No dip to white found in the closing section.".to_string()
+            }
+            TailProblem::RampTooShort { measured_seconds } => format!(
+                "The dip to white takes {:.2}s, expected {:.2}s ({:.2}-{:.2}s). A ramp this short is a hard cut rather than a dissolve.",
+                measured_seconds,
+                RAMP_NOMINAL_SECONDS,
+                ramp_min(),
+                ramp_max()
+            ),
+            TailProblem::RampTooLong { measured_seconds } => format!(
+                "The dip to white takes {:.2}s, expected {:.2}s ({:.2}-{:.2}s). A longer transition than the 1.00s default usually means the default has drifted.",
+                measured_seconds,
+                RAMP_NOMINAL_SECONDS,
+                ramp_min(),
+                ramp_max()
+            ),
+            TailProblem::StingTooShort { measured_seconds } => format!(
+                "The sting runs {:.2}s, expected {:.2}s. It has been cut short.",
+                measured_seconds, STING_NOMINAL_SECONDS
+            ),
+            TailProblem::StingTooLong { measured_seconds } => format!(
+                "The sting runs {:.2}s, expected {:.2}s. Something follows it, or its duration was changed.",
+                measured_seconds, STING_NOMINAL_SECONDS
+            ),
+            TailProblem::DoesNotEndOnSting { trailing_seconds } => format!(
+                "{:.2}s of content follows the sting, so the video does not end on it.",
+                trailing_seconds
+            ),
+        }
+    }
+}
+
+/// Shortest acceptable 10-90% rise.
+pub fn ramp_min() -> f64 {
+    RAMP_NOMINAL_SECONDS - RAMP_TOLERANCE_SECONDS
+}
+
+/// Longest acceptable 10-90% rise.
+pub fn ramp_max() -> f64 {
+    RAMP_NOMINAL_SECONDS + RAMP_TOLERANCE_SECONDS
+}
+
+/// What the tail's structure turned out to be.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TailAnalysis {
+    /// Where the dip reaches white, which is the cut the sting starts at.
+    pub peak_at_seconds: Option<f64>,
+    /// Measured 10-90% rise time.
+    pub ramp_seconds: Option<f64>,
+    /// Content after the peak.
+    pub sting_seconds: Option<f64>,
+    /// Content after the sting stops being on screen.
+    pub trailing_seconds: Option<f64>,
+    pub problems: Vec<TailProblem>,
+}
+
+impl TailAnalysis {
+    pub fn is_sound(&self) -> bool {
+        self.problems.is_empty()
+    }
+
+    /// Where the dip begins, which is where the watermark stops being expected.
+    ///
+    /// The watermark span ends here rather than at the peak: the mark is already
+    /// fading under the dissolve before white is reached, so measuring to the
+    /// peak would report a gap for every correct render (B4.6).
+    pub fn dip_start_seconds(&self) -> Option<f64> {
+        match (self.peak_at_seconds, self.ramp_seconds) {
+            (Some(peak), Some(ramp)) => Some((peak - ramp).max(0.0)),
+            // A peak with no measurable ramp still bounds the span: better to
+            // stop at the peak than to check the watermark through the dip.
+            (Some(peak), None) => Some(peak),
+            _ => None,
+        }
+    }
+}
+
+/// Finds the white peak: the brightest full-frame white in the window (D5).
+///
+/// Both conditions matter. `YAVG` alone passes a bright element over dark
+/// footage; the `YMIN` guard requires the whole frame to be white, so a lighting
+/// flash or a white title card cannot qualify (B5.4). Ties go to the earliest
+/// frame, because when white is held for several frames the cut is where it
+/// starts.
+pub fn find_white_peak(samples: &[LumaSample]) -> Option<usize> {
+    let mut best: Option<usize> = None;
+
+    for (index, sample) in samples.iter().enumerate() {
+        if sample.yavg < WHITE_PEAK_YAVG_MIN || sample.ymin < WHITE_PEAK_YMIN_MIN {
+            continue;
+        }
+
+        match best {
+            Some(current) if samples[current].yavg >= sample.yavg => {}
+            _ => best = Some(index),
+        }
+    }
+
+    best
+}
+
+/// Measures the 10-90% rise time into the peak (A7).
+///
+/// The baseline is the darkest frame in the second or so before the peak, so
+/// the rise is measured from the shot the dip actually started from rather than
+/// from an assumed black or from an unrelated dark shot earlier in the window
+/// (see `RAMP_BASELINE_WINDOW_SECONDS`). Crossings are linearly interpolated
+/// between the bracketing samples: frame quantisation is 0.02-0.04s against a
+/// ±0.08s tolerance, so rounding to whole frames would spend a third of the
+/// budget on arithmetic rather than on real variation.
+///
+/// Returns `None` when the peak is the first sample, leaving nothing to rise
+/// from.
+pub fn measure_ramp(samples: &[LumaSample], peak: usize) -> Option<f64> {
+    if peak == 0 || peak >= samples.len() {
+        return None;
+    }
+
+    let peak_yavg = samples[peak].yavg;
+    let baseline_from = samples[peak].at_seconds - RAMP_BASELINE_WINDOW_SECONDS;
+    let baseline = samples[..peak]
+        .iter()
+        .filter(|s| s.at_seconds >= baseline_from)
+        .map(|s| s.yavg)
+        .fold(f64::INFINITY, f64::min);
+
+    let rise = peak_yavg - baseline;
+    if !rise.is_finite() || rise <= 0.0 {
+        return None;
+    }
+
+    let low_target = baseline + rise * RAMP_RISE_LOW_FRACTION;
+    let high_target = baseline + rise * RAMP_RISE_HIGH_FRACTION;
+
+    // Walk back from the peak so a dip that follows earlier bright content is
+    // measured from its own approach, not from the first time the video was
+    // ever that bright.
+    let high_at = crossing_before(samples, peak, high_target)?;
+    let low_at = crossing_before(samples, peak, low_target)?;
+
+    Some((high_at - low_at).max(0.0))
+}
+
+/// Time at which the samples last crossed `target` on the way up to `peak`.
+///
+/// Linearly interpolated between the two bracketing samples.
+fn crossing_before(samples: &[LumaSample], peak: usize, target: f64) -> Option<f64> {
+    let mut index = peak;
+
+    while index > 0 {
+        let current = &samples[index];
+        let previous = &samples[index - 1];
+
+        if current.yavg >= target && previous.yavg < target {
+            let span = current.yavg - previous.yavg;
+            let fraction = if span > 0.0 {
+                (target - previous.yavg) / span
+            } else {
+                0.0
+            };
+            return Some(
+                previous.at_seconds + (current.at_seconds - previous.at_seconds) * fraction,
+            );
+        }
+
+        index -= 1;
+    }
+
+    // Never below the target in this window: the rise began before it started.
+    samples.first().map(|s| s.at_seconds)
+}
+
+/// Checks a tail's structure against the derived model (B5).
+///
+/// `end_seconds` should come from `VideoProbe::end_seconds`, not the container
+/// duration - the whole structure is measured relative to the end, so a 14ms
+/// error there shifts every measurement (A7).
+pub fn analyse_tail(
+    samples: &[LumaSample],
+    end_seconds: f64,
+    duration_seconds: f64,
+) -> TailAnalysis {
+    if duration_seconds < TAIL_WINDOW_SECONDS {
+        return TailAnalysis {
+            peak_at_seconds: None,
+            ramp_seconds: None,
+            sting_seconds: None,
+            trailing_seconds: None,
+            problems: vec![TailProblem::VideoTooShort { duration_seconds }],
+        };
+    }
+
+    let Some(peak) = find_white_peak(samples) else {
+        return TailAnalysis {
+            peak_at_seconds: None,
+            ramp_seconds: None,
+            sting_seconds: None,
+            trailing_seconds: None,
+            problems: vec![TailProblem::NoWhitePeak],
+        };
+    };
+
+    let peak_at = samples[peak].at_seconds;
+    let ramp = measure_ramp(samples, peak);
+    let sting = (end_seconds - peak_at).max(0.0);
+    let trailing = trailing_after_sting(samples, peak, end_seconds);
+
+    let mut problems = Vec::new();
+
+    match ramp {
+        Some(measured) if measured < ramp_min() => problems.push(TailProblem::RampTooShort {
+            measured_seconds: measured,
+        }),
+        Some(measured) if measured > ramp_max() => problems.push(TailProblem::RampTooLong {
+            measured_seconds: measured,
+        }),
+        // No measurable rise at all is the extreme of a hard cut, reported as
+        // such rather than passed over silently.
+        None => problems.push(TailProblem::RampTooShort {
+            measured_seconds: 0.0,
+        }),
+        _ => {}
+    }
+
+    if sting < STING_NOMINAL_SECONDS - STING_TOLERANCE_SECONDS {
+        problems.push(TailProblem::StingTooShort {
+            measured_seconds: sting,
+        });
+    } else if sting > STING_NOMINAL_SECONDS + STING_TOLERANCE_SECONDS {
+        problems.push(TailProblem::StingTooLong {
+            measured_seconds: sting,
+        });
+    }
+
+    if let Some(trailing_seconds) = trailing {
+        if trailing_seconds > TRAILING_TOLERANCE_SECONDS {
+            problems.push(TailProblem::DoesNotEndOnSting { trailing_seconds });
+        }
+    }
+
+    TailAnalysis {
+        peak_at_seconds: Some(peak_at),
+        ramp_seconds: ramp,
+        sting_seconds: Some(sting),
+        trailing_seconds: trailing,
+        problems,
+    }
+}
+
+/// How long after the sting stops being on screen the video continues.
+///
+/// The sting's own brightness sets the bar, so this does not assume a white
+/// logo card: the last frame at or above half the settled mean is taken as the
+/// last frame showing it. A couple of black frames of export padding leave a
+/// trailing figure of a frame or two, which the tolerance absorbs (B5.8).
+fn trailing_after_sting(samples: &[LumaSample], peak: usize, end_seconds: f64) -> Option<f64> {
+    let after_peak = samples.get(peak + 1..)?;
+    if after_peak.is_empty() {
+        return None;
+    }
+
+    let mut levels: Vec<f64> = after_peak.iter().map(|s| s.yavg).collect();
+    levels.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let settled = levels[levels.len() / 2];
+
+    let floor = settled * ON_STING_FRACTION;
+    let last_on_sting = after_peak
+        .iter()
+        .rev()
+        .find(|sample| sample.yavg >= floor)
+        .map(|sample| sample.at_seconds)?;
+
+    Some((end_seconds - last_on_sting).max(0.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FPS: f64 = 50.0;
+    const FRAME: f64 = 1.0 / FPS;
+    const CONTENT_YAVG: f64 = 60.0;
+    const PEAK_YAVG: f64 = 235.0;
+    const STING_YAVG: f64 = 224.8;
+
+    /// Builds the tail A6 derives: content, a linear ramp to white over half a
+    /// 1.00s centred transition, then a static sting to the end.
+    ///
+    /// A linear ramp is what a dissolve produces, so its 10-90% rise is exactly
+    /// 80% of the half-transition - 0.400s for the 0.5s here, which is the
+    /// figure both measured renders produced.
+    fn tail_samples(end: f64, sting_seconds: f64, ramp_seconds: f64) -> Vec<LumaSample> {
+        let peak_at = end - sting_seconds;
+        let ramp_start = peak_at - ramp_seconds;
+        let window_start = end - TAIL_WINDOW_SECONDS;
+
+        let mut samples = Vec::new();
+        let mut t = window_start;
+
+        while t <= end + f64::EPSILON {
+            let (yavg, ymin) = if t < ramp_start {
+                (CONTENT_YAVG, 0.0)
+            } else if t <= peak_at {
+                // Whole frame whitens together, which is what a dip to white is.
+                let progress = if ramp_seconds > 0.0 {
+                    ((t - ramp_start) / ramp_seconds).clamp(0.0, 1.0)
+                } else {
+                    1.0
+                };
+                (
+                    CONTENT_YAVG + (PEAK_YAVG - CONTENT_YAVG) * progress,
+                    PEAK_YAVG * progress,
+                )
+            } else {
+                (STING_YAVG, 54.0)
+            };
+
+            samples.push(LumaSample {
+                at_seconds: (t * 1000.0).round() / 1000.0,
+                yavg,
+                ymin,
+            });
+            t += FRAME;
+        }
+
+        samples
+    }
+
+    fn correct_tail(end: f64) -> Vec<LumaSample> {
+        tail_samples(end, STING_NOMINAL_SECONDS, 0.5)
+    }
+
+    #[test]
+    fn b5_1_locates_the_peak_where_the_white_frame_actually_is() {
+        let samples = correct_tail(100.0);
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        // T-5.00s, the cut the 5.00s still begins at (A6).
+        let peak = analysis.peak_at_seconds.expect("a peak");
+        assert!(
+            (peak - 95.0).abs() < FRAME,
+            "expected the peak at T-5s, got {}",
+            peak
+        );
+        assert!(analysis.is_sound(), "unexpected {:?}", analysis.problems);
+    }
+
+    #[test]
+    fn b5_2_detects_a_limited_range_peak_without_consulting_color_range() {
+        // 235 is limited-range white, which is what both measured renders coded.
+        let samples = correct_tail(100.0);
+        assert!(find_white_peak(&samples).is_some());
+    }
+
+    #[test]
+    fn b5_3_detects_a_full_range_peak() {
+        let mut samples = correct_tail(100.0);
+        for sample in samples.iter_mut() {
+            if sample.yavg >= WHITE_PEAK_YAVG_MIN {
+                sample.yavg = 255.0;
+                sample.ymin = 255.0;
+            }
+        }
+
+        assert!(find_white_peak(&samples).is_some());
+    }
+
+    #[test]
+    fn b5_4_rejects_a_bright_frame_that_is_not_full_frame_white() {
+        // High mean, dark pixels still present: a white card over dark footage,
+        // or a lighting flash. Brightness alone must not qualify.
+        let samples = vec![
+            LumaSample {
+                at_seconds: 90.0,
+                yavg: 60.0,
+                ymin: 0.0,
+            },
+            LumaSample {
+                at_seconds: 95.0,
+                yavg: 240.0,
+                ymin: 5.0,
+            },
+        ];
+
+        assert_eq!(find_white_peak(&samples), None);
+    }
+
+    #[test]
+    fn b5_5_names_a_missing_dip_to_white() {
+        let samples: Vec<LumaSample> = (0..100)
+            .map(|i| LumaSample {
+                at_seconds: 88.0 + i as f64 * FRAME,
+                yavg: 120.0,
+                ymin: 3.0,
+            })
+            .collect();
+
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        assert_eq!(analysis.problems, vec![TailProblem::NoWhitePeak]);
+        assert_eq!(analysis.peak_at_seconds, None);
+    }
+
+    #[test]
+    fn b5_6_reports_a_short_sting_with_the_duration_it_measured() {
+        let samples = tail_samples(100.0, 2.0, 0.5);
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        let measured = match analysis
+            .problems
+            .iter()
+            .find(|p| matches!(p, TailProblem::StingTooShort { .. }))
+        {
+            Some(TailProblem::StingTooShort { measured_seconds }) => *measured_seconds,
+            other => panic!("expected a short sting, got {:?}", other),
+        };
+
+        assert!(
+            (measured - 2.0).abs() < 0.05,
+            "the measured duration must be reported, got {}",
+            measured
+        );
+        // The number has to reach the operator, not just the category.
+        assert!(TailProblem::StingTooShort {
+            measured_seconds: measured
+        }
+        .message()
+        .contains("2.00"));
+    }
+
+    #[test]
+    fn b5_7_reports_a_hard_cut_as_a_missing_ramp() {
+        // One frame from content to white is what a cut looks like.
+        let samples = tail_samples(100.0, STING_NOMINAL_SECONDS, FRAME);
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        let measured = match analysis
+            .problems
+            .iter()
+            .find(|p| matches!(p, TailProblem::RampTooShort { .. }))
+        {
+            Some(TailProblem::RampTooShort { measured_seconds }) => *measured_seconds,
+            other => panic!("expected a missing ramp, got {:?}", other),
+        };
+
+        assert!(
+            measured < ramp_min(),
+            "a cut must measure below the ramp floor, got {}",
+            measured
+        );
+    }
+
+    #[test]
+    fn b5_8_tolerates_a_couple_of_trailing_black_frames() {
+        let mut samples = correct_tail(100.0);
+        let last = samples.last().expect("samples").at_seconds;
+        for i in 1..=2 {
+            samples.push(LumaSample {
+                at_seconds: last + i as f64 * FRAME,
+                yavg: 0.0,
+                ymin: 0.0,
+            });
+        }
+
+        let end = last + 2.0 * FRAME;
+        let analysis = analyse_tail(&samples, end, end);
+
+        assert!(
+            analysis.is_sound(),
+            "two black frames are export padding, not a defect: {:?}",
+            analysis.problems
+        );
+    }
+
+    #[test]
+    fn b5_8_still_reports_content_that_runs_on_past_the_sting() {
+        let mut samples = correct_tail(100.0);
+        let last = samples.last().expect("samples").at_seconds;
+        // A whole second of black after the sting is not padding.
+        let extra = (1.0 / FRAME) as usize;
+        for i in 1..=extra {
+            samples.push(LumaSample {
+                at_seconds: last + i as f64 * FRAME,
+                yavg: 0.0,
+                ymin: 0.0,
+            });
+        }
+
+        let end = last + 1.0;
+        let analysis = analyse_tail(&samples, end, end);
+
+        assert!(
+            analysis
+                .problems
+                .iter()
+                .any(|p| matches!(p, TailProblem::DoesNotEndOnSting { .. })),
+            "expected a trailing-content problem, got {:?}",
+            analysis.problems
+        );
+    }
+
+    #[test]
+    fn b5_9_reports_a_video_too_short_to_have_a_tail() {
+        let samples = correct_tail(100.0);
+        let analysis = analyse_tail(&samples, 8.0, 8.0);
+
+        assert_eq!(
+            analysis.problems,
+            vec![TailProblem::VideoTooShort {
+                duration_seconds: 8.0
+            }],
+            "a short video must be reported as such rather than analysed partially"
+        );
+        assert!(analysis.message_mentions_length());
+    }
+
+    #[test]
+    fn b5_10_offers_no_dip_start_when_no_peak_was_found() {
+        let analysis = analyse_tail(&[], 100.0, 100.0);
+        assert_eq!(analysis.dip_start_seconds(), None);
+    }
+
+    #[test]
+    fn the_ramp_measures_the_10_to_90_rise_the_calibration_settled_on() {
+        let samples = correct_tail(100.0);
+        let peak = find_white_peak(&samples).expect("a peak");
+        let ramp = measure_ramp(&samples, peak).expect("a ramp");
+
+        // 80% of a 0.5s half-transition. Both measured renders gave 0.400s.
+        assert!(
+            (ramp - RAMP_NOMINAL_SECONDS).abs() < 0.03,
+            "expected a 0.400s 10-90% rise, got {}",
+            ramp
+        );
+    }
+
+    #[test]
+    fn a_dark_shot_earlier_in_the_window_does_not_distort_the_ramp() {
+        // Regression: taking the baseline as the darkest frame anywhere in the
+        // 12s window put the 10% target below the level the dip started from,
+        // so the crossing search walked back past the ramp and measured a
+        // multi-second rise on a correct render. Real footage has dark shots.
+        let mut samples = correct_tail(100.0);
+        for sample in samples.iter_mut() {
+            if (89.0..90.0).contains(&sample.at_seconds) {
+                sample.yavg = 4.0;
+                sample.ymin = 0.0;
+            }
+        }
+
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        assert!(
+            analysis.is_sound(),
+            "a dark shot 6s earlier must not change the ramp: {:?} (ramp {:?})",
+            analysis.problems,
+            analysis.ramp_seconds
+        );
+    }
+
+    #[test]
+    fn a_two_second_transition_drift_is_caught_as_too_long_a_ramp() {
+        // The drift the check exists to find: a 2.00s default gives a 1.0s rise.
+        let samples = tail_samples(100.0, STING_NOMINAL_SECONDS, 1.25);
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        assert!(
+            analysis
+                .problems
+                .iter()
+                .any(|p| matches!(p, TailProblem::RampTooLong { .. })),
+            "expected too long a ramp, got {:?}",
+            analysis.problems
+        );
+    }
+
+    #[test]
+    fn the_dip_start_is_where_the_ramp_began_not_where_it_peaked() {
+        // The watermark is already fading before white is reached, so a span
+        // ending at the peak would report a gap on every correct render (B4.6).
+        let samples = correct_tail(100.0);
+        let analysis = analyse_tail(&samples, 100.0, 100.0);
+
+        let dip_start = analysis.dip_start_seconds().expect("a dip start");
+        let peak = analysis.peak_at_seconds.expect("a peak");
+
+        assert!(
+            dip_start < peak,
+            "the dip must start before the peak: {} vs {}",
+            dip_start,
+            peak
+        );
+        assert!((dip_start - (peak - RAMP_NOMINAL_SECONDS)).abs() < 0.05);
+    }
+
+    impl TailAnalysis {
+        /// Test helper: does any problem actually say how long the video was?
+        fn message_mentions_length(&self) -> bool {
+            self.problems.iter().any(|p| p.message().contains("8.0s"))
+        }
+    }
+
+    /// Real `signalstats` output, from a real H.264 encode.
+    ///
+    /// The rest of this module's tests generate their samples from the same
+    /// model the analysis checks against, which proves the arithmetic but could
+    /// not catch the model being wrong about ffmpeg. This fixture was captured
+    /// from an actual render built to the A6 structure: 25fps, a 0.5s fade to
+    /// white ending at t=15.000, then a 5.00s still. 500 frames at 25fps, so
+    /// the true end is exactly 20.000s.
+    mod real_output {
+        use super::*;
+        use crate::kavanagh::parsing::parse_signalstats;
+
+        const CAPTURE: &str = include_str!("testdata/signalstats-tail.txt");
+        const END: f64 = 20.0;
+
+        #[test]
+        fn the_encode_peaks_at_full_frame_white_where_the_model_says() {
+            let samples = parse_signalstats(CAPTURE);
+            let peak = find_white_peak(&samples).expect("a white peak");
+
+            assert_eq!(
+                samples[peak].at_seconds, 15.0,
+                "the cut is at T-5.000s, and the peak is the cut"
+            );
+            // Limited-range white, whole frame: exactly what D5's thresholds
+            // were written for, and what both calibration renders measured.
+            assert_eq!(samples[peak].yavg, 235.0);
+            assert_eq!(samples[peak].ymin, 235.0);
+        }
+
+        #[test]
+        fn a_correct_render_passes_every_structural_check() {
+            let samples = parse_signalstats(CAPTURE);
+            let analysis = analyse_tail(&samples, END, END);
+
+            assert!(
+                analysis.is_sound(),
+                "a correctly built tail must pass: {:?}",
+                analysis.problems
+            );
+            assert_eq!(analysis.sting_seconds, Some(5.0));
+        }
+
+        #[test]
+        fn the_measured_ramp_matches_the_calibrated_figure() {
+            let samples = parse_signalstats(CAPTURE);
+            let peak = find_white_peak(&samples).expect("a white peak");
+            let ramp = measure_ramp(&samples, peak).expect("a ramp");
+
+            // A7 settled on 0.400s from two real renders; this encode measures
+            // 0.402s, inside a tolerance that exists for frame quantisation.
+            assert!(
+                (ramp - RAMP_NOMINAL_SECONDS).abs() <= RAMP_TOLERANCE_SECONDS,
+                "expected ~{}s, measured {}s",
+                RAMP_NOMINAL_SECONDS,
+                ramp
+            );
+        }
+
+        #[test]
+        fn the_sting_settles_by_the_offset_identity_is_matched_from() {
+            // Why STING_SETTLED_OFFSET_SECONDS is 0.5: the still's first half
+            // second is underneath the fade from white, so matching before then
+            // compares a part-white frame against the reference JPG.
+            let samples = parse_signalstats(CAPTURE);
+            let peak = find_white_peak(&samples).expect("a white peak");
+            let settled_from = samples[peak].at_seconds
+                + crate::kavanagh::thresholds::STING_SETTLED_OFFSET_SECONDS;
+
+            let settled: Vec<f64> = samples
+                .iter()
+                .filter(|s| s.at_seconds >= settled_from)
+                .map(|s| s.yavg)
+                .collect();
+
+            let first = settled.first().copied().expect("settled frames");
+            assert!(
+                settled.iter().all(|y| (y - first).abs() < 0.5),
+                "the sting must be static from the settled offset onwards"
+            );
+        }
+    }
+}

--- a/src-tauri/src/kavanagh/testdata/signalstats-tail.txt
+++ b/src-tauri/src/kavanagh/testdata/signalstats-tail.txt
@@ -1,0 +1,450 @@
+frame:0    pts:179200  pts_time:14
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.865
+frame:1    pts:179712  pts_time:14.04
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.856
+frame:2    pts:180224  pts_time:14.08
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.838
+frame:3    pts:180736  pts_time:14.12
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.836
+frame:4    pts:181248  pts_time:14.16
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.811
+frame:5    pts:181760  pts_time:14.2
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.798
+frame:6    pts:182272  pts_time:14.24
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.77
+frame:7    pts:182784  pts_time:14.28
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.764
+frame:8    pts:183296  pts_time:14.32
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.731
+frame:9    pts:183808  pts_time:14.36
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.729
+frame:10   pts:184320  pts_time:14.4
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.707
+frame:11   pts:184832  pts_time:14.44
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.694
+frame:12   pts:185344  pts_time:14.48
+lavfi.signalstats.YMIN=8
+lavfi.signalstats.YAVG=125.674
+frame:13   pts:185856  pts_time:14.52
+lavfi.signalstats.YMIN=10
+lavfi.signalstats.YAVG=125.69
+frame:14   pts:186368  pts_time:14.56
+lavfi.signalstats.YMIN=25
+lavfi.signalstats.YAVG=134.142
+frame:15   pts:186880  pts_time:14.6
+lavfi.signalstats.YMIN=42
+lavfi.signalstats.YAVG=142.523
+frame:16   pts:187392  pts_time:14.64
+lavfi.signalstats.YMIN=58
+lavfi.signalstats.YAVG=151.129
+frame:17   pts:187904  pts_time:14.68
+lavfi.signalstats.YMIN=69
+lavfi.signalstats.YAVG=159.153
+frame:18   pts:188416  pts_time:14.72
+lavfi.signalstats.YMIN=93
+lavfi.signalstats.YAVG=167.786
+frame:19   pts:188928  pts_time:14.76
+lavfi.signalstats.YMIN=113
+lavfi.signalstats.YAVG=176.222
+frame:20   pts:189440  pts_time:14.8
+lavfi.signalstats.YMIN=121
+lavfi.signalstats.YAVG=184.567
+frame:21   pts:189952  pts_time:14.84
+lavfi.signalstats.YMIN=143
+lavfi.signalstats.YAVG=193.02
+frame:22   pts:190464  pts_time:14.88
+lavfi.signalstats.YMIN=161
+lavfi.signalstats.YAVG=201.644
+frame:23   pts:190976  pts_time:14.92
+lavfi.signalstats.YMIN=176
+lavfi.signalstats.YAVG=209.636
+frame:24   pts:191488  pts_time:14.96
+lavfi.signalstats.YMIN=194
+lavfi.signalstats.YAVG=218.251
+frame:25   pts:192000  pts_time:15
+lavfi.signalstats.YMIN=235
+lavfi.signalstats.YAVG=235
+frame:26   pts:192512  pts_time:15.04
+lavfi.signalstats.YMIN=219
+lavfi.signalstats.YAVG=233.611
+frame:27   pts:193024  pts_time:15.08
+lavfi.signalstats.YMIN=203
+lavfi.signalstats.YAVG=232.222
+frame:28   pts:193536  pts_time:15.12
+lavfi.signalstats.YMIN=187
+lavfi.signalstats.YAVG=230.833
+frame:29   pts:194048  pts_time:15.16
+lavfi.signalstats.YMIN=172
+lavfi.signalstats.YAVG=229.531
+frame:30   pts:194560  pts_time:15.2
+lavfi.signalstats.YMIN=156
+lavfi.signalstats.YAVG=228.142
+frame:31   pts:195072  pts_time:15.24
+lavfi.signalstats.YMIN=140
+lavfi.signalstats.YAVG=226.767
+frame:32   pts:195584  pts_time:15.28
+lavfi.signalstats.YMIN=124
+lavfi.signalstats.YAVG=225.378
+frame:33   pts:196096  pts_time:15.32
+lavfi.signalstats.YMIN=108
+lavfi.signalstats.YAVG=224.003
+frame:34   pts:196608  pts_time:15.36
+lavfi.signalstats.YMIN=92
+lavfi.signalstats.YAVG=222.614
+frame:35   pts:197120  pts_time:15.4
+lavfi.signalstats.YMIN=77
+lavfi.signalstats.YAVG=221.298
+frame:36   pts:197632  pts_time:15.44
+lavfi.signalstats.YMIN=60
+lavfi.signalstats.YAVG=219.822
+frame:37   pts:198144  pts_time:15.48
+lavfi.signalstats.YMIN=45
+lavfi.signalstats.YAVG=218.52
+frame:38   pts:198656  pts_time:15.52
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.145
+frame:39   pts:199168  pts_time:15.56
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:40   pts:199680  pts_time:15.6
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:41   pts:200192  pts_time:15.64
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:42   pts:200704  pts_time:15.68
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:43   pts:201216  pts_time:15.72
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:44   pts:201728  pts_time:15.76
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:45   pts:202240  pts_time:15.8
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:46   pts:202752  pts_time:15.84
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:47   pts:203264  pts_time:15.88
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:48   pts:203776  pts_time:15.92
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:49   pts:204288  pts_time:15.96
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:50   pts:204800  pts_time:16
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:51   pts:205312  pts_time:16.04
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:52   pts:205824  pts_time:16.08
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:53   pts:206336  pts_time:16.12
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:54   pts:206848  pts_time:16.16
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:55   pts:207360  pts_time:16.2
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:56   pts:207872  pts_time:16.24
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:57   pts:208384  pts_time:16.28
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:58   pts:208896  pts_time:16.32
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:59   pts:209408  pts_time:16.36
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:60   pts:209920  pts_time:16.4
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:61   pts:210432  pts_time:16.44
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:62   pts:210944  pts_time:16.48
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:63   pts:211456  pts_time:16.52
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:64   pts:211968  pts_time:16.56
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:65   pts:212480  pts_time:16.6
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:66   pts:212992  pts_time:16.64
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:67   pts:213504  pts_time:16.68
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:68   pts:214016  pts_time:16.72
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:69   pts:214528  pts_time:16.76
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:70   pts:215040  pts_time:16.8
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:71   pts:215552  pts_time:16.84
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:72   pts:216064  pts_time:16.88
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:73   pts:216576  pts_time:16.92
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:74   pts:217088  pts_time:16.96
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:75   pts:217600  pts_time:17
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:76   pts:218112  pts_time:17.04
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:77   pts:218624  pts_time:17.08
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:78   pts:219136  pts_time:17.12
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:79   pts:219648  pts_time:17.16
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:80   pts:220160  pts_time:17.2
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:81   pts:220672  pts_time:17.24
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:82   pts:221184  pts_time:17.28
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:83   pts:221696  pts_time:17.32
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:84   pts:222208  pts_time:17.36
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:85   pts:222720  pts_time:17.4
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:86   pts:223232  pts_time:17.44
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:87   pts:223744  pts_time:17.48
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:88   pts:224256  pts_time:17.52
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:89   pts:224768  pts_time:17.56
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:90   pts:225280  pts_time:17.6
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:91   pts:225792  pts_time:17.64
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:92   pts:226304  pts_time:17.68
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:93   pts:226816  pts_time:17.72
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:94   pts:227328  pts_time:17.76
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:95   pts:227840  pts_time:17.8
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:96   pts:228352  pts_time:17.84
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:97   pts:228864  pts_time:17.88
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:98   pts:229376  pts_time:17.92
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:99   pts:229888  pts_time:17.96
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:100  pts:230400  pts_time:18
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:101  pts:230912  pts_time:18.04
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:102  pts:231424  pts_time:18.08
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:103  pts:231936  pts_time:18.12
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:104  pts:232448  pts_time:18.16
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:105  pts:232960  pts_time:18.2
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:106  pts:233472  pts_time:18.24
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:107  pts:233984  pts_time:18.28
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:108  pts:234496  pts_time:18.32
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:109  pts:235008  pts_time:18.36
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:110  pts:235520  pts_time:18.4
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:111  pts:236032  pts_time:18.44
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:112  pts:236544  pts_time:18.48
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:113  pts:237056  pts_time:18.52
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:114  pts:237568  pts_time:18.56
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:115  pts:238080  pts_time:18.6
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:116  pts:238592  pts_time:18.64
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:117  pts:239104  pts_time:18.68
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:118  pts:239616  pts_time:18.72
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:119  pts:240128  pts_time:18.76
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:120  pts:240640  pts_time:18.8
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:121  pts:241152  pts_time:18.84
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:122  pts:241664  pts_time:18.88
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:123  pts:242176  pts_time:18.92
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:124  pts:242688  pts_time:18.96
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:125  pts:243200  pts_time:19
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:126  pts:243712  pts_time:19.04
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:127  pts:244224  pts_time:19.08
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:128  pts:244736  pts_time:19.12
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:129  pts:245248  pts_time:19.16
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:130  pts:245760  pts_time:19.2
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:131  pts:246272  pts_time:19.24
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:132  pts:246784  pts_time:19.28
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:133  pts:247296  pts_time:19.32
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:134  pts:247808  pts_time:19.36
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:135  pts:248320  pts_time:19.4
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:136  pts:248832  pts_time:19.44
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:137  pts:249344  pts_time:19.48
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:138  pts:249856  pts_time:19.52
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:139  pts:250368  pts_time:19.56
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:140  pts:250880  pts_time:19.6
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:141  pts:251392  pts_time:19.64
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:142  pts:251904  pts_time:19.68
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:143  pts:252416  pts_time:19.72
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:144  pts:252928  pts_time:19.76
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:145  pts:253440  pts_time:19.8
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:146  pts:253952  pts_time:19.84
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:147  pts:254464  pts_time:19.88
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:148  pts:254976  pts_time:19.92
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144
+frame:149  pts:255488  pts_time:19.96
+lavfi.signalstats.YMIN=29
+lavfi.signalstats.YAVG=217.144

--- a/src-tauri/src/kavanagh/thresholds.rs
+++ b/src-tauri/src/kavanagh/thresholds.rs
@@ -109,6 +109,125 @@ pub const THUMBNAIL_WIDTH: u32 = 480;
 /// end (B11.3).
 pub const MAX_STDERR_BYTES: usize = 8 * 1024;
 
+// ---------------------------------------------------------------------------
+// Tail and sting (stage 3, B5-B7)
+//
+// These are not hand-tuned tolerances around observed footage. The tail is
+// produced by two Premiere preferences - Video Transition Default Duration
+// 1.00s and Still Image Default Duration 5.00s - so the structure is a
+// deterministic consequence of software defaults (A6):
+//
+//   T-5.5s ─── T-5.0s ─── T-4.5s ──────────── T-0s
+//      │          │          │                   │
+//    ramp up   FULL WHITE  settled              end
+//    (0.5s)    (the cut)   └── 4.5s static ──────┘
+//
+// A 1.00s transition applied Center at Cut ramps up for 0.5s, so the peak is
+// the cut, and the 5.00s still begins there. Catching preset drift is the
+// stated purpose of the check, so the tolerances are deliberately tight:
+// loose ones would pass the very drift this exists to find.
+// ---------------------------------------------------------------------------
+
+/// Mean luma at or above which a frame may be the white peak (D5).
+///
+/// Cleared by limited-range white at 235 and full-range at 255, so no ffprobe
+/// `color_range` is consulted - it reads `unknown` on ordinary encodes. Both
+/// measured renders peaked at exactly 235.00.
+pub const WHITE_PEAK_YAVG_MIN: f64 = 232.0;
+
+/// Minimum luma the peak frame's darkest pixel must also reach (D5).
+///
+/// Without this a bright-but-partial frame passes on YAVG alone - a white
+/// title card over dark footage, or a lighting flash. Both measured peaks had
+/// YMIN 235, i.e. the whole frame was white; a frame retaining any genuinely
+/// dark content sits far below this (B5.4).
+pub const WHITE_PEAK_YMIN_MIN: f64 = 200.0;
+
+/// Fractions of the rise used to measure the ramp.
+///
+/// The ramp is measured as a **10-90% rise time**, settled in A7 after three
+/// candidate definitions were compared on two renders: 10-90% measured exactly
+/// 0.400s on both, where baseline-departure varied (0.460 vs 0.480) and
+/// mid-to-peak is a half-measure of a symmetric ramp.
+pub const RAMP_RISE_LOW_FRACTION: f64 = 0.10;
+pub const RAMP_RISE_HIGH_FRACTION: f64 = 0.90;
+
+/// Expected 10-90% rise time, in seconds.
+///
+/// Mathematically exact for a linear dissolve rather than observed: 80% of a
+/// 0.500s half-transition. Measured 0.400s on both renders, variance zero.
+pub const RAMP_NOMINAL_SECONDS: f64 = 0.400;
+
+/// Tolerance either side of the nominal ramp.
+///
+/// Frame quantisation is 0.02s at 50fps and 0.04s at 25fps, so this is several
+/// frames of slack against a measurement that did not vary at all. The window
+/// [0.32, 0.48] still catches every drift worth catching: a hard cut is about
+/// one frame, a 2.00s transition gives 0.8s, and a 0.50s one gives 0.2s.
+pub const RAMP_TOLERANCE_SECONDS: f64 = 0.08;
+
+/// Expected sting duration, from Still Image Default Duration (A6).
+pub const STING_NOMINAL_SECONDS: f64 = 5.00;
+
+/// Tolerance on the sting duration.
+///
+/// Wider than the ramp's because the end of the video is a harder edge to
+/// measure: the container may carry a partial final frame, and a render can be
+/// trimmed a frame or two short. Still far tighter than the failure it exists
+/// to catch, which is a sting of 2s or of 10s (B5.6).
+pub const STING_TOLERANCE_SECONDS: f64 = 0.25;
+
+/// Content allowed after the sting before the video is judged not to end on it.
+///
+/// A stray black frame or two is an artefact of export, not a defect (B5.8).
+/// Two frames is 0.04s at 50fps, so this is generous without admitting a whole
+/// extra shot after the logo.
+pub const TRAILING_TOLERANCE_SECONDS: f64 = 0.20;
+
+/// How long after the peak the sting is considered settled.
+///
+/// The still's opening 0.5s sits underneath the fade from white, so identity
+/// must be matched against what comes after it. Derived rather than intuited:
+/// it is the second half of the 1.00s centred transition (A6). Matching the
+/// first post-peak frame would compare a half-white frame against the JPG.
+pub const STING_SETTLED_OFFSET_SECONDS: f64 = 0.5;
+
+/// Correlation a settled sting frame must reach to identify a reference (D7).
+///
+/// Strict, because the reference *is* the source asset: nothing is composited
+/// over the sting, so only encode and scaling differences are tolerated. The
+/// band is wide despite the strictness - a correct render matched its
+/// reference at 0.9989, while the wrong-resolution variant of the same asset
+/// reached only 0.7869, and two renders' sting frames correlated at 1.0000.
+pub const STING_MATCH_CONFIDENCE: f32 = 0.95;
+
+/// Size both the sting frames and the reference JPGs are scaled to before
+/// being compared.
+///
+/// A fixed size on both sides is what makes the comparison resolution-agnostic,
+/// which matters in practice: both calibration renders carry the *1080p* sting
+/// asset on a UHD timeline, and matched their 1080p reference at 0.9989 while
+/// the 4K variant of the same asset reached only 0.7869 (A5). Small because the
+/// sting is a large flat logo - the identity is in its layout, not its detail -
+/// and 320x180 keeps a full pool comparison to a few million operations.
+pub const STING_COMPARISON_WIDTH: u32 = 320;
+pub const STING_COMPARISON_HEIGHT: u32 = 180;
+
+/// Frames per second sampled across the settled sting.
+///
+/// The hold is ~4.5s, so this takes roughly nine frames: enough for the freeze
+/// check to have something to compare and for identity to be carried by the
+/// worst of several frames rather than one lucky one (B6.7).
+pub const STING_SAMPLE_FPS: f64 = 2.0;
+
+/// Largest mean absolute luma difference across settled sting frames that
+/// still counts as frozen (D7).
+///
+/// A held JPG measured 0.00 on both renders, and 0.01 across renders, so this
+/// is entirely encode noise headroom. Motion, a stray cut inside the hold, or
+/// a wrong layer left visible all move this by tens (B6.5, B6.6).
+pub const STING_FREEZE_MAX_MAD: f64 = 2.0;
+
 /// Validates an operator's match confidence override.
 ///
 /// Rejected rather than clamped (B13.3). Silently clamping 8.5 to 0.999 leaves

--- a/src-tauri/src/kavanagh/verdict.rs
+++ b/src-tauri/src/kavanagh/verdict.rs
@@ -1,0 +1,180 @@
+//! The single verdict a run reduces to (B7).
+//!
+//! Three states here, four on the wire. A run that could not judge the video at
+//! all - missing ffmpeg, an unreadable file - never reaches this function: it is
+//! the `Err` arm of the command's `Result`, and the frontend renders it as a
+//! fourth `error` state distinct from `fail` (B7.4). Declaring an `Error`
+//! variant here would be a variant nothing could ever construct.
+//!
+//! Warnings exist for the one case that is housekeeping rather than a defect: a
+//! structurally correct tail whose logo is not in the references folder (D8).
+
+use serde::Serialize;
+
+use super::sting::{StingOutcome, StingReport};
+use super::tail::TailAnalysis;
+use super::watermark::WatermarkOutcome;
+
+/// What a whole run concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Verdict {
+    Pass,
+    /// Nothing is broken, but something needs a human's attention.
+    Warning,
+    Fail,
+}
+
+/// Combines the two checks into one verdict.
+///
+/// Every input keeps its own result in the report regardless of what comes out
+/// here (B7.2): a failing watermark must not hide what the tail did, or an
+/// operator fixes one fault, re-runs, and discovers the next one (D9).
+///
+/// `sting` is `None` when there was no white peak to locate a sting from. That
+/// only happens alongside a tail failure, and is a failure in its own right
+/// rather than an absence to pass over: a video whose closing logo was never
+/// looked at has not been checked.
+pub fn overall(
+    watermark: WatermarkOutcome,
+    tail: &TailAnalysis,
+    sting: Option<&StingReport>,
+) -> Verdict {
+    let sting_failed = sting.map(|s| s.is_failure()).unwrap_or(true);
+    if watermark == WatermarkOutcome::Fail || !tail.is_sound() || sting_failed {
+        return Verdict::Fail;
+    }
+
+    match sting.map(|s| s.outcome) {
+        Some(StingOutcome::Unrecognised) | Some(StingOutcome::PoolUnavailable) => Verdict::Warning,
+        Some(StingOutcome::Matched) => Verdict::Pass,
+        // Both unreachable above, and left explicit rather than folded into a
+        // catch-all so a new outcome has to be classified here to compile.
+        Some(StingOutcome::NotFrozen) | None => Verdict::Fail,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kavanagh::tail::{TailAnalysis, TailProblem};
+
+    fn sound_tail() -> TailAnalysis {
+        TailAnalysis {
+            peak_at_seconds: Some(95.0),
+            ramp_seconds: Some(0.4),
+            sting_seconds: Some(5.0),
+            trailing_seconds: Some(0.0),
+            problems: Vec::new(),
+        }
+    }
+
+    fn broken_tail() -> TailAnalysis {
+        TailAnalysis {
+            peak_at_seconds: None,
+            ramp_seconds: None,
+            sting_seconds: None,
+            trailing_seconds: None,
+            problems: vec![TailProblem::NoWhitePeak],
+        }
+    }
+
+    fn sting(outcome: StingOutcome) -> StingReport {
+        StingReport {
+            outcome,
+            matched_reference: None,
+            best_reference: None,
+            best_confidence: 0.99,
+            freeze_mad: Some(0.0),
+            frames_compared: 3,
+            threshold: 0.95,
+        }
+    }
+
+    #[test]
+    fn b7_1_passes_when_both_checks_pass() {
+        assert_eq!(
+            overall(
+                WatermarkOutcome::Pass,
+                &sound_tail(),
+                Some(&sting(StingOutcome::Matched))
+            ),
+            Verdict::Pass
+        );
+    }
+
+    #[test]
+    fn b7_2_a_failing_watermark_fails_the_run_without_erasing_the_tail_result() {
+        let tail = sound_tail();
+        let sting = sting(StingOutcome::Matched);
+
+        assert_eq!(
+            overall(WatermarkOutcome::Fail, &tail, Some(&sting)),
+            Verdict::Fail
+        );
+        // The point of B7.2: the other half is still there to be reported.
+        assert!(tail.is_sound());
+        assert_eq!(sting.outcome, StingOutcome::Matched);
+    }
+
+    #[test]
+    fn b7_3_an_unrecognised_sting_warns_and_is_neither_pass_nor_fail() {
+        let verdict = overall(
+            WatermarkOutcome::Pass,
+            &sound_tail(),
+            Some(&sting(StingOutcome::Unrecognised)),
+        );
+
+        assert_eq!(verdict, Verdict::Warning);
+        assert_ne!(verdict, Verdict::Pass);
+        assert_ne!(verdict, Verdict::Fail);
+    }
+
+    #[test]
+    fn a_broken_tail_fails_the_run_even_with_a_perfect_watermark() {
+        assert_eq!(
+            overall(
+                WatermarkOutcome::Pass,
+                &broken_tail(),
+                Some(&sting(StingOutcome::Matched))
+            ),
+            Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn a_sting_that_is_not_held_fails_rather_than_warns() {
+        assert_eq!(
+            overall(
+                WatermarkOutcome::Pass,
+                &sound_tail(),
+                Some(&sting(StingOutcome::NotFrozen))
+            ),
+            Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn a_sting_that_was_never_located_cannot_pass() {
+        // No white peak means nothing located the closing logo, so there is no
+        // basis for a pass even though no sting check actively failed.
+        assert_eq!(
+            overall(WatermarkOutcome::Pass, &broken_tail(), None),
+            Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn an_unavailable_pool_warns_rather_than_passing_silently() {
+        // Passing here would report a green tick on a video whose logo nobody
+        // checked, which is the failure mode worth being loud about.
+        assert_eq!(
+            overall(
+                WatermarkOutcome::Pass,
+                &sound_tail(),
+                Some(&sting(StingOutcome::PoolUnavailable))
+            ),
+            Verdict::Warning
+        );
+    }
+}

--- a/src-tauri/src/kavanagh/watermark.rs
+++ b/src-tauri/src/kavanagh/watermark.rs
@@ -47,14 +47,12 @@ use super::thresholds::{
 };
 
 /// Which stage of a run progress refers to.
-///
-/// Stage 3's tail analysis adds a `Tail` variant when it starts emitting one. It
-/// is not declared here in advance: an unconstructed variant is dead code, and the
-/// frontend's union has to grow at the same time anyway.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Phase {
     Probe,
+    /// The closing dip, sting identity and the freeze check (stage 3).
+    Tail,
     Watermark,
     Refine,
 }
@@ -67,6 +65,8 @@ pub struct AnalysisRequest {
     pub ffprobe: String,
     /// Absolute paths of the watermark reference pool, listed by the frontend.
     pub reference_files: Vec<String>,
+    /// Absolute paths of the sting reference pool, listed by the frontend.
+    pub sting_reference_files: Vec<String>,
     /// An operator's advanced override, or `None` for the calibrated default.
     pub match_threshold: Option<f32>,
     /// Where the dip to white begins, once stage 3 can measure it. `None` today.
@@ -233,6 +233,27 @@ pub fn analyse(
     cancel: &watch::Receiver<bool>,
     progress: &mut dyn FnMut(Phase, f64, &str),
 ) -> Result<WatermarkReport, KavanaghError> {
+    // Before the probe, not after it: an out-of-range threshold should cost
+    // nothing to find out about, and spawning ffprobe first would report a
+    // missing file to someone whose actual mistake was the threshold (B13.3).
+    resolve_match_confidence(request.match_threshold)
+        .map_err(|message| KavanaghError::Threshold { message })?;
+
+    let probe = probe_video(request, cancel)?;
+    analyse_with_probe(request, &probe, cancel, progress)
+}
+
+/// The watermark check, given a probe someone else already paid for.
+///
+/// A whole run probes once and both checks need the result, so `check::run_check`
+/// calls this rather than `analyse` - an ffprobe per check is cheap but it is
+/// still a second process spawn for an answer already in hand.
+pub fn analyse_with_probe(
+    request: &AnalysisRequest,
+    probe: &VideoProbe,
+    cancel: &watch::Receiver<bool>,
+    progress: &mut dyn FnMut(Phase, f64, &str),
+) -> Result<WatermarkReport, KavanaghError> {
     let mut percentage = MonotonicPercentage::default();
     let report = |progress: &mut dyn FnMut(Phase, f64, &str),
                   percentage: &mut MonotonicPercentage,
@@ -251,19 +272,10 @@ pub fn analyse(
         progress,
         &mut percentage,
         Phase::Probe,
-        2.0,
-        "Reading the video",
-    );
-    let probe = probe_video(request, cancel)?;
-
-    report(
-        progress,
-        &mut percentage,
-        Phase::Probe,
         8.0,
         "Preparing reference watermarks",
     );
-    let prepared = prepare_references(request, &probe, cancel)?;
+    let prepared = prepare_references(request, probe, cancel)?;
 
     let span = watermark_span(
         probe.duration_seconds,
@@ -437,7 +449,7 @@ pub fn analyse(
 }
 
 /// Asks ffprobe for the dimensions and duration the whole check depends on.
-fn probe_video(
+pub fn probe_video(
     request: &AnalysisRequest,
     cancel: &watch::Receiver<bool>,
 ) -> Result<VideoProbe, KavanaghError> {
@@ -447,7 +459,10 @@ fn probe_video(
         "-select_streams".to_string(),
         "v:0".to_string(),
         "-show_entries".to_string(),
-        "stream=width,height".to_string(),
+        // nb_frames and r_frame_rate are what the true end is derived from, in
+        // preference to the container's duration field (A7). Both are optional:
+        // a stream that cannot report them falls back to the duration.
+        "stream=width,height,nb_frames,r_frame_rate".to_string(),
         "-show_entries".to_string(),
         "format=duration".to_string(),
         "-of".to_string(),
@@ -880,7 +895,7 @@ pub fn file_name_of(path: &str) -> String {
 }
 
 /// Turns a process failure into the error the frontend renders.
-fn run_error(error: RunError) -> KavanaghError {
+pub fn run_error(error: RunError) -> KavanaghError {
     match error {
         RunError::Cancelled => KavanaghError::Cancelled {
             message: "The quality control run was cancelled.".to_string(),

--- a/src-tauri/src/kavanagh/watermark.rs
+++ b/src-tauri/src/kavanagh/watermark.rs
@@ -224,25 +224,6 @@ pub fn sampling_frame_size(prepared: &PreparedReferences) -> usize {
     prepared.region_width as usize * prepared.region_height as usize * prepared.regions.len().max(1)
 }
 
-/// Runs the whole watermark check.
-///
-/// `progress` is a plain closure rather than an `AppHandle` so the analysis can be
-/// exercised without a Tauri runtime.
-pub fn analyse(
-    request: &AnalysisRequest,
-    cancel: &watch::Receiver<bool>,
-    progress: &mut dyn FnMut(Phase, f64, &str),
-) -> Result<WatermarkReport, KavanaghError> {
-    // Before the probe, not after it: an out-of-range threshold should cost
-    // nothing to find out about, and spawning ffprobe first would report a
-    // missing file to someone whose actual mistake was the threshold (B13.3).
-    resolve_match_confidence(request.match_threshold)
-        .map_err(|message| KavanaghError::Threshold { message })?;
-
-    let probe = probe_video(request, cancel)?;
-    analyse_with_probe(request, &probe, cancel, progress)
-}
-
 /// The watermark check, given a probe someone else already paid for.
 ///
 /// A whole run probes once and both checks need the result, so `check::run_check`

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,10 @@ use std::sync::Mutex;
 use baker::*;
 use build_project::{transfer_files_with_progress, cancel_file_transfer, OperationRegistry};
 use commands::*;
-use kavanagh::{kavanagh_cancel_run, kavanagh_detect_ffmpeg, kavanagh_run_watermark_check, kavanagh_save_evidence, KavanaghRunState};
+use kavanagh::{
+    kavanagh_cancel_run, kavanagh_detect_ffmpeg, kavanagh_run_check, kavanagh_run_watermark_check,
+    kavanagh_save_evidence, KavanaghRunState,
+};
 use state::AuthState;
 
 fn main() {
@@ -112,6 +115,7 @@ fn main() {
             // Issue #180: Video QC - ffmpeg discovery and the watermark check
             kavanagh_detect_ffmpeg,
             kavanagh_run_watermark_check,
+            kavanagh_run_check,
             kavanagh_cancel_run,
             kavanagh_save_evidence
         ])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,8 +18,8 @@ use baker::*;
 use build_project::{transfer_files_with_progress, cancel_file_transfer, OperationRegistry};
 use commands::*;
 use kavanagh::{
-    kavanagh_cancel_run, kavanagh_detect_ffmpeg, kavanagh_run_check, kavanagh_run_watermark_check,
-    kavanagh_save_evidence, KavanaghRunState,
+    kavanagh_cancel_run, kavanagh_detect_ffmpeg, kavanagh_run_check, kavanagh_save_evidence,
+    KavanaghRunState,
 };
 use state::AuthState;
 
@@ -114,7 +114,6 @@ fn main() {
             cancel_file_transfer,
             // Issue #180: Video QC - ffmpeg discovery and the watermark check
             kavanagh_detect_ffmpeg,
-            kavanagh_run_watermark_check,
             kavanagh_run_check,
             kavanagh_cancel_run,
             kavanagh_save_evidence

--- a/src/features/Kavanagh/__contracts__/kavanagh.contract.test.ts
+++ b/src/features/Kavanagh/__contracts__/kavanagh.contract.test.ts
@@ -29,10 +29,10 @@ describe('Kavanagh barrel shape', () => {
     expect(typeof barrel.useKavanaghAvailability).toBe('function')
   })
 
-  it('exports the watermark run hook the upload flow will consume in stage 4', async () => {
+  it('exports the run hook the upload flow will consume in stage 4', async () => {
     const barrel = await import('../index')
 
-    expect(typeof barrel.useWatermarkCheck).toBe('function')
+    expect(typeof barrel.useKavanaghCheck).toBe('function')
   })
 
   it('does not leak internal helpers through the barrel', async () => {
@@ -82,22 +82,26 @@ describe('Kavanagh I/O boundary', () => {
     expect(calls[0].args).toMatchObject({ customDir: null })
   })
 
-  it('routes a watermark run through the kavanagh_run_watermark_check command', async () => {
+  it('routes a run through the kavanagh_run_check command, with both pools', async () => {
     const calls = captureInvokes()
-    const { runWatermarkCheck } = await import('../api')
+    const { runKavanaghCheck } = await import('../api')
 
-    await runWatermarkCheck({
+    await runKavanaghCheck({
       videoPath: '/Volumes/Renders/module.mp4',
       referenceFiles: ['/refs/Watermarks/right.png'],
+      stingReferenceFiles: ['/refs/Stings/current.jpg'],
       ffmpegDirectory: null,
       matchThreshold: 0.92
     })
 
-    expect(calls[0].cmd).toBe('kavanagh_run_watermark_check')
+    expect(calls[0].cmd).toBe('kavanagh_run_check')
+    // Both pools travel in one request: the tail has to run before the watermark
+    // pass to tell it where to stop, so they cannot be two calls (D9).
     expect(calls[0].args).toMatchObject({
       request: {
         videoPath: '/Volumes/Renders/module.mp4',
         referenceFiles: ['/refs/Watermarks/right.png'],
+        stingReferenceFiles: ['/refs/Stings/current.jpg'],
         ffmpegDirectory: null,
         matchThreshold: 0.92
       }
@@ -106,11 +110,12 @@ describe('Kavanagh I/O boundary', () => {
 
   it('sends a null threshold rather than omitting it, so the default applies', async () => {
     const calls = captureInvokes()
-    const { runWatermarkCheck } = await import('../api')
+    const { runKavanaghCheck } = await import('../api')
 
-    await runWatermarkCheck({
+    await runKavanaghCheck({
       videoPath: '/a.mp4',
-      referenceFiles: ['/refs/right.png']
+      referenceFiles: ['/refs/right.png'],
+      stingReferenceFiles: []
     })
 
     // An omitted key would arrive as a missing argument rather than an explicit

--- a/src/features/Kavanagh/api.ts
+++ b/src/features/Kavanagh/api.ts
@@ -21,9 +21,9 @@ import {
 } from './internal/referencePool'
 import type {
   FfmpegAvailability,
+  KavanaghCheckReport,
   KavanaghProgressEvent,
-  KavanaghThumbnail,
-  KavanaghWatermarkReport
+  KavanaghThumbnail
 } from './types'
 
 /**
@@ -78,10 +78,18 @@ export async function listReferencePool(
 }
 
 /** What to check, and with what. */
-export interface WatermarkCheckRequest {
+export interface KavanaghCheckRequest {
   videoPath: string
   /** The watermark pool's files, from `listReferencePool`. */
   referenceFiles: string[]
+  /**
+   * The sting pool's files, from `listReferencePool`.
+   *
+   * An empty pool is not refused: the tail is still worth measuring, and the
+   * sting check reports the pool as unavailable rather than failing the run
+   * (B6.4).
+   */
+  stingReferenceFiles: string[]
   /** The Settings ffmpeg directory, when one is configured. */
   ffmpegDirectory?: string | null
   /** An advanced override; omit for the calibrated default (B13.1). */
@@ -89,21 +97,26 @@ export interface WatermarkCheckRequest {
 }
 
 /**
- * Runs the watermark check over one video.
+ * Runs both checks over one video and returns a single verdict.
+ *
+ * One command rather than two, because the order matters: the watermark is not
+ * expected over the closing dip, and the dip is found by the tail analysis, so
+ * the tail must run first and hand the watermark pass its end point (D9).
  *
  * Long-running: the promise settles when the analysis finishes, while progress
- * arrives on the `kavanagh-progress` event. Rejects with a `KavanaghError` - including a
- * `busy` rejection when a run is already in flight (D19).
+ * arrives on the `kavanagh-progress` event. Rejects with a `KavanaghError` -
+ * including a `busy` rejection when a run is already in flight (D19).
  */
-export async function runWatermarkCheck(
-  request: WatermarkCheckRequest
-): Promise<KavanaghWatermarkReport> {
-  return invoke<KavanaghWatermarkReport>('kavanagh_run_watermark_check', {
+export async function runKavanaghCheck(
+  request: KavanaghCheckRequest
+): Promise<KavanaghCheckReport> {
+  return invoke<KavanaghCheckReport>('kavanagh_run_check', {
     request: {
       videoPath: request.videoPath,
       referenceFiles: request.referenceFiles,
+      stingReferenceFiles: request.stingReferenceFiles,
       ffmpegDirectory: request.ffmpegDirectory ?? null,
-      // Omitted rather than null when there is no override: the Rust side treats
+      // Null rather than omitted when there is no override: the Rust side treats
       // `None` as "use the calibrated default".
       matchThreshold: request.matchThreshold ?? null
     }

--- a/src/features/Kavanagh/components/KavanaghPage.test.tsx
+++ b/src/features/Kavanagh/components/KavanaghPage.test.tsx
@@ -14,7 +14,13 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { UseKavanaghAvailabilityResult } from '../hooks/useKavanaghAvailability'
-import type { KavanaghProgressEvent, KavanaghWatermarkReport } from '../types'
+import type {
+  KavanaghCheckReport,
+  KavanaghProgressEvent,
+  KavanaghStingReport,
+  KavanaghTailAnalysis,
+  KavanaghWatermarkReport
+} from '../types'
 
 const mockAvailability = vi.fn<() => UseKavanaghAvailabilityResult>()
 
@@ -24,7 +30,7 @@ vi.mock('../hooks/useKavanaghAvailability', () => ({
 
 // The single I/O boundary. Mocking it and nothing else is what keeps the real page,
 // the real run hook and the real report rendering under test.
-const runWatermarkCheck = vi.fn()
+const runKavanaghCheck = vi.fn()
 const cancelKavanaghRun = vi.fn()
 const saveKavanaghEvidence = vi.fn()
 const pickVideoFile = vi.fn()
@@ -32,7 +38,7 @@ const pickEvidenceFolder = vi.fn()
 let emitProgress: ((event: KavanaghProgressEvent) => void) | null = null
 
 vi.mock('../api', () => ({
-  runWatermarkCheck: (...args: unknown[]) => runWatermarkCheck(...args),
+  runKavanaghCheck: (...args: unknown[]) => runKavanaghCheck(...args),
   cancelKavanaghRun: () => cancelKavanaghRun(),
   saveKavanaghEvidence: (...args: unknown[]) => saveKavanaghEvidence(...args),
   pickVideoFile: () => pickVideoFile(),
@@ -78,7 +84,7 @@ const READY: UseKavanaghAvailabilityResult = {
   }
 }
 
-const PASSING_REPORT: KavanaghWatermarkReport = {
+const PASSING_WATERMARK: KavanaghWatermarkReport = {
   outcome: 'pass',
   corner: 'topRight',
   span: { startSeconds: 0, endSeconds: 132, approximated: true },
@@ -95,11 +101,29 @@ const PASSING_REPORT: KavanaghWatermarkReport = {
   referencesUsed: 4,
   video: { width: 3840, height: 2160, durationSeconds: 144 },
   thumbnails: [],
-  notes: ['The dip to white has not been located, so the watermark was checked over…']
+  notes: []
 }
 
-const FAILING_REPORT: KavanaghWatermarkReport = {
-  ...PASSING_REPORT,
+const SOUND_TAIL: KavanaghTailAnalysis = {
+  peakAtSeconds: 139.0,
+  rampSeconds: 0.4,
+  stingSeconds: 5.0,
+  trailingSeconds: 0.04,
+  problems: []
+}
+
+const MATCHED_STING: KavanaghStingReport = {
+  outcome: 'matched',
+  matchedReference: 'WBS_Sting_2024.jpg',
+  bestReference: 'WBS_Sting_2024.jpg',
+  bestConfidence: 0.9989,
+  freezeMad: 0.0,
+  framesCompared: 9,
+  threshold: 0.95
+}
+
+const FAILING_WATERMARK: KavanaghWatermarkReport = {
+  ...PASSING_WATERMARK,
   outcome: 'fail',
   gaps: [
     {
@@ -114,6 +138,30 @@ const FAILING_REPORT: KavanaghWatermarkReport = {
     { label: 'watermark-missing-252.0s', atSeconds: 252, jpeg: [255, 216, 255, 217] }
   ],
   notes: []
+}
+
+const PASSING_REPORT: KavanaghCheckReport = {
+  verdict: 'pass',
+  watermark: PASSING_WATERMARK,
+  tail: SOUND_TAIL,
+  sting: MATCHED_STING,
+  problemMessages: [],
+  notes: []
+}
+
+const FAILING_REPORT: KavanaghCheckReport = {
+  ...PASSING_REPORT,
+  verdict: 'fail',
+  watermark: FAILING_WATERMARK,
+  problemMessages: []
+}
+
+/** A report whose watermark half differs, the rest held steady. */
+function withWatermark(
+  base: KavanaghCheckReport,
+  overrides: Partial<KavanaghWatermarkReport>
+): KavanaghCheckReport {
+  return { ...base, watermark: { ...base.watermark, ...overrides } }
 }
 
 function renderPage() {
@@ -205,7 +253,7 @@ describe('KavanaghPage watermark run', () => {
 
   it('B8.1 shows progress with its phase, then renders the report', async () => {
     let settle: (report: KavanaghWatermarkReport) => void = () => {}
-    runWatermarkCheck.mockImplementation(
+    runKavanaghCheck.mockImplementation(
       () => new Promise<KavanaghWatermarkReport>((resolve) => (settle = resolve))
     )
 
@@ -213,10 +261,10 @@ describe('KavanaghPage watermark run', () => {
     await userEvent.click(screen.getByRole('button', { name: /choose video/i }))
     await userEvent.click(screen.getByRole('button', { name: /run quality control/i }))
 
-    await waitFor(() => expect(runWatermarkCheck).toHaveBeenCalled())
+    await waitFor(() => expect(runKavanaghCheck).toHaveBeenCalled())
     // The first argument only: React Query hands a mutation context along as a
     // second one, which is not part of the request.
-    expect(runWatermarkCheck.mock.calls[0][0]).toMatchObject({
+    expect(runKavanaghCheck.mock.calls[0][0]).toMatchObject({
       videoPath: '/Volumes/Renders/module.mp4',
       referenceFiles: ['/Volumes/Brand/QC references/Watermarks/right.png']
     })
@@ -236,9 +284,7 @@ describe('KavanaghPage watermark run', () => {
     settle(PASSING_REPORT)
 
     await waitFor(() =>
-      expect(
-        screen.getByText(/watermark present throughout, top-right/i)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/present throughout, top-right/i)).toBeInTheDocument()
     )
     expect(
       screen.getByText(/WBS_Watermark_BlackRight\.png/, { exact: false })
@@ -246,9 +292,7 @@ describe('KavanaghPage watermark run', () => {
   })
 
   it('B8.6 disables a second start while a run is in flight', async () => {
-    runWatermarkCheck.mockImplementation(
-      () => new Promise<KavanaghWatermarkReport>(() => {})
-    )
+    runKavanaghCheck.mockImplementation(() => new Promise<KavanaghCheckReport>(() => {}))
 
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /choose video/i }))
@@ -257,13 +301,13 @@ describe('KavanaghPage watermark run', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /run quality control/i })).toBeDisabled()
     )
-    expect(runWatermarkCheck).toHaveBeenCalledTimes(1)
+    expect(runKavanaghCheck).toHaveBeenCalledTimes(1)
   })
 
   it('B8.6 surfaces the backend rejection when a run is already in flight', async () => {
     // The page's own guard can be bypassed - a second page, or a run started from
     // the upload flow in stage 4 - so the backend's rejection has to be shown.
-    runWatermarkCheck.mockRejectedValue({
+    runKavanaghCheck.mockRejectedValue({
       kind: 'busy',
       message: 'A quality control run is already in progress.'
     })
@@ -279,7 +323,7 @@ describe('KavanaghPage watermark run', () => {
 
   it('B8.2 cancels the run and returns the page to idle without showing a failure', async () => {
     let reject: (error: unknown) => void = () => {}
-    runWatermarkCheck.mockImplementation(
+    runKavanaghCheck.mockImplementation(
       () => new Promise<KavanaghWatermarkReport>((_, r) => (reject = r))
     )
     cancelKavanaghRun.mockResolvedValue(true)
@@ -302,7 +346,7 @@ describe('KavanaghPage watermark run', () => {
   })
 
   it('B11.3 shows ffmpeg stderr rather than a generic failure', async () => {
-    runWatermarkCheck.mockRejectedValue({
+    runKavanaghCheck.mockRejectedValue({
       kind: 'ffmpeg',
       message: 'ffmpeg could not decode this video for the watermark check.',
       stderr: "Unknown decoder 'hevc'"
@@ -321,7 +365,7 @@ describe('KavanaghPage watermark run', () => {
   })
 
   it('B12.1 shows a probe failure as its own specific reason', async () => {
-    runWatermarkCheck.mockRejectedValue({
+    runKavanaghCheck.mockRejectedValue({
       kind: 'probe',
       message: 'This file has no video stream, so there is nothing to check.'
     })
@@ -334,6 +378,24 @@ describe('KavanaghPage watermark run', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(/no video stream/i)
     )
   })
+
+  it('B7.4 shows a run that could not judge the video as an error, not a failure', async () => {
+    // "Not judged" and "judged bad" send an operator to different places: one is
+    // a file or toolchain to fix, the other is a render to re-export.
+    runKavanaghCheck.mockRejectedValue({
+      kind: 'probe',
+      message: 'This file has no video stream, so there is nothing to check.'
+    })
+
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /choose video/i }))
+    await userEvent.click(screen.getByRole('button', { name: /run quality control/i }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    // No verdict at all, rather than a verdict of "failed".
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByText(/^failed\.$/i)).not.toBeInTheDocument()
+  })
 })
 
 describe('KavanaghPage report', () => {
@@ -343,19 +405,84 @@ describe('KavanaghPage report', () => {
     pickVideoFile.mockResolvedValue('/Volumes/Renders/module.mp4')
   })
 
-  async function runWith(report: KavanaghWatermarkReport) {
-    runWatermarkCheck.mockResolvedValue(report)
+  async function runWith(report: KavanaghCheckReport) {
+    runKavanaghCheck.mockResolvedValue(report)
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /choose video/i }))
     await userEvent.click(screen.getByRole('button', { name: /run quality control/i }))
-    await waitFor(() => expect(screen.getByText(/watermark report/i)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /^report$/i })).toBeInTheDocument()
+    )
   }
 
   it('B4.2 reports a gap as a time range rather than one timestamp', async () => {
     await runWith(FAILING_REPORT)
 
-    expect(screen.getByText(/watermark check failed/i)).toBeInTheDocument()
+    expect(screen.getByText(/missing for part of the render/i)).toBeInTheDocument()
     expect(screen.getByText(/4:12\.0 to 4:31\.0/)).toBeInTheDocument()
+  })
+
+  it('B7.1 leads with a pass covering both checks, not just the watermark', async () => {
+    await runWith(PASSING_REPORT)
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      /passed\. the watermark and the closing sting are both correct/i
+    )
+  })
+
+  it('B7.3 renders a warning as neither a pass nor a failure', async () => {
+    // An unrecognised sting means the references folder needs a new variant.
+    // Rendering it as a failure is how people learn to ignore failures (D8).
+    await runWith({
+      ...PASSING_REPORT,
+      verdict: 'warning',
+      sting: {
+        ...MATCHED_STING,
+        outcome: 'unrecognised',
+        matchedReference: null,
+        bestConfidence: 0.7869
+      },
+      problemMessages: [
+        'The tail is a held still, but it matches nothing in the stings folder - closest was WBS_Sting_2024.jpg at 0.787, below 0.95. If this is a new sting, add it to the folder.'
+      ]
+    })
+
+    const banner = screen.getByRole('status')
+    expect(banner).toHaveTextContent(/passed with a warning/i)
+    expect(banner).not.toHaveTextContent(/^failed/i)
+    expect(banner).toHaveTextContent(/matches nothing in the stings folder/i)
+  })
+
+  it('B7.2 shows what the tail measured even when the watermark is what failed', async () => {
+    // Fixing one fault only to discover the next is the failure mode D9 exists
+    // to avoid, so both halves are always on screen.
+    await runWith(FAILING_REPORT)
+
+    expect(screen.getByText(/missing for part of the render/i)).toBeInTheDocument()
+    expect(screen.getByText(/peaks at 2:19\.0/)).toBeInTheDocument()
+    expect(screen.getByText(/WBS_Sting_2024\.jpg/)).toBeInTheDocument()
+  })
+
+  it('shows the tail measurements a disputed verdict is argued with', async () => {
+    // The tolerances are tight by design, so a verdict is only answerable next
+    // to the numbers that produced it.
+    await runWith(PASSING_REPORT)
+
+    expect(screen.getByText(/over 0\.40s/)).toBeInTheDocument()
+    expect(screen.getByText(/5\.00s/)).toBeInTheDocument()
+    expect(screen.getByText(/9 frames, mean difference 0\.00/)).toBeInTheDocument()
+  })
+
+  it('names the fault the tail found, with the measurement behind it', async () => {
+    await runWith({
+      ...FAILING_REPORT,
+      tail: { ...SOUND_TAIL, rampSeconds: 0.25 },
+      problemMessages: [
+        'The dip to white takes 0.25s, expected 0.40s (0.32-0.48s). A ramp this short is a hard cut rather than a dissolve.'
+      ]
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent(/takes 0\.25s, expected 0\.40s/i)
   })
 
   it('shows the score range and threshold on a pass, not just a green tick', async () => {
@@ -371,15 +498,16 @@ describe('KavanaghPage report', () => {
   it('names the closest reference and its score when nothing matched at all', async () => {
     // How a wrong-resolution watermark is told apart from a missing one: one comes
     // close and names an asset, the other does not.
-    await runWith({
-      ...FAILING_REPORT,
-      corner: null,
-      matchedSamples: 0,
-      matchedReference: null,
-      bestReference: 'WBS_Watermark_BlackRight_4K.png',
-      bestConfidence: 0.389,
-      weakestConfidence: -0.1483
-    })
+    await runWith(
+      withWatermark(FAILING_REPORT, {
+        corner: null,
+        matchedSamples: 0,
+        matchedReference: null,
+        bestReference: 'WBS_Watermark_BlackRight_4K.png',
+        bestConfidence: 0.389,
+        weakestConfidence: -0.1483
+      })
+    )
 
     expect(
       screen.getByText(/closest reference WBS_Watermark_BlackRight_4K\.png/i)
@@ -394,28 +522,44 @@ describe('KavanaghPage report', () => {
   })
 
   it('B3.7 names the corner change and when it happened', async () => {
-    await runWith({
-      ...FAILING_REPORT,
-      gaps: [],
-      cornerChanges: [{ atSeconds: 30, expected: 'topRight', found: 'topLeft' }]
-    })
+    await runWith(
+      withWatermark(FAILING_REPORT, {
+        gaps: [],
+        cornerChanges: [{ atSeconds: 30, expected: 'topRight', found: 'topLeft' }]
+      })
+    )
 
     expect(screen.getByText(/expected top-right, found top-left/i)).toBeInTheDocument()
     expect(screen.getByText(/0:30\.0/, { exact: false })).toBeInTheDocument()
   })
 
-  it('B5.10 states that the checked span was approximated', async () => {
-    await runWith(PASSING_REPORT)
+  it('B5.10 states that the checked span was approximated when no dip was found', async () => {
+    // Both faults are reported rather than one hiding the other (D9): the tail
+    // says there is no dip, and the watermark result says its span was a guess.
+    await runWith({
+      ...FAILING_REPORT,
+      tail: {
+        peakAtSeconds: null,
+        rampSeconds: null,
+        stingSeconds: null,
+        trailingSeconds: null,
+        problems: [{ kind: 'noWhitePeak' }]
+      },
+      sting: null,
+      problemMessages: ['No dip to white found in the closing section.'],
+      notes: ['No dip to white was found, so the watermark was checked over the first…']
+    })
 
-    expect(screen.getByText(/dip to white has not been located/i)).toBeInTheDocument()
+    expect(screen.getByText(/no dip to white found/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/the span is approximate|checked over the first/i)
+    ).toBeInTheDocument()
   })
 
   it('B13.2 says when a non-default threshold was applied', async () => {
-    await runWith({
-      ...PASSING_REPORT,
-      threshold: 0.92,
-      thresholdIsDefault: false
-    })
+    await runWith(
+      withWatermark(PASSING_REPORT, { threshold: 0.92, thresholdIsDefault: false })
+    )
 
     expect(screen.getByText(/0\.920 \(overridden\)/)).toBeInTheDocument()
   })
@@ -455,7 +599,7 @@ describe('KavanaghPage report', () => {
       expect(saveKavanaghEvidence).toHaveBeenCalledWith(
         '/Volumes/Evidence',
         'kavanagh-module',
-        FAILING_REPORT.thumbnails
+        FAILING_REPORT.watermark.thumbnails
       )
     )
     expect(toastSuccess).toHaveBeenCalledWith(
@@ -497,7 +641,7 @@ describe('KavanaghPage report', () => {
     await userEvent.click(screen.getByRole('button', { name: /choose video/i }))
 
     await waitFor(() =>
-      expect(screen.queryByText(/watermark report/i)).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /^report$/i })).not.toBeInTheDocument()
     )
   })
 })

--- a/src/features/Kavanagh/components/KavanaghPage.tsx
+++ b/src/features/Kavanagh/components/KavanaghPage.tsx
@@ -1,13 +1,17 @@
 /**
- * Kavanagh page (issue #180, stages 1-2)
+ * Kavanagh page (issue #180, stages 1-3)
  *
- * Stage 1 established the page and its prerequisite reporting. Stage 2 adds the
- * watermark check: pick a render, run it, watch the phases, read the report.
+ * Pick a render, run it, watch the phases, read the report. One run covers both
+ * checks - the watermark throughout, and the closing dip to white into an
+ * approved sting - reduced to a single verdict (B7).
  *
- * The report's failure thumbnails are held in memory and nothing is written to
- * disk unless the operator uses "Save evidence…" (D15). The tail and sting checks
- * arrive in stage 3, which is why the verdict here is about the watermark alone
- * and the report says out loud that the checked span was approximated.
+ * The report leads with that verdict and the sentences behind it, then shows
+ * each check's own measurements underneath. Both halves are always rendered,
+ * whichever one decided the verdict: an operator should learn everything wrong
+ * with a render in one run rather than fixing one fault to discover the next.
+ *
+ * Failure thumbnails are held in memory and nothing is written to disk unless
+ * the operator uses "Save evidence…" (D15).
  */
 
 import { useApiKeys, useBreadcrumb } from '@shared/hooks'
@@ -20,7 +24,7 @@ import { toast } from 'sonner'
 
 import { pickEvidenceFolder, pickVideoFile, saveKavanaghEvidence } from '../api'
 import { useKavanaghAvailability } from '../hooks/useKavanaghAvailability'
-import { useWatermarkCheck } from '../hooks/useWatermarkCheck'
+import { useKavanaghCheck } from '../hooks/useKavanaghCheck'
 import { asKavanaghError } from '../internal/kavanaghError'
 import { REFERENCE_POOLS, type ReferencePoolStatus } from '../internal/referencePool'
 import {
@@ -31,8 +35,11 @@ import {
   phaseLabel
 } from '../internal/reportFormatting'
 import type {
+  KavanaghCheckReport,
   KavanaghError,
   KavanaghProgressEvent,
+  KavanaghStingReport,
+  KavanaghTailAnalysis,
   KavanaghThumbnail,
   KavanaghWatermarkReport
 } from '../types'
@@ -45,7 +52,7 @@ const KavanaghContent: React.FC = () => {
 
   const { available, reason, pending, pools, poolFiles } = useKavanaghAvailability()
   const { data: settings } = useApiKeys()
-  const { isRunning, progress, report, error, run, cancel, reset } = useWatermarkCheck()
+  const { isRunning, progress, report, error, run, cancel, reset } = useKavanaghCheck()
 
   const [videoPath, setVideoPath] = React.useState<string | null>(null)
 
@@ -63,6 +70,7 @@ const KavanaghContent: React.FC = () => {
     void run({
       videoPath,
       referenceFiles: poolFiles.watermarks,
+      stingReferenceFiles: poolFiles.stings,
       ffmpegDirectory: settings?.ffmpegDirectory ?? null,
       matchThreshold: settings?.kavanaghMatchThreshold
     })
@@ -119,7 +127,7 @@ const KavanaghContent: React.FC = () => {
             {error && <RunFailure error={error} />}
           </section>
 
-          {report && <WatermarkReportView report={report} videoPath={videoPath} />}
+          {report && <CheckReportView report={report} videoPath={videoPath} />}
         </div>
       </div>
     </div>
@@ -229,7 +237,137 @@ const RunFailure: React.FC<{ error: KavanaghError }> = ({ error }) => (
   </div>
 )
 
-/** The report for one completed run. */
+/** The report for one completed run: the verdict, then each check underneath. */
+const CheckReportView: React.FC<{
+  report: KavanaghCheckReport
+  videoPath: string | null
+}> = ({ report, videoPath }) => (
+  <section aria-labelledby="kavanagh-report" className="space-y-4">
+    <h2 id="kavanagh-report" className="text-foreground text-sm font-semibold">
+      Report
+    </h2>
+
+    <VerdictBanner verdict={report.verdict} problems={report.problemMessages} />
+
+    <TailSection tail={report.tail} sting={report.sting} />
+
+    <WatermarkReportView report={report.watermark} videoPath={videoPath} />
+
+    {report.notes.length > 0 && (
+      <ul className="text-muted-foreground space-y-1 text-xs">
+        {report.notes.map((note, index) => (
+          <li key={`${index}-${note.slice(0, 24)}`}>{note}</li>
+        ))}
+      </ul>
+    )}
+  </section>
+)
+
+/**
+ * The one line an operator reads first, and the sentences behind it.
+ *
+ * Three renderings, not two. A warning is neither a pass nor a failure: an
+ * unrecognised sting means the references folder needs a new variant, which is
+ * housekeeping, and rendering it as a failure would train people to ignore
+ * failures (D8, B7.3).
+ */
+const VerdictBanner: React.FC<{
+  verdict: KavanaghCheckReport['verdict']
+  problems: string[]
+}> = ({ verdict, problems }) => {
+  const style =
+    verdict === 'pass'
+      ? 'border-emerald-500/40 bg-emerald-500/10'
+      : verdict === 'warning'
+        ? 'border-amber-500/40 bg-amber-500/10'
+        : 'border-destructive/40 bg-destructive/10'
+
+  const headline =
+    verdict === 'pass'
+      ? 'Passed. The watermark and the closing sting are both correct.'
+      : verdict === 'warning'
+        ? 'Passed with a warning.'
+        : 'Failed.'
+
+  return (
+    <div
+      role="status"
+      className={`flex items-start gap-2 rounded-md border p-3 text-sm ${style}`}
+    >
+      {verdict === 'pass' ? (
+        <CheckCircle2
+          className="mt-0.5 size-4 shrink-0 text-emerald-500"
+          aria-hidden="true"
+        />
+      ) : verdict === 'warning' ? (
+        <AlertTriangle
+          className="mt-0.5 size-4 shrink-0 text-amber-500"
+          aria-hidden="true"
+        />
+      ) : (
+        <XCircle className="text-destructive mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      )}
+      <div className="text-foreground">
+        <p className="font-medium">{headline}</p>
+        {problems.length > 0 && (
+          <ul className="text-muted-foreground mt-1 space-y-1 text-xs">
+            {problems.map((problem, index) => (
+              <li key={`${index}-${problem.slice(0, 24)}`}>{problem}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * What the closing tail measured, whatever the verdict.
+ *
+ * The measurements are shown on a pass as well as a failure. The whole point of
+ * the tolerances is that they are tight enough to catch preset drift, so an
+ * operator arguing with a verdict needs the number that produced it - "ramp
+ * 0.25s" is a diagnosis, "the ramp is wrong" is an argument.
+ */
+const TailSection: React.FC<{
+  tail: KavanaghTailAnalysis
+  sting: KavanaghStingReport | null
+}> = ({ tail, sting }) => (
+  <div>
+    <h3 className="text-foreground mb-1 text-xs font-semibold">Closing tail</h3>
+    <dl className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs">
+      <dt>Dip to white</dt>
+      <dd>
+        {tail.peakAtSeconds === null
+          ? 'not found'
+          : `peaks at ${formatTime(tail.peakAtSeconds)}`}
+        {tail.rampSeconds !== null && `, over ${tail.rampSeconds.toFixed(2)}s`}
+      </dd>
+
+      <dt>Sting</dt>
+      <dd>
+        {tail.stingSeconds === null ? 'not measured' : `${tail.stingSeconds.toFixed(2)}s`}
+        {sting?.matchedReference
+          ? `, matching ${sting.matchedReference}`
+          : sting?.bestReference
+            ? `, closest ${sting.bestReference}`
+            : ''}
+        {sting && ` at ${sting.bestConfidence.toFixed(4)}`}
+      </dd>
+
+      {sting !== null && sting.freezeMad !== null && (
+        <>
+          <dt>Held steady</dt>
+          <dd>
+            {sting.framesCompared} frames, mean difference {sting.freezeMad.toFixed(2)}
+          </dd>
+        </>
+      )}
+    </dl>
+  </div>
+)
+
+/** What the watermark check measured. */
 const WatermarkReportView: React.FC<{
   report: KavanaghWatermarkReport
   videoPath: string | null
@@ -237,34 +375,14 @@ const WatermarkReportView: React.FC<{
   const passed = report.outcome === 'pass'
 
   return (
-    <section aria-labelledby="kavanagh-report" className="space-y-4">
-      <h2 id="kavanagh-report" className="text-foreground text-sm font-semibold">
-        Watermark report
-      </h2>
-
-      <div
-        className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
-          passed
-            ? 'border-emerald-500/40 bg-emerald-500/10'
-            : 'border-destructive/40 bg-destructive/10'
-        }`}
-      >
-        {passed ? (
-          <CheckCircle2
-            className="mt-0.5 size-4 shrink-0 text-emerald-500"
-            aria-hidden="true"
-          />
-        ) : (
-          <XCircle
-            className="text-destructive mt-0.5 size-4 shrink-0"
-            aria-hidden="true"
-          />
-        )}
-        <div className="text-foreground">
-          <p className="font-medium">
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-foreground mb-1 text-xs font-semibold">Watermark</h3>
+        <div className="text-foreground text-sm">
+          <p>
             {passed
-              ? `Watermark present throughout, ${cornerLabel(report.corner)}.`
-              : 'Watermark check failed.'}
+              ? `Present throughout, ${cornerLabel(report.corner)}.`
+              : 'Missing for part of the render.'}
           </p>
           {/*
             The scores are shown whatever the verdict. Two real renders with equally
@@ -339,7 +457,7 @@ const WatermarkReportView: React.FC<{
       {report.thumbnails.length > 0 && (
         <EvidenceView thumbnails={report.thumbnails} videoPath={videoPath} />
       )}
-    </section>
+    </div>
   )
 }
 

--- a/src/features/Kavanagh/hooks/useKavanaghCheck.ts
+++ b/src/features/Kavanagh/hooks/useKavanaghCheck.ts
@@ -1,8 +1,10 @@
 /**
- * useWatermarkCheck (issue #180, stage 2, B3, B4, B8, B10, B11)
+ * useKavanaghCheck (issue #180, stages 2-3, B3-B8, B10, B11)
  *
- * Owns one watermark run: starting it, showing its progress, cancelling it, and
- * holding the report it produced.
+ * Owns one run: starting it, showing its progress, cancelling it, and holding
+ * the report it produced. One run covers both checks - the watermark and the
+ * closing tail - because the tail has to run first to tell the watermark pass
+ * where to stop (D9).
  *
  * The report is held in memory here and nowhere else (D16). Failure thumbnails
  * come with it as JPEG bytes and are never written to disk unless the operator
@@ -16,34 +18,30 @@ import React from 'react'
 import {
   cancelKavanaghRun,
   listenKavanaghProgress,
-  runWatermarkCheck,
-  type WatermarkCheckRequest
+  runKavanaghCheck,
+  type KavanaghCheckRequest
 } from '../api'
 import { asKavanaghError, isCancellation } from '../internal/kavanaghError'
-import type {
-  KavanaghError,
-  KavanaghProgressEvent,
-  KavanaghWatermarkReport
-} from '../types'
+import type { KavanaghCheckReport, KavanaghError, KavanaghProgressEvent } from '../types'
 
-export interface UseWatermarkCheckResult {
+export interface UseKavanaghCheckResult {
   /** True while a run is in flight, which is what disables a second start (B8.6). */
   isRunning: boolean
   /** The most recent progress event, or null before the first one arrives. */
   progress: KavanaghProgressEvent | null
   /** The report from the last completed run, or null. */
-  report: KavanaghWatermarkReport | null
+  report: KavanaghCheckReport | null
   /** Why the last run failed, or null. A cancellation is not surfaced here. */
   error: KavanaghError | null
-  run: (request: WatermarkCheckRequest) => Promise<void>
+  run: (request: KavanaghCheckRequest) => Promise<void>
   cancel: () => Promise<void>
   /** Clears the report and any error, releasing the thumbnails held with it. */
   reset: () => void
 }
 
-export function useWatermarkCheck(): UseWatermarkCheckResult {
+export function useKavanaghCheck(): UseKavanaghCheckResult {
   const [progress, setProgress] = React.useState<KavanaghProgressEvent | null>(null)
-  const [report, setReport] = React.useState<KavanaghWatermarkReport | null>(null)
+  const [report, setReport] = React.useState<KavanaghCheckReport | null>(null)
   const [error, setError] = React.useState<KavanaghError | null>(null)
 
   // Subscribed for the page's lifetime rather than per run: `listen` resolves
@@ -73,7 +71,7 @@ export function useWatermarkCheck(): UseWatermarkCheckResult {
   }, [])
 
   const mutation = useMutation({
-    mutationFn: runWatermarkCheck,
+    mutationFn: runKavanaghCheck,
     // A QC run costs a full decode pass. Retrying one automatically would double
     // that for a failure that is nearly always a real one.
     retry: false,
@@ -92,7 +90,7 @@ export function useWatermarkCheck(): UseWatermarkCheckResult {
   })
 
   const run = React.useCallback(
-    async (request: WatermarkCheckRequest) => {
+    async (request: KavanaghCheckRequest) => {
       try {
         await mutation.mutateAsync(request)
       } catch {

--- a/src/features/Kavanagh/index.ts
+++ b/src/features/Kavanagh/index.ts
@@ -12,13 +12,19 @@ export { default as KavanaghPage } from './components/KavanaghPage'
 /** Hook resolving whether QC can run: ffmpeg toolchain plus both reference pools */
 export { useKavanaghAvailability } from './hooks/useKavanaghAvailability'
 export type { UseKavanaghAvailabilityResult } from './hooks/useKavanaghAvailability'
-/** Hook owning one watermark run: start, progress, cancel, and the report it produced */
-export { useWatermarkCheck } from './hooks/useWatermarkCheck'
-export type { UseWatermarkCheckResult } from './hooks/useWatermarkCheck'
+/** Hook owning one run: start, progress, cancel, and the report it produced */
+export { useKavanaghCheck } from './hooks/useKavanaghCheck'
+export type { UseKavanaghCheckResult } from './hooks/useKavanaghCheck'
 
 // Types
 /** Whether the ffmpeg toolchain was found, and where, or why not */
 export type { FfmpegAvailability } from './types'
+/** Everything one run concluded: the verdict, and both checks' own results */
+export type { KavanaghCheckReport } from './types'
+/** What the closing tail measured, and what is wrong with it */
+export type { KavanaghTailAnalysis } from './types'
+/** What the closing sting matched, and whether it was held steady */
+export type { KavanaghStingReport } from './types'
 /** Everything one watermark run concluded, including gaps and in-memory evidence */
 export type { KavanaghWatermarkReport } from './types'
 /** Why a QC run did not produce a report, tagged by cause */

--- a/src/features/Kavanagh/types.ts
+++ b/src/features/Kavanagh/types.ts
@@ -18,12 +18,8 @@ export type FfmpegAvailability =
 /** Which top corner a watermark occupies. */
 export type KavanaghCorner = 'topLeft' | 'topRight'
 
-/**
- * Which stage of a run progress refers to.
- *
- * Stage 3 adds `tail` when the tail analysis starts emitting one.
- */
-export type KavanaghPhase = 'probe' | 'watermark' | 'refine'
+/** Which stage of a run progress refers to. */
+export type KavanaghPhase = 'probe' | 'tail' | 'watermark' | 'refine'
 
 /**
  * A contiguous absence of the watermark, as a measured time range.
@@ -89,6 +85,85 @@ export interface KavanaghWatermarkReport {
   video: { width: number; height: number; durationSeconds: number }
   thumbnails: KavanaghThumbnail[]
   /** Caveats worth stating alongside the verdict. */
+  notes: string[]
+}
+
+/**
+ * What is wrong with a render's closing tail (B5).
+ *
+ * Mirrors the `#[serde(tag = "kind")]` enum in `src-tauri/src/kavanagh/tail.rs`.
+ * Each variant carries what was measured; the sentence to show an operator comes
+ * from `problemMessages` on the report, written on the Rust side where the
+ * tolerances live.
+ */
+export type KavanaghTailProblem =
+  | { kind: 'videoTooShort'; durationSeconds: number }
+  | { kind: 'noWhitePeak' }
+  | { kind: 'rampTooShort'; measuredSeconds: number }
+  | { kind: 'rampTooLong'; measuredSeconds: number }
+  | { kind: 'stingTooShort'; measuredSeconds: number }
+  | { kind: 'stingTooLong'; measuredSeconds: number }
+  | { kind: 'doesNotEndOnSting'; trailingSeconds: number }
+
+/** What the closing tail's structure turned out to be. */
+export interface KavanaghTailAnalysis {
+  /** Where the dip reaches white, which is the cut the sting starts at. */
+  peakAtSeconds: number | null
+  /** Measured 10-90% rise time into the peak. */
+  rampSeconds: number | null
+  /** Content after the peak. */
+  stingSeconds: number | null
+  /** Content after the sting stops being on screen. */
+  trailingSeconds: number | null
+  problems: KavanaghTailProblem[]
+}
+
+/**
+ * What the sting check concluded (B6).
+ *
+ * `unrecognised` is a warning rather than a failure: it normally means a new
+ * variant needs adding to the references folder (D8). `notFrozen` is a failure -
+ * a tail that is not a held still is wrong whatever it correlates with.
+ */
+export type KavanaghStingOutcome =
+  | 'matched'
+  | 'unrecognised'
+  | 'notFrozen'
+  | 'poolUnavailable'
+
+/** Everything the sting check measured. */
+export interface KavanaghStingReport {
+  outcome: KavanaghStingOutcome
+  matchedReference: string | null
+  /** The closest reference, whether or not it passed. */
+  bestReference: string | null
+  bestConfidence: number
+  /** Mean absolute luma difference across the hold; ~0 for a held still. */
+  freezeMad: number | null
+  framesCompared: number
+  threshold: number
+}
+
+/**
+ * What a whole run concluded.
+ *
+ * Four states to the Rust enum's three. A run that could not judge the video at
+ * all rejects rather than returning a report, so `error` is reached through the
+ * catch rather than off the wire - but it is a distinct state to render, because
+ * "not judged" and "judged bad" send an operator to different places (B7.4).
+ */
+export type KavanaghVerdict = 'pass' | 'warning' | 'fail' | 'error'
+
+/** Everything one run concluded, with each check's own result intact (B7.2). */
+export interface KavanaghCheckReport {
+  verdict: Exclude<KavanaghVerdict, 'error'>
+  watermark: KavanaghWatermarkReport
+  tail: KavanaghTailAnalysis
+  /** Null when no white peak was found, so no sting could be located. */
+  sting: KavanaghStingReport | null
+  /** One sentence per fault, ready to render, written where the tolerances are. */
+  problemMessages: string[]
+  /** Caveats about the run as a whole, as opposed to either check. */
   notes: string[]
 }
 


### PR DESCRIPTION
Stage 3 of #180: the closing dip to white, the sting that follows it, and the single verdict a run reduces to (B5, B6, B7). Stage 4 is upload gating and is not in here.

## What a run does now

One run, both checks, one verdict. The order is forced rather than chosen: the watermark is not expected over the closing dip, but the dip is found by the tail analysis, so the tail runs first and hands the watermark pass its end point (D9). That circular dependency is why `check.rs` exists rather than the work living in `watermark.rs`.

| check | what it measures |
| --- | --- |
| Tail | white peak, 10-90% ramp, sting duration, whether the video ends on it |
| Sting | which reference it matches, and whether it is genuinely held still |
| Watermark | unchanged from stage 2, now with a measured span rather than a guess |

## Calibrated, not tuned

The tail is a consequence of two Premiere preferences - Video Transition Default Duration 1.00s and Still Image Default Duration 5.00s - so it is checked against a derived model. A 1.00s transition applied Center at Cut reaches white *at* the cut, and the 5.00s still begins there:

```
T-5.5s ─── T-5.0s ─── T-4.5s ──────────── T-0s
   │          │          │                   │
 ramp up   FULL WHITE  settled              end
 (0.5s)    (the cut)   └── 4.5s static ──────┘
```

Tolerances are tight on purpose: catching preset drift is the stated point of the check, and loose ones would pass the very drift it exists to find. A 2.00s transition gives a 0.8s rise and a 0.50s one gives 0.2s, both outside the 0.32-0.48s window.

## Verified against real renders, not only synthetic samples

ffmpeg was available locally, so rather than only testing my own model I built a real H.264 render to the A6 structure and ran the pipeline over it:

| | measured | expected |
| --- | --- | --- |
| peak | t=15.000, YAVG/YMIN 235/235 | T-5.000s, limited-range white |
| ramp (10-90%) | 0.4021s | 0.400s |
| sting | 5.000s | 5.00s |
| identity | 1.0000 | above 0.95 |
| freeze MAD | 0.00 | ~0 |

Its `signalstats` output is committed as a fixture, so the analyser is pinned against real encoder output rather than against the model that generated my other test samples. Two deliberately broken cuts of the same render were checked too:

- **hard cut, no dissolve** → `NoWhitePeak`, sting never located, verdict fail
- **2s sting instead of 5s** → `StingTooShort { 2.0 }` while the logo still matched at 1.0000, i.e. "right logo, wrong duration"

## Three bugs that testing caught

1. **The ramp baseline was wrong on real footage.** It took the darkest frame anywhere in the 12s window, so a dark shot earlier in the tail dragged the 10% target below where the dip actually started and the crossing search walked back past the ramp entirely - a multi-second ramp, and a false failure, on a correct render. Bounded to 1.5s before the peak, with a regression test that fails without the fix.
2. **A7's frame-count rule was inert.** I added the parsing for `nb_frames`/`r_frame_rate` but never asked ffprobe for them, so the end still came from the container duration. Only visible by printing the probe against a real file.
3. **Threshold validation moved after the first spawn.** Splitting `analyse()` so the probe is not run twice put the probe ahead of validation, which B13.3 exists to forbid. The existing suite caught it.

## Tests

Rust 220 → 261, frontend 2876 → 2882, both green, no warnings on either side.

New tests were mutation-verified rather than assumed to work: dropping the YMIN guard fails B5.4, widening the ramp tolerance fails the hard-cut and drift tests, returning the peak as the dip start fails the span test, rendering warnings as failures fails B7.3, and removing the tail section fails the two tests that read it.

## Two decisions worth flagging

**`Verdict` has three states in Rust, four in TypeScript.** A run that could not judge the video is the `Err` arm of the command's `Result`, so a Rust `Error` variant would be one nothing could ever construct. The frontend renders the fourth state, and B7.4's assertion lives there: an error shows its alert and no verdict at all.

**`kavanagh_run_watermark_check` is retired**, along with `useWatermarkCheck` and `runWatermarkCheck`. It is superseded rather than merely unused - the full check contains it - and keeping a second entry point that skips the tail would leave two ways to check a render, one of which is wrong about the watermark span.

## Follow-ups, not in here

- Stage 4: upload flow integration and gating (B9).
- The `stings/` pool is read but never validated for resolution; A5's note about a 1080p sting on a UHD timeline is handled by scaling both sides to a fixed comparison size, not by warning about it.