### PR TITLE
fix(upload): folder picker menu scrolls inside the Add Video dialog

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,6 +77,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] }
     },
     {
+      name: 'folder-picker-dialog-scroll',
+      testMatch: /folder-picker-dialog-scroll\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
       // Every project here uses an explicit testMatch, so a spec that matches
       // none of them never runs at all. Issue #166.
       name: 'posterframe-backgrounds',

--- a/src/features/Upload/components/SproutFolderPicker.tsx
+++ b/src/features/Upload/components/SproutFolderPicker.tsx
@@ -13,8 +13,15 @@
  *
  * Two details are load-bearing and look cosmetic if you skim them:
  *
- * 1. `modal={false}` — the menu renders inside AddVideoDialog, and a modal
- *    dropdown nested in a modal dialog leaves `pointer-events: none` on the body.
+ * 1. The menu is MODAL (Radix's default - no `modal` prop). Inside
+ *    AddVideoDialog, the dialog's scroll lock cancels wheel events over
+ *    anything portalled outside its subtree; a modal menu mounts its own
+ *    scroll lock above the dialog's, which is the only thing that lets the
+ *    folder list scroll there (issue #191). An earlier `modal={false}`
+ *    workaround - for a Radix bug that left `pointer-events: none` on the
+ *    body after nested modals closed - made every folder below the fold
+ *    unreachable; that bug no longer reproduces on the current Radix version,
+ *    and folder-picker-dialog-scroll.spec.ts guards both behaviours.
  * 2. The filter input stops its own keydown from bubbling. Radix fires typeahead
  *    for any single character typed anywhere inside menu content and moves DOM
  *    focus onto the matching item, so without this the box takes exactly one
@@ -439,7 +446,7 @@ export const SproutFolderPicker: React.FC<SproutFolderPickerProps> = ({
   }
 
   return (
-    <DropdownMenu open={isOpen} onOpenChange={close} modal={false}>
+    <DropdownMenu open={isOpen} onOpenChange={close}>
       {/*
         Styled directly rather than `asChild` + <Button>. `@shared/ui/button` is
         a Framer Motion component, and composing a motion element through Radix's

--- a/tests/e2e/specs/folder-picker-dialog-scroll.spec.ts
+++ b/tests/e2e/specs/folder-picker-dialog-scroll.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Sprout folder picker inside the Add Video dialog (issue #191).
+ *
+ * The picker's menu scrolls fine on /upload/sprout, and the picker suite
+ * proves it there - but inside Baker's Add Video dialog the dialog's scroll
+ * lock (react-remove-scroll) cancels wheel events over anything portalled
+ * outside its subtree. A non-modal menu brings no scroll lock of its own, so
+ * every folder below the fold was unreachable. Only a real browser inside the
+ * real dialog can check this, hence e2e.
+ */
+import { expect, test, type Page } from '@playwright/test'
+
+import {
+  PROJECT_NAME,
+  installBackgroundMocks
+} from '../fixtures/posterframe-backgrounds.fixture'
+
+/**
+ * Walk Baker to the Add Video dialog's upload tab and open the folder menu,
+ * with enough folders that the menu must scroll.
+ *
+ * The backgrounds fixture owns the whole IPC mock, so the folder listing is
+ * layered over it rather than combined with the sprout-folders fixture.
+ */
+async function openFolderMenu(page: Page) {
+  await installBackgroundMocks(page, { bakerJourney: true })
+  await page.addInitScript(
+    (folders) => {
+      const win = window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (cmd: string, args?: unknown) => Promise<unknown>
+        }
+      }
+      const base = win.__TAURI_INTERNALS__.invoke
+      win.__TAURI_INTERNALS__.invoke = async (cmd: string, args?: unknown) => {
+        if (cmd === 'get_folders') {
+          return {
+            folders,
+            truncated: false,
+            rate_limit_remaining: null,
+            rate_limit_reset: null
+          }
+        }
+        return base(cmd, args)
+      }
+    },
+    Array.from({ length: 30 }, (_, i) => ({
+      id: `folder-${i}`,
+      name: `Folder ${String(i).padStart(2, '0')}`,
+      parent_id: null
+    }))
+  )
+
+  await page.goto('/ingest/baker')
+  await page.getByRole('button', { name: /select|choose|browse/i }).first().click()
+  await page
+    .getByRole('button', { name: /^(start )?scan/i })
+    .first()
+    .click()
+  await expect(page.getByText(PROJECT_NAME).first()).toBeVisible({ timeout: 20000 })
+  await page.getByText(PROJECT_NAME).first().click()
+  await page.getByRole('tab', { name: /^videos/i }).click()
+  await expect(page.getByRole('heading', { name: /video links/i })).toBeVisible({
+    timeout: 15000
+  })
+
+  await page.getByRole('button', { name: /add video/i }).click()
+  await page.getByRole('tab', { name: /upload file/i }).click()
+  await page.getByRole('button', { name: /select video file/i }).click()
+
+  const trigger = page.getByRole('button', { name: /^Folder:/ })
+  await expect(trigger).toBeVisible({ timeout: 15000 })
+  await trigger.click()
+
+  const menu = page.getByRole('menu')
+  await expect(menu).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: /Folder 00/ })).toBeVisible({
+    timeout: 10000
+  })
+  return menu
+}
+
+test.describe('folder picker inside the Add Video dialog (#191)', () => {
+  test('b1_wheel_scrolls_the_menu_despite_the_dialogs_scroll_lock', async ({
+    page
+  }) => {
+    const menu = await openFolderMenu(page)
+
+    const overflow = await menu.evaluate((el) => ({
+      canScroll: el.scrollHeight > el.clientHeight,
+      scrollTop: el.scrollTop
+    }))
+    expect(overflow.canScroll, 'the menu must overflow for this test to mean anything')
+      .toBe(true)
+    expect(overflow.scrollTop).toBe(0)
+
+    const box = await menu.boundingBox()
+    if (!box) throw new Error('menu has no bounding box')
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(0, 300)
+
+    await expect
+      .poll(async () => menu.evaluate((el) => el.scrollTop), { timeout: 3000 })
+      .toBeGreaterThan(0)
+  })
+
+  test('b2_body_pointer_events_recover_after_menu_and_dialog_close', async ({
+    page
+  }) => {
+    // Guards the historical Radix bug the old modal={false} workaround
+    // existed for: a modal menu nested in a modal dialog left
+    // pointer-events: none on the body after both closed.
+    await openFolderMenu(page)
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('menu')).toBeHidden()
+    await page.getByRole('button', { name: /^cancel$/i }).click()
+    await expect(page.getByRole('dialog')).toBeHidden()
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => getComputedStyle(document.body).pointerEvents)
+      )
+      .toBe('auto')
+
+    // The page behind must be clickable again.
+    await page.getByRole('tab', { name: /^videos/i }).click()
+    await expect(page.getByRole('heading', { name: /video links/i })).toBeVisible()
+  })
+})


### PR DESCRIPTION
Closes #191

## What changed

One behaviour-bearing line: the Sprout folder picker's dropdown is now **modal** (Radix's default) instead of `modal={false}`, plus the header comment documenting why that is load-bearing.

## Why

Field report: in Baker's Add Video dialog, the folder list could not be scrolled - every folder below the visible rows was unreachable. Reproduced with a Playwright probe: the menu's CSS was correct (`max-h-[320px] overflow-y-auto`, scrollHeight 1041 vs clientHeight 318) but a real wheel gesture left `scrollTop` at 0. The dialog's scroll lock (react-remove-scroll) cancels wheel events over anything portalled outside its subtree, and a non-modal menu brings no scroll lock of its own. A modal menu mounts its own lock above the dialog's, which permits scrolling within the menu.

`modal={false}` was itself a workaround for a historical Radix bug (nested modals leaving `pointer-events: none` on the body after close). That bug does not reproduce on @radix-ui/react-dropdown-menu 2.1.16 - verified body pointer-events return to `auto` and the page is clickable after menu and dialog both close.

## Behaviours and evidence

- **B1** wheel scrolls the menu inside the dialog - new e2e test, committed red first (fails on master with `scrollTop: 0`).
- **B2** body pointer-events recover after menu and dialog close - guards the historical bug the old workaround existed for.
- All **14 existing picker e2e behaviours** pass unchanged (typeahead, hover rate-limit, 40-folder scroll on the standalone page, search).
- Full unit suite green (334 files / 5,158 tests), lint 0 errors.

## Notes for review

- The existing '40 folders scrolls instead of clipping' e2e test runs on /upload/sprout, where no dialog lock exists - which is exactly why it never caught this. The new spec lives in its own file with its own Playwright project entry (every project uses explicit testMatch).
- No version bump, per the release flow.