### PR TITLE
feat(kavanagh): gate Sprout uploads on the check (#180 stage 4)

### DIFF
--- a/src/features/Kavanagh/hooks/useKavanaghCheck.ts
+++ b/src/features/Kavanagh/hooks/useKavanaghCheck.ts
@@ -33,7 +33,15 @@ export interface UseKavanaghCheckResult {
   report: KavanaghCheckReport | null
   /** Why the last run failed, or null. A cancellation is not surfaced here. */
   error: KavanaghError | null
-  run: (request: KavanaghCheckRequest) => Promise<void>
+  /**
+   * Starts a run. Resolves to the report, or null when the run failed or was
+   * cancelled.
+   *
+   * The report is returned as well as held in state because a caller that has
+   * to *decide* something on it - the upload gate - cannot read the state it
+   * just set within the same tick.
+   */
+  run: (request: KavanaghCheckRequest) => Promise<KavanaghCheckReport | null>
   cancel: () => Promise<void>
   /** Clears the report and any error, releasing the thumbnails held with it. */
   reset: () => void
@@ -92,10 +100,11 @@ export function useKavanaghCheck(): UseKavanaghCheckResult {
   const run = React.useCallback(
     async (request: KavanaghCheckRequest) => {
       try {
-        await mutation.mutateAsync(request)
+        return await mutation.mutateAsync(request)
       } catch {
         // Already recorded in `onError`; rethrowing would make every caller
         // handle a failure the hook has already turned into state.
+        return null
       }
     },
     [mutation]

--- a/src/features/Upload/components/KavanaghUploadGate.tsx
+++ b/src/features/Upload/components/KavanaghUploadGate.tsx
@@ -1,0 +1,138 @@
+/**
+ * The Kavanagh gate's own surface in the Sprout upload flow (issue #180, B9)
+ *
+ * Split out of `UploadSprout` rather than inlined: the opt-in, the two verdict
+ * banners and the override dialog are one cohesive thing, and folding them into
+ * the page's body took it past the complexity the repo lints for.
+ *
+ * The policy these render lives in `useKavanaghForUpload`. Everything here is
+ * presentation, which is why a warning and a failure look as different as they
+ * do - a warning is information, a failure is a decision (D14).
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@shared/ui/alert-dialog'
+import { Checkbox } from '@shared/ui/checkbox'
+import { Label } from '@shared/ui/label'
+import { AlertTriangle, CheckCircle2 } from 'lucide-react'
+import React from 'react'
+
+import type { UseKavanaghForUploadResult } from '../hooks/useKavanaghForUpload'
+
+/** The opt-in, and whatever the last run concluded. */
+export const KavanaghGateControls: React.FC<{
+  kavanagh: UseKavanaghForUploadResult
+  uploading: boolean
+}> = ({ kavanagh, uploading }) => (
+  <>
+    {/*
+      Opt-in per video and off until asked for (D13): a check costs a full
+      decode pass, and not every upload needs one.
+    */}
+    <div className="mb-4 flex items-start gap-2">
+      <Checkbox
+        id="kavanagh-before-upload"
+        checked={kavanagh.enabled}
+        onCheckedChange={(checked) => kavanagh.setEnabled(checked === true)}
+        disabled={uploading || kavanagh.checking}
+      />
+      <div className="grid gap-0.5 leading-none">
+        <Label
+          htmlFor="kavanagh-before-upload"
+          className="text-sm leading-none font-medium"
+        >
+          Check with Kavanagh before uploading
+        </Label>
+        <p className="text-muted-foreground text-xs">
+          {kavanagh.available
+            ? 'Checks the watermark and the closing sting first. A failure asks before uploading.'
+            : (kavanagh.unavailableReason ?? 'Kavanagh cannot run at the moment.')}
+        </p>
+      </div>
+    </div>
+
+    {/*
+      A warning is shown but never blocks (D14). Blocking on an out-of-date
+      references folder would teach people to click through the override, which
+      costs more than it saves.
+    */}
+    {kavanagh.report?.verdict === 'warning' && (
+      <div
+        role="status"
+        className="mb-4 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm"
+      >
+        <AlertTriangle
+          className="mt-0.5 size-4 shrink-0 text-amber-500"
+          aria-hidden="true"
+        />
+        <div className="text-foreground">
+          <p className="font-medium">Uploaded with a warning.</p>
+          <ul className="text-muted-foreground mt-1 space-y-1 text-xs">
+            {kavanagh.report.problemMessages.map((problem, index) => (
+              <li key={`${index}-${problem.slice(0, 24)}`}>{problem}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    )}
+
+    {kavanagh.report?.verdict === 'pass' && !uploading && (
+      <p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs">
+        <CheckCircle2 className="size-3.5 text-emerald-500" aria-hidden="true" />
+        Kavanagh passed this render.
+      </p>
+    )}
+  </>
+)
+
+/**
+ * The confirm standing between a failed render and Sprout.
+ *
+ * An AlertDialog rather than a toast or a disabled button: it is the repo's
+ * convention for a destructive confirm, and publishing a render that failed its
+ * checks is exactly that.
+ */
+export const KavanaghBlockDialog: React.FC<{
+  kavanagh: UseKavanaghForUploadResult
+  onOverride: () => void
+}> = ({ kavanagh, onOverride }) => (
+  <AlertDialog open={kavanagh.block !== null}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>
+          {kavanagh.block?.error
+            ? 'This render was not checked'
+            : 'This render failed its checks'}
+        </AlertDialogTitle>
+        <AlertDialogDescription asChild>
+          <div className="space-y-2">
+            <p>
+              {kavanagh.block?.error
+                ? kavanagh.block.error.message
+                : 'Kavanagh found the following. Uploading anyway publishes it to Sprout as it is.'}
+            </p>
+            {kavanagh.block?.report && (
+              <ul className="space-y-1 text-xs">
+                {kavanagh.block.report.problemMessages.map((problem, index) => (
+                  <li key={`${index}-${problem.slice(0, 24)}`}>{problem}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel onClick={kavanagh.dismiss}>Do not upload</AlertDialogCancel>
+        <AlertDialogAction onClick={onOverride}>Upload anyway</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+)

--- a/src/features/Upload/components/UploadSprout.test.tsx
+++ b/src/features/Upload/components/UploadSprout.test.tsx
@@ -14,7 +14,7 @@
 import '@testing-library/jest-dom'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -83,6 +83,30 @@ vi.mock('../hooks/useUploadEvents', () => ({
   useUploadEvents: vi.fn(() => mockUploadEventsState)
 }))
 
+// The Kavanagh gate is this page's other I/O boundary. Mocked here so the page's
+// own behaviour is under test; the policy it implements has its own tests in
+// useKavanaghForUpload.test.ts.
+const mockGate = vi.fn()
+const mockOverride = vi.fn()
+const mockDismiss = vi.fn()
+let mockKavanagh = {
+  enabled: false,
+  setEnabled: vi.fn(),
+  checking: false,
+  report: null as unknown,
+  block: null as unknown,
+  available: true,
+  unavailableReason: null as string | null,
+  gate: mockGate,
+  override: mockOverride,
+  dismiss: mockDismiss,
+  reset: vi.fn()
+}
+
+vi.mock('../hooks/useKavanaghForUpload', () => ({
+  useKavanaghForUpload: () => mockKavanagh
+}))
+
 vi.mock('../hooks/useImageRefresh', () => ({
   useImageRefresh: vi.fn(() => mockImageRefreshState)
 }))
@@ -110,6 +134,22 @@ describe('UploadSprout Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset to default states
+    // The gate lets everything through unless a test says otherwise, which is
+    // what a switched-off check does (B9.1).
+    mockGate.mockResolvedValue(true)
+    mockKavanagh = {
+      enabled: false,
+      setEnabled: vi.fn(),
+      checking: false,
+      report: null,
+      block: null,
+      available: true,
+      unavailableReason: null,
+      gate: mockGate,
+      override: mockOverride,
+      dismiss: mockDismiss,
+      reset: vi.fn()
+    }
     mockApiKeyState = { apiKey: 'test-api-key', isLoading: false }
     mockFileUploadState = {
       selectedFile: null,
@@ -294,7 +334,82 @@ describe('UploadSprout Page', () => {
       expect(uploadButton).not.toBeDisabled()
     })
 
-    it('should call uploadFile when Upload Video button is clicked', () => {
+    it('B9.3 does not upload when the gate holds the render back', async () => {
+      mockGate.mockResolvedValue(false)
+      renderUploadSprout()
+
+      fireEvent.click(screen.getByRole('button', { name: /Upload Video/i }))
+
+      await waitFor(() => expect(mockGate).toHaveBeenCalled())
+      // Nothing reaches Sprout: the check runs before the upload, not beside it.
+      expect(mockUploadFile).not.toHaveBeenCalled()
+    })
+
+    it('B9.3 shows what failed, so the decision is an informed one', async () => {
+      mockKavanagh.block = {
+        report: {
+          verdict: 'fail',
+          problemMessages: ['The watermark is missing from 4:12 to 4:31.']
+        },
+        error: null
+      }
+      renderUploadSprout()
+
+      expect(screen.getByRole('alertdialog')).toHaveTextContent(/failed its checks/i)
+      expect(screen.getByText(/missing from 4:12 to 4:31/i)).toBeInTheDocument()
+    })
+
+    it('B9.4 uploads the render the block interrupted when overridden', async () => {
+      mockKavanagh.block = {
+        report: { verdict: 'fail', problemMessages: ['Something is wrong.'] },
+        error: null
+      }
+      renderUploadSprout()
+
+      fireEvent.click(screen.getByRole('button', { name: /upload anyway/i }))
+
+      // Overriding uploads, rather than only closing the dialog and asking the
+      // operator to press Upload a second time.
+      expect(mockOverride).toHaveBeenCalled()
+      await waitFor(() =>
+        expect(mockUploadFile).toHaveBeenCalledWith('test-api-key', '', null)
+      )
+    })
+
+    it('B9.5 uploads nothing when the block is dismissed', async () => {
+      mockKavanagh.block = {
+        report: { verdict: 'fail', problemMessages: ['Something is wrong.'] },
+        error: null
+      }
+      renderUploadSprout()
+
+      fireEvent.click(screen.getByRole('button', { name: /do not upload/i }))
+
+      expect(mockDismiss).toHaveBeenCalled()
+      expect(mockUploadFile).not.toHaveBeenCalled()
+    })
+
+    it('B9.6 shows a warning without ever asking to confirm', async () => {
+      mockKavanagh.report = {
+        verdict: 'warning',
+        problemMessages: ['The sting matches nothing in the folder.']
+      }
+      renderUploadSprout()
+
+      expect(screen.getByRole('status')).toHaveTextContent(/uploaded with a warning/i)
+      // No dialog at all: a warning is housekeeping, not a decision (D14).
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    })
+
+    it('says why the check cannot run rather than offering it silently', async () => {
+      mockKavanagh.available = false
+      mockKavanagh.unavailableReason = 'Kavanagh needs ffprobe, which could not be found.'
+      renderUploadSprout()
+
+      expect(screen.getByText(/needs ffprobe/i)).toBeInTheDocument()
+    })
+
+    it('should call uploadFile when Upload Video button is clicked', async () => {
       renderUploadSprout()
 
       const uploadButton = screen.getByRole('button', { name: /Upload Video/i })
@@ -302,7 +417,11 @@ describe('UploadSprout Page', () => {
 
       // The destination is passed explicitly (issue #155) -- null is the account
       // root, which is what a fresh session with no default resolves to.
-      expect(mockUploadFile).toHaveBeenCalledWith('test-api-key', '', null)
+      // Awaited because the upload now passes the Kavanagh gate first, which is
+      // a promise even when the check is switched off.
+      await waitFor(() =>
+        expect(mockUploadFile).toHaveBeenCalledWith('test-api-key', '', null)
+      )
     })
   })
 

--- a/src/features/Upload/components/UploadSprout.tsx
+++ b/src/features/Upload/components/UploadSprout.tsx
@@ -14,6 +14,8 @@ import { useSproutVideoApiKey } from '@shared/hooks'
 import { useBreadcrumb } from '@shared/hooks'
 import { fileNameToTitle } from '@shared/utils'
 import { useFileUpload } from '../hooks/useFileUpload'
+import { useKavanaghForUpload } from '../hooks/useKavanaghForUpload'
+import { KavanaghBlockDialog, KavanaghGateControls } from './KavanaghUploadGate'
 import { useSproutFolderSelection } from '../hooks/useSproutFolderSelection'
 import { SproutFolderPicker } from './SproutFolderPicker'
 import { useImageRefresh } from '../hooks/useImageRefresh'
@@ -23,6 +25,24 @@ import ExternalLink from '@shared/ui/ExternalLink'
 import FormattedDate from '@shared/ui/FormattedDate'
 import { AlertTriangle, RefreshCw, Sprout } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
+
+/**
+ * What the upload button says, given everything that can be happening to it.
+ *
+ * A function rather than nested ternaries in the tree: the page is already at
+ * the complexity the repo lints for, and this is the part of it that reads
+ * worst inline.
+ */
+function uploadButtonLabel(state: {
+  checking: boolean
+  uploading: boolean
+  apiKeyLoading: boolean
+}): string {
+  if (state.checking) return 'Checking with Kavanagh...'
+  if (state.uploading) return 'Uploading...'
+  if (state.apiKeyLoading) return 'Loading...'
+  return 'Upload Video'
+}
 
 const UploadSproutContent: React.FC = () => {
   // Custom hooks
@@ -36,6 +56,7 @@ const UploadSproutContent: React.FC = () => {
   const { thumbnailLoaded, refreshTimestamp, setThumbnailLoaded } =
     useImageRefresh(response)
   const [title, setTitle] = useState('')
+  const kavanagh = useKavanaghForUpload()
 
   // Page label - shadcn breadcrumb component (memoized to prevent infinite re-renders)
   const breadcrumbItems = useMemo(
@@ -52,11 +73,13 @@ const UploadSproutContent: React.FC = () => {
     const file = await selectFile()
     if (file) {
       setTitle(fileNameToTitle(file))
+      // A previous render's verdict must not linger beside a different file.
+      kavanagh.reset()
     }
   }
 
-  // Handle upload with API key
-  const handleUpload = async () => {
+  // The upload itself, once anything gating it has let it through.
+  const performUpload = async () => {
     // Reset progress and message before starting upload
     setProgress(0)
     setMessage(null)
@@ -66,6 +89,21 @@ const UploadSproutContent: React.FC = () => {
     await uploadFile(apiKey, title, selectedFolder)
     // Only remember a folder an upload actually used.
     commitFolder(selectedFolder)
+  }
+
+  // Handle upload with API key
+  const handleUpload = async () => {
+    // Checked before anything reaches Sprout, not after (B9.3). A failure holds
+    // the upload here and opens the override dialog; a warning does not (D14).
+    if (selectedFile && !(await kavanagh.gate(selectedFile))) return
+    await performUpload()
+  }
+
+  // Proceeding past a failure is a deliberate act, so it runs the upload the
+  // block interrupted rather than asking the operator to press Upload again.
+  const handleOverride = async () => {
+    kavanagh.override()
+    await performUpload()
   }
 
   return (
@@ -157,16 +195,24 @@ const UploadSproutContent: React.FC = () => {
                   <Progress value={progress} />
                 </div>
               )}
+              <KavanaghGateControls kavanagh={kavanagh} uploading={uploading} />
+
               <Button
                 onClick={handleUpload}
                 className="w-full"
-                disabled={!selectedFile || !apiKey || uploading || apiKeyLoading}
+                disabled={
+                  !selectedFile ||
+                  !apiKey ||
+                  uploading ||
+                  apiKeyLoading ||
+                  kavanagh.checking
+                }
               >
-                {uploading
-                  ? 'Uploading...'
-                  : apiKeyLoading
-                    ? 'Loading...'
-                    : 'Upload Video'}
+                {uploadButtonLabel({
+                  checking: kavanagh.checking,
+                  uploading,
+                  apiKeyLoading
+                })}
               </Button>
 
               {message && (
@@ -243,6 +289,8 @@ const UploadSproutContent: React.FC = () => {
           )}
         </div>
       </div>
+
+      <KavanaghBlockDialog kavanagh={kavanagh} onOverride={() => void handleOverride()} />
     </div>
   )
 }

--- a/src/features/Upload/hooks/useKavanaghForUpload.test.ts
+++ b/src/features/Upload/hooks/useKavanaghForUpload.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Kavanagh gating for the Sprout upload flow (issue #180, stage 4, B9)
+ *
+ * The behaviour under test is a policy, not a calculation: what may go to
+ * Sprout, and what has to be confirmed first. Only the Kavanagh module is
+ * mocked - the run hook and the availability hook - so the preference, the
+ * gate's decisions and the block state are the real thing.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { KavanaghCheckReport } from '@features/Kavanagh'
+
+const run = vi.fn()
+const resetRun = vi.fn()
+let runningState = false
+let reportState: KavanaghCheckReport | null = null
+let availabilityState = {
+  available: true,
+  reason: null as string | null,
+  poolFiles: {
+    watermarks: ['/refs/Watermarks/right.png'],
+    stings: ['/refs/Stings/current.jpg']
+  }
+}
+
+vi.mock('@features/Kavanagh', () => ({
+  useKavanaghCheck: () => ({
+    isRunning: runningState,
+    report: reportState,
+    run,
+    reset: resetRun,
+    progress: null,
+    error: null,
+    cancel: vi.fn()
+  }),
+  useKavanaghAvailability: () => availabilityState
+}))
+
+vi.mock('@shared/hooks', () => ({
+  useApiKeys: () => ({
+    data: { ffmpegDirectory: '/opt/homebrew/bin', kavanaghMatchThreshold: undefined }
+  })
+}))
+
+vi.mock('@shared/utils', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }
+}))
+
+const { useKavanaghForUpload } = await import('./useKavanaghForUpload')
+
+const PASSING: KavanaghCheckReport = {
+  verdict: 'pass',
+  watermark: {
+    outcome: 'pass',
+    corner: 'topRight',
+    span: { startSeconds: 0, endSeconds: 139, approximated: false },
+    gaps: [],
+    cornerChanges: [],
+    coarseSamples: 70,
+    matchedSamples: 70,
+    bestConfidence: 0.9973,
+    weakestConfidence: 0.9803,
+    bestReference: 'right.png',
+    matchedReference: 'right.png',
+    threshold: 0.85,
+    thresholdIsDefault: true,
+    referencesUsed: 2,
+    video: { width: 3840, height: 2160, durationSeconds: 144 },
+    thumbnails: [],
+    notes: []
+  },
+  tail: {
+    peakAtSeconds: 139,
+    rampSeconds: 0.4,
+    stingSeconds: 5,
+    trailingSeconds: 0,
+    problems: []
+  },
+  sting: {
+    outcome: 'matched',
+    matchedReference: 'current.jpg',
+    bestReference: 'current.jpg',
+    bestConfidence: 0.9989,
+    freezeMad: 0,
+    framesCompared: 9,
+    threshold: 0.95
+  },
+  problemMessages: [],
+  notes: []
+}
+
+const FAILING: KavanaghCheckReport = {
+  ...PASSING,
+  verdict: 'fail',
+  watermark: { ...PASSING.watermark, outcome: 'fail' },
+  problemMessages: ['The watermark is missing from 4:12 to 4:31.']
+}
+
+const WARNING: KavanaghCheckReport = {
+  ...PASSING,
+  verdict: 'warning',
+  sting: { ...PASSING.sting!, outcome: 'unrecognised', matchedReference: null },
+  problemMessages: ['The tail is a held still, but it matches nothing in the folder.']
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  runningState = false
+  reportState = null
+  availabilityState = {
+    available: true,
+    reason: null,
+    poolFiles: {
+      watermarks: ['/refs/Watermarks/right.png'],
+      stings: ['/refs/Stings/current.jpg']
+    }
+  }
+})
+
+describe('Kavanagh upload preference', () => {
+  it('B9.1 is off when the preference has never been set', () => {
+    const { result } = renderHook(() => useKavanaghForUpload())
+
+    expect(result.current.enabled).toBe(false)
+  })
+
+  it('B9.8 remembers the choice across a reload', async () => {
+    const first = renderHook(() => useKavanaghForUpload())
+    act(() => first.result.current.setEnabled(true))
+    await waitFor(() => expect(first.result.current.enabled).toBe(true))
+
+    // A second mount is what a reload looks like from here.
+    const second = renderHook(() => useKavanaghForUpload())
+
+    expect(second.result.current.enabled).toBe(true)
+  })
+
+  it('does not turn itself on for a stored value that merely looks truthy', () => {
+    localStorage.setItem(
+      'kavanagh-upload-preferences',
+      JSON.stringify({ enabled: 'yes' })
+    )
+
+    const { result } = renderHook(() => useKavanaghForUpload())
+
+    expect(result.current.enabled).toBe(false)
+  })
+
+  it('stays off rather than throwing when the stored preference is corrupt', () => {
+    localStorage.setItem('kavanagh-upload-preferences', 'not json')
+
+    const { result } = renderHook(() => useKavanaghForUpload())
+
+    expect(result.current.enabled).toBe(false)
+  })
+})
+
+describe('Kavanagh upload gating', () => {
+  it('B9.7 spawns nothing at all when the check is switched off', async () => {
+    const { result } = renderHook(() => useKavanaghForUpload())
+
+    let proceed = false
+    await act(async () => {
+      proceed = await result.current.gate('/Volumes/Renders/module.mp4')
+    })
+
+    expect(proceed).toBe(true)
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('B9.2 lets a passing render upload without interruption', async () => {
+    run.mockResolvedValue(PASSING)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+
+    let proceed = false
+    await act(async () => {
+      proceed = await result.current.gate('/Volumes/Renders/module.mp4')
+    })
+
+    expect(proceed).toBe(true)
+    expect(result.current.block).toBeNull()
+    // Both pools travel with the request, or the sting could not be identified.
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        videoPath: '/Volumes/Renders/module.mp4',
+        referenceFiles: ['/refs/Watermarks/right.png'],
+        stingReferenceFiles: ['/refs/Stings/current.jpg']
+      })
+    )
+  })
+
+  it('B9.3 blocks a failing render before anything reaches Sprout', async () => {
+    run.mockResolvedValue(FAILING)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+
+    let proceed = true
+    await act(async () => {
+      proceed = await result.current.gate('/Volumes/Renders/module.mp4')
+    })
+
+    expect(proceed).toBe(false)
+    expect(result.current.block?.report).toEqual(FAILING)
+  })
+
+  it('B9.6 lets a warning through without an override', async () => {
+    // An unrecognised sting is the references folder being out of date, not a
+    // broken render. Blocking here would train people to click through (D8).
+    run.mockResolvedValue(WARNING)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+
+    let proceed = false
+    await act(async () => {
+      proceed = await result.current.gate('/Volumes/Renders/module.mp4')
+    })
+
+    expect(proceed).toBe(true)
+    expect(result.current.block).toBeNull()
+  })
+
+  it('B9.4 clears the block when the operator overrides it', async () => {
+    run.mockResolvedValue(FAILING)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+    await act(async () => {
+      await result.current.gate('/a.mp4')
+    })
+
+    act(() => result.current.override())
+
+    expect(result.current.block).toBeNull()
+  })
+
+  it('B9.5 clears the block when the operator dismisses it', async () => {
+    run.mockResolvedValue(FAILING)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+    await act(async () => {
+      await result.current.gate('/a.mp4')
+    })
+
+    act(() => result.current.dismiss())
+
+    expect(result.current.block).toBeNull()
+  })
+
+  it('blocks rather than waving through a render it could not check', async () => {
+    // Beyond B9, which does not say. The operator asked for a check; uploading
+    // unchecked without saying so is the one outcome nobody chose.
+    run.mockResolvedValue(null)
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+
+    let proceed = true
+    await act(async () => {
+      proceed = await result.current.gate('/a.mp4')
+    })
+
+    expect(proceed).toBe(false)
+    expect(result.current.block?.error?.message).toMatch(/could not be checked/i)
+  })
+
+  it('blocks when the check is switched on but cannot run', async () => {
+    availabilityState = {
+      available: false,
+      reason: 'Kavanagh needs ffprobe, which could not be found.',
+      poolFiles: { watermarks: [], stings: [] }
+    }
+    const { result } = renderHook(() => useKavanaghForUpload())
+    act(() => result.current.setEnabled(true))
+
+    let proceed = true
+    await act(async () => {
+      proceed = await result.current.gate('/a.mp4')
+    })
+
+    expect(proceed).toBe(false)
+    expect(result.current.block?.error?.message).toMatch(/ffprobe/i)
+    expect(run).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/Upload/hooks/useKavanaghForUpload.ts
+++ b/src/features/Upload/hooks/useKavanaghForUpload.ts
@@ -1,0 +1,199 @@
+/**
+ * useKavanaghForUpload (issue #180, stage 4, B9)
+ *
+ * Runs a Kavanagh check before a Sprout upload, and decides whether the upload
+ * may go ahead.
+ *
+ * Opt-in per video, off until someone turns it on, remembered in localStorage -
+ * the same shape as the poster frame preference next door, because not every
+ * video needs checking and a check costs a full decode pass (D13).
+ *
+ * The gating policy is D14, and the asymmetry in it is deliberate:
+ *
+ * - a **failure** blocks, and can only be got past with a deliberate confirm;
+ * - a **warning** never blocks and needs no confirm.
+ *
+ * An unrecognised sting is the warning case, and it means the references folder
+ * needs a new variant rather than that the render is broken. Blocking on it
+ * would teach people to click through the override by reflex, which would cost
+ * more than it saved the first time a real failure appeared.
+ */
+
+import { useKavanaghAvailability, useKavanaghCheck } from '@features/Kavanagh'
+import type { KavanaghCheckReport, KavanaghError } from '@features/Kavanagh'
+import { useApiKeys } from '@shared/hooks'
+import { logger } from '@shared/utils'
+import React from 'react'
+
+const PREFS_KEY = 'kavanagh-upload-preferences'
+
+interface KavanaghUploadPreferences {
+  enabled: boolean
+}
+
+/** Off until someone asks for it (B9.1). */
+const DEFAULT_PREFERENCES: KavanaghUploadPreferences = { enabled: false }
+
+function loadPreferences(): KavanaghUploadPreferences {
+  try {
+    const stored = localStorage.getItem(PREFS_KEY)
+    if (!stored) return DEFAULT_PREFERENCES
+
+    const parsed = JSON.parse(stored) as Partial<KavanaghUploadPreferences>
+    // Explicitly `=== true`: a stored `"yes"`, or a shape from some future
+    // version, must not turn the check on by being truthy.
+    return { enabled: parsed.enabled === true }
+  } catch (error) {
+    logger.warn('Failed to load Kavanagh upload preferences:', error)
+    return DEFAULT_PREFERENCES
+  }
+}
+
+function savePreferences(preferences: KavanaghUploadPreferences): void {
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify(preferences))
+  } catch (error) {
+    // A preference that cannot be remembered is not worth failing an upload for.
+    logger.warn('Failed to save Kavanagh upload preferences:', error)
+  }
+}
+
+/** Why an upload is being held back. */
+export interface KavanaghBlock {
+  /** The report behind the block, or null when the run never produced one. */
+  report: KavanaghCheckReport | null
+  /** Set when the run could not judge the video at all (B7.4). */
+  error: KavanaghError | null
+}
+
+export interface UseKavanaghForUploadResult {
+  /** Whether uploads are checked first. Remembered across reloads (B9.8). */
+  enabled: boolean
+  setEnabled: (enabled: boolean) => void
+  /** True while a check runs ahead of an upload. */
+  checking: boolean
+  /** The last run's report, whatever its verdict. */
+  report: KavanaghCheckReport | null
+  /** Set while a failure is holding an upload back; null otherwise. */
+  block: KavanaghBlock | null
+  /** Whether the check can run at all - ffmpeg and both reference pools. */
+  available: boolean
+  /** Why it cannot, when it cannot. */
+  unavailableReason: string | null
+  /**
+   * Runs the check if it is switched on, and answers whether the upload may
+   * proceed now.
+   *
+   * `true` when the check is off, when it passed, and when it warned. `false`
+   * only when something is holding the upload back, in which case `block` says
+   * what.
+   */
+  gate: (videoPath: string) => Promise<boolean>
+  /** Proceeds past a block, deliberately (B9.4). */
+  override: () => void
+  /** Abandons the upload the block interrupted (B9.5). */
+  dismiss: () => void
+  /** Clears the last report, for when a different render is chosen. */
+  reset: () => void
+}
+
+export function useKavanaghForUpload(): UseKavanaghForUploadResult {
+  const [enabled, setEnabledState] = React.useState(() => loadPreferences().enabled)
+  const [block, setBlock] = React.useState<KavanaghBlock | null>(null)
+
+  const { data: settings } = useApiKeys()
+  const { available, reason, poolFiles } = useKavanaghAvailability()
+  const { isRunning, report, run, reset: resetRun } = useKavanaghCheck()
+
+  const setEnabled = React.useCallback((next: boolean) => {
+    setEnabledState(next)
+    savePreferences({ enabled: next })
+  }, [])
+
+  const gate = React.useCallback(
+    async (videoPath: string): Promise<boolean> => {
+      // Nothing is spawned when the check is off (B9.7). This is the first line
+      // rather than a condition further down for exactly that reason.
+      if (!enabled) return true
+
+      setBlock(null)
+
+      // Switched on but unable to run: held back rather than waved through. The
+      // operator asked for a check, and uploading unchecked without saying so
+      // would be the one outcome nobody chose.
+      if (!available) {
+        setBlock({
+          report: null,
+          error: {
+            kind: 'unavailable',
+            message: reason ?? 'Kavanagh cannot run, so this render was not checked.'
+          }
+        })
+        return false
+      }
+
+      const result = await run({
+        videoPath,
+        referenceFiles: poolFiles.watermarks,
+        stingReferenceFiles: poolFiles.stings,
+        ffmpegDirectory: settings?.ffmpegDirectory ?? null,
+        matchThreshold: settings?.kavanaghMatchThreshold
+      })
+
+      // A run that could not judge the video is not a judged-bad render, but it
+      // is still not a checked one, so it blocks with the same override rather
+      // than passing silently (B7.4 applied to D14).
+      if (!result) {
+        setBlock({
+          report: null,
+          error: {
+            kind: 'io',
+            message:
+              'This render could not be checked, so nothing is known about it. Upload anyway only if you are sure.'
+          }
+        })
+        return false
+      }
+
+      // Warnings do not block and need no confirm (B9.6, D14).
+      if (result.verdict === 'fail') {
+        setBlock({ report: result, error: null })
+        return false
+      }
+
+      return true
+    },
+    [
+      enabled,
+      available,
+      reason,
+      run,
+      poolFiles.watermarks,
+      poolFiles.stings,
+      settings?.ffmpegDirectory,
+      settings?.kavanaghMatchThreshold
+    ]
+  )
+
+  const override = React.useCallback(() => setBlock(null), [])
+  const dismiss = React.useCallback(() => setBlock(null), [])
+
+  const reset = React.useCallback(() => {
+    setBlock(null)
+    resetRun()
+  }, [resetRun])
+
+  return {
+    enabled,
+    setEnabled,
+    checking: isRunning,
+    report,
+    block,
+    available,
+    unavailableReason: reason,
+    gate,
+    override,
+    dismiss,
+    reset
+  }
+}


### PR DESCRIPTION
The last stage of #180. An upload can now be checked before anything reaches Sprout - opt-in per video, off until someone asks for it (B9).

## The policy, and why it is asymmetric

D14, and the asymmetry is the point:

| verdict | upload |
| --- | --- |
| pass | proceeds, uninterrupted |
| **warning** | **proceeds, no confirm** |
| fail | blocked, deliberate confirm to override |
| could not be judged | blocked, same confirm |

A warning is an unrecognised sting, which means the references folder wants a new variant rather than that the render is broken. Blocking on it would teach people to click through the override by reflex, and that habit would cost more the first time a real failure appeared than it ever saved.

## Off by default, and off means nothing runs

The preference mirrors the poster frame one next door: localStorage, defaulting to off, read with an explicit `=== true` so a stored `"yes"` - or some future shape - cannot switch checking on by being truthy. B9.7 asks that nothing is spawned when it is off, so that is the gate's first line rather than a condition further down.

## Two cases B9 does not cover

Both resolved towards holding the upload back, and flagged here because they are decisions rather than readings of the spec:

- **A run that could not judge the video.** Not a judged-bad render, but not a checked one either.
- **The check switched on while ffmpeg or a reference pool is missing.**

Both block with the same override rather than passing silently. The operator asked for a check; uploading unchecked without saying so is the one outcome nobody chose. Say the word if you would rather either waved through.

## One change outside stage 4

`useKavanaghCheck.run` now returns its report as well as setting it in state. A caller that has to *decide* something on the verdict cannot read the state it just set within the same tick, and the gate is exactly that caller. The page ignores the return, so nothing else moves.

## A complexity regression, fixed rather than left

Inlining the opt-in, the two verdict banners and the dialog took `UploadSprout` to a complexity of 30 against the repo's limit of 15 - a warning that was not there on master. The gate's surface is now its own component and the upload button's four-way label is a function, which puts the repo back to the same 19 warnings it had before this branch, none of them in a file this touches.

## Tests

Twelve hook tests for the policy, six page tests for what it looks like. Frontend 2882 → 2900, Rust 261 unchanged, both green in 29s.

Each new test was mutation-verified rather than assumed to work:

| mutation | fails |
| --- | --- |
| warnings block too | B9.6 |
| run the check even when switched off | B9.7 |
| ignore the gate's answer | B9.3 |

## #180 is complete after this

All four stages are in: discovery and pools, watermark, tail and sting, and now gating. The follow-ups the issue recorded as out of scope are untouched - Baker batch QC across a scanned drive, QC status in `breadcrumbs.json`, and any check beyond these two.